### PR TITLE
Use separate types to represent user and assistant messages

### DIFF
--- a/rust/acp_tests.rs
+++ b/rust/acp_tests.rs
@@ -25,18 +25,21 @@ impl Agent for TestAgent {
         })
     }
 
-    async fn send_message(&self, _request: SendMessageParams) -> Result<SendMessageResponse> {
-        Ok(SendMessageResponse)
+    async fn send_user_message(
+        &self,
+        _request: SendUserMessageParams,
+    ) -> Result<SendUserMessageResponse> {
+        Ok(SendUserMessageResponse)
     }
 }
 
 #[async_trait(?Send)]
 impl Client for TestClient {
-    async fn stream_message_chunk(
+    async fn stream_assistant_message_chunk(
         &self,
-        _request: StreamMessageChunkParams,
-    ) -> Result<StreamMessageChunkResponse> {
-        Ok(StreamMessageChunkResponse {})
+        _request: StreamAssistantMessageChunkParams,
+    ) -> Result<StreamAssistantMessageChunkResponse> {
+        Ok(StreamAssistantMessageChunkResponse {})
     }
 
     async fn request_tool_call_confirmation(

--- a/rust/schema.rs
+++ b/rust/schema.rs
@@ -146,10 +146,10 @@ acp_peer!(
     AnyClientResult,
     CLIENT_METHODS,
     (
-        stream_message_chunk,
-        "streamMessageChunk",
-        StreamMessageChunkParams,
-        StreamMessageChunkResponse
+        stream_assistant_message_chunk,
+        "streamAssistantMessageChunk",
+        StreamAssistantMessageChunkParams,
+        StreamAssistantMessageChunkResponse
     ),
     (
         request_tool_call_confirmation,
@@ -196,10 +196,10 @@ acp_peer!(
         CreateThreadResponse
     ),
     (
-        send_message,
-        "sendMessage",
-        SendMessageParams,
-        SendMessageResponse
+        send_user_message,
+        "sendUserMessage",
+        SendUserMessageParams,
+        SendUserMessageResponse
     )
 );
 
@@ -223,22 +223,21 @@ pub struct AuthenticateResponse;
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct Message {
-    pub role: Role,
-    pub chunks: Vec<MessageChunk>,
+pub struct UserMessage {
+    pub chunks: Vec<UserMessageChunk>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "camelCase")]
-pub enum MessageChunk {
+pub enum UserMessageChunk {
     Text { chunk: String },
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub enum Role {
-    User,
-    Assistant,
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum AssistantMessageChunk {
+    Text { chunk: String },
+    Thought { chunk: String },
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -275,25 +274,25 @@ pub struct ThreadId(pub String);
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct SendMessageParams {
+pub struct SendUserMessageParams {
     pub thread_id: ThreadId,
-    pub message: Message,
+    pub message: UserMessage,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct SendMessageResponse;
+pub struct SendUserMessageResponse;
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct StreamMessageChunkParams {
+pub struct StreamAssistantMessageChunkParams {
     pub thread_id: ThreadId,
-    pub chunk: MessageChunk,
+    pub chunk: AssistantMessageChunk,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct StreamMessageChunkResponse;
+pub struct StreamAssistantMessageChunkResponse;
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]

--- a/schema.json
+++ b/schema.json
@@ -27,7 +27,7 @@
           "$ref": "#/$defs/CreateThreadParams"
         },
         {
-          "$ref": "#/$defs/SendMessageParams"
+          "$ref": "#/$defs/SendUserMessageParams"
         }
       ]
     },
@@ -43,14 +43,14 @@
           "$ref": "#/$defs/CreateThreadResponse"
         },
         {
-          "$ref": "#/$defs/SendMessageResponse"
+          "$ref": "#/$defs/SendUserMessageResponse"
         }
       ]
     },
     "AnyClientRequest": {
       "anyOf": [
         {
-          "$ref": "#/$defs/StreamMessageChunkParams"
+          "$ref": "#/$defs/StreamAssistantMessageChunkParams"
         },
         {
           "$ref": "#/$defs/RequestToolCallConfirmationParams"
@@ -66,7 +66,7 @@
     "AnyClientResult": {
       "anyOf": [
         {
-          "$ref": "#/$defs/StreamMessageChunkResponse"
+          "$ref": "#/$defs/StreamAssistantMessageChunkResponse"
         },
         {
           "$ref": "#/$defs/RequestToolCallConfirmationResponse"
@@ -76,6 +76,36 @@
         },
         {
           "$ref": "#/$defs/UpdateToolCallResponse"
+        }
+      ]
+    },
+    "AssistantMessageChunk": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "text"
+            },
+            "chunk": {
+              "type": "string"
+            }
+          },
+          "required": ["type", "chunk"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "thought"
+            },
+            "chunk": {
+              "type": "string"
+            }
+          },
+          "required": ["type", "chunk"]
         }
       ]
     },
@@ -121,38 +151,6 @@
         }
       },
       "required": ["isAuthenticated"]
-    },
-    "Message": {
-      "type": "object",
-      "properties": {
-        "chunks": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/MessageChunk"
-          }
-        },
-        "role": {
-          "$ref": "#/$defs/Role"
-        }
-      },
-      "required": ["role", "chunks"]
-    },
-    "MessageChunk": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "text"
-            },
-            "chunk": {
-              "type": "string"
-            }
-          },
-          "required": ["type", "chunk"]
-        }
-      ]
     },
     "PushToolCallParams": {
       "type": "object",
@@ -228,15 +226,11 @@
       },
       "required": ["id", "outcome"]
     },
-    "Role": {
-      "type": "string",
-      "enum": ["user", "assistant"]
-    },
-    "SendMessageParams": {
+    "SendUserMessageParams": {
       "type": "object",
       "properties": {
         "message": {
-          "$ref": "#/$defs/Message"
+          "$ref": "#/$defs/UserMessage"
         },
         "threadId": {
           "$ref": "#/$defs/ThreadId"
@@ -244,14 +238,14 @@
       },
       "required": ["threadId", "message"]
     },
-    "SendMessageResponse": {
+    "SendUserMessageResponse": {
       "type": "null"
     },
-    "StreamMessageChunkParams": {
+    "StreamAssistantMessageChunkParams": {
       "type": "object",
       "properties": {
         "chunk": {
-          "$ref": "#/$defs/MessageChunk"
+          "$ref": "#/$defs/AssistantMessageChunk"
         },
         "threadId": {
           "$ref": "#/$defs/ThreadId"
@@ -259,7 +253,7 @@
       },
       "required": ["threadId", "chunk"]
     },
-    "StreamMessageChunkResponse": {
+    "StreamAssistantMessageChunkResponse": {
       "type": "null"
     },
     "ThreadId": {
@@ -437,6 +431,35 @@
     },
     "UpdateToolCallResponse": {
       "type": "null"
+    },
+    "UserMessage": {
+      "type": "object",
+      "properties": {
+        "chunks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/UserMessageChunk"
+          }
+        }
+      },
+      "required": ["chunks"]
+    },
+    "UserMessageChunk": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "text"
+            },
+            "chunk": {
+              "type": "string"
+            }
+          },
+          "required": ["type", "chunk"]
+        }
+      ]
     }
   }
 }

--- a/typescript/acp.test.ts
+++ b/typescript/acp.test.ts
@@ -13,10 +13,10 @@ import {
   PushToolCallResponse,
   RequestToolCallConfirmationParams,
   RequestToolCallConfirmationResponse,
-  SendMessageParams,
-  SendMessageResponse,
-  StreamMessageChunkParams,
-  StreamMessageChunkResponse,
+  SendUserMessageParams,
+  SendUserMessageResponse,
+  StreamAssistantMessageChunkParams,
+  StreamAssistantMessageChunkResponse,
   UpdateToolCallParams,
   UpdateToolCallResponse,
 } from "./acp.js";
@@ -216,16 +216,16 @@ class StubAgent implements Agent {
   createThread(_: CreateThreadParams): Promise<CreateThreadResponse> {
     throw new Error("Method not implemented.");
   }
-  sendMessage(_: SendMessageParams): Promise<SendMessageResponse> {
+  sendUserMessage(_: SendUserMessageParams): Promise<SendUserMessageResponse> {
     throw new Error("Method not implemented.");
   }
 }
 
 class StubClient implements Client {
   constructor(private agent: Agent) {}
-  streamMessageChunk(
-    _: StreamMessageChunkParams,
-  ): Promise<StreamMessageChunkResponse> {
+  streamAssistantMessageChunk(
+    _: StreamAssistantMessageChunkParams,
+  ): Promise<StreamAssistantMessageChunkResponse> {
     throw new Error("Method not implemented.");
   }
   requestToolCallConfirmation(

--- a/typescript/schema.ts
+++ b/typescript/schema.ts
@@ -4,14 +4,19 @@ export type AgentCodingProtocol =
   | AnyAgentRequest
   | AnyAgentResult;
 export type AnyClientRequest =
-  | StreamMessageChunkParams
+  | StreamAssistantMessageChunkParams
   | RequestToolCallConfirmationParams
   | PushToolCallParams
   | UpdateToolCallParams;
-export type MessageChunk = {
-  type: "text";
-  chunk: string;
-};
+export type AssistantMessageChunk =
+  | {
+      type: "text";
+      chunk: string;
+    }
+  | {
+      type: "thought";
+      chunk: string;
+    };
 export type ThreadId = string;
 export type ToolCallConfirmation =
   | {
@@ -63,11 +68,11 @@ export type Icon =
 export type ToolCallStatus = "running" | "finished" | "error";
 export type ToolCallId = number;
 export type AnyClientResult =
-  | StreamMessageChunkResponse
+  | StreamAssistantMessageChunkResponse
   | RequestToolCallConfirmationResponse
   | PushToolCallResponse
   | UpdateToolCallResponse;
-export type StreamMessageChunkResponse = null;
+export type StreamAssistantMessageChunkResponse = null;
 export type ToolCallConfirmationOutcome =
   | "allow"
   | "alwaysAllow"
@@ -79,21 +84,24 @@ export type AnyAgentRequest =
   | InitializeParams
   | AuthenticateParams
   | CreateThreadParams
-  | SendMessageParams;
+  | SendUserMessageParams;
 export type InitializeParams = null;
 export type AuthenticateParams = null;
 export type CreateThreadParams = null;
-export type Role = "user" | "assistant";
+export type UserMessageChunk = {
+  type: "text";
+  chunk: string;
+};
 export type AnyAgentResult =
   | InitializeResponse
   | AuthenticateResponse
   | CreateThreadResponse
-  | SendMessageResponse;
+  | SendUserMessageResponse;
 export type AuthenticateResponse = null;
-export type SendMessageResponse = null;
+export type SendUserMessageResponse = null;
 
-export interface StreamMessageChunkParams {
-  chunk: MessageChunk;
+export interface StreamAssistantMessageChunkParams {
+  chunk: AssistantMessageChunk;
   threadId: ThreadId;
 }
 export interface RequestToolCallConfirmationParams {
@@ -122,13 +130,12 @@ export interface RequestToolCallConfirmationResponse {
 export interface PushToolCallResponse {
   id: ToolCallId;
 }
-export interface SendMessageParams {
-  message: Message;
+export interface SendUserMessageParams {
+  message: UserMessage;
   threadId: ThreadId;
 }
-export interface Message {
-  chunks: MessageChunk[];
-  role: Role;
+export interface UserMessage {
+  chunks: UserMessageChunk[];
 }
 export interface InitializeResponse {
   isAuthenticated: boolean;
@@ -138,9 +145,9 @@ export interface CreateThreadResponse {
 }
 
 export interface Client {
-  streamMessageChunk(
-    params: StreamMessageChunkParams,
-  ): Promise<StreamMessageChunkResponse>;
+  streamAssistantMessageChunk(
+    params: StreamAssistantMessageChunkParams,
+  ): Promise<StreamAssistantMessageChunkResponse>;
   requestToolCallConfirmation(
     params: RequestToolCallConfirmationParams,
   ): Promise<RequestToolCallConfirmationResponse>;
@@ -149,7 +156,7 @@ export interface Client {
 }
 
 export const CLIENT_METHODS = new Set([
-  "streamMessageChunk",
+  "streamAssistantMessageChunk",
   "requestToolCallConfirmation",
   "pushToolCall",
   "updateToolCall",
@@ -159,12 +166,14 @@ export interface Agent {
   initialize(params: InitializeParams): Promise<InitializeResponse>;
   authenticate(params: AuthenticateParams): Promise<AuthenticateResponse>;
   createThread(params: CreateThreadParams): Promise<CreateThreadResponse>;
-  sendMessage(params: SendMessageParams): Promise<SendMessageResponse>;
+  sendUserMessage(
+    params: SendUserMessageParams,
+  ): Promise<SendUserMessageResponse>;
 }
 
 export const AGENT_METHODS = new Set([
   "initialize",
   "authenticate",
   "createThread",
-  "sendMessage",
+  "sendUserMessage",
 ]);


### PR DESCRIPTION
The content allowed in each kind of message is distinct. Eliminate the role for now since it's covered in the types.