### PR TITLE
Add MaxTurns to StopReason enum

### DIFF
--- a/rust/agent.rs
+++ b/rust/agent.rs
@@ -150,6 +150,9 @@ pub enum StopReason {
     EndTurn,
     /// The turn ended because the agent reached the maximum number of tokens.
     MaxTokens,
+    /// The turn ended because the agent reached the maximum number of allowed
+    /// agent requests between user turns.
+    MaxTurnRequests,
     /// The turn ended because the agent refused to continue. The user prompt
     /// and everything that comes after it won't be included in the next
     /// prompt, so this should be reflected in the UI.

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -944,6 +944,11 @@
           "type": "string"
         },
         {
+          "const": "max_turn_requests",
+          "description": "The turn ended because the agent reached the maximum number of allowed\nagent requests between user turns.",
+          "type": "string"
+        },
+        {
           "const": "refusal",
           "description": "The turn ended because the agent refused to continue. The user prompt\nand everything that comes after it won't be included in the next\nprompt, so this should be reflected in the UI.",
           "type": "string"

--- a/typescript/schema.ts
+++ b/typescript/schema.ts
@@ -210,6 +210,7 @@ export const loadSessionResponseSchema = z.null();
 export const stopReasonSchema = z.union([
   z.literal("end_turn"),
   z.literal("max_tokens"),
+  z.literal("max_turn_requests"),
   z.literal("refusal"),
   z.literal("cancelled"),
 ]);


### PR DESCRIPTION
Multiple agents use this as a way to apply an upper bound to the number of subsequent tool calls (including us) so this would be a valid stop reason
