### PR TITLE
Add URI field to ImageContent

### DIFF
--- a/rust/content.rs
+++ b/rust/content.rs
@@ -36,6 +36,8 @@ pub struct ImageContent {
     pub data: String,
     #[serde(rename = "mimeType")]
     pub mime_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uri: Option<String>,
 }
 
 /// Audio provided to or from an LLM.


### PR DESCRIPTION
This is not present in MCP, but is a useful extension for the client.