### PR TITLE
Revert "Use American English spelling "canceled" instead of "cancelled" throughout code and tests"

### DIFF
--- a/rust/agent.rs
+++ b/rust/agent.rs
@@ -173,9 +173,8 @@ pub enum StopReason {
     /// and everything that comes after it won't be included in the next
     /// prompt, so this should be reflected in the UI.
     Refusal,
-    /// The turn was canceled by the client.
-    #[serde(alias = "cancelled")]
-    Canceled,
+    /// The turn was cancelled by the client.
+    Cancelled,
 }
 
 // Capabilities

--- a/rust/client.rs
+++ b/rust/client.rs
@@ -97,10 +97,11 @@ pub struct RequestPermissionResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "outcome", rename_all = "snake_case")]
 pub enum RequestPermissionOutcome {
-    #[serde(alias = "cancelled")]
-    Canceled,
+    Cancelled,
     #[serde(rename_all = "camelCase")]
-    Selected { option_id: PermissionOptionId },
+    Selected {
+        option_id: PermissionOptionId,
+    },
 }
 
 // Write text file

--- a/rust/rpc_tests.rs
+++ b/rust/rpc_tests.rs
@@ -39,7 +39,7 @@ impl Client for TestClient {
         let mut responses = responses.lock().unwrap();
         let outcome = responses
             .pop()
-            .unwrap_or(RequestPermissionOutcome::Canceled);
+            .unwrap_or(RequestPermissionOutcome::Cancelled);
         Ok(RequestPermissionResponse { outcome })
     }
 
@@ -322,9 +322,9 @@ async fn test_cancel_notification() {
 
             tokio::task::yield_now().await;
 
-            let canceled = agent.cancellations_received.lock().unwrap();
-            assert_eq!(canceled.len(), 1);
-            assert_eq!(canceled[0], session_id);
+            let cancelled = agent.cancellations_received.lock().unwrap();
+            assert_eq!(cancelled.len(), 1);
+            assert_eq!(cancelled[0], session_id);
         })
         .await;
 }

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -724,7 +724,7 @@
         {
           "properties": {
             "outcome": {
-              "const": "canceled",
+              "const": "cancelled",
               "type": "string"
             }
           },
@@ -994,8 +994,8 @@
           "type": "string"
         },
         {
-          "const": "canceled",
-          "description": "The turn was canceled by the client.",
+          "const": "cancelled",
+          "description": "The turn was cancelled by the client.",
           "type": "string"
         }
       ]

--- a/typescript/acp.test.ts
+++ b/typescript/acp.test.ts
@@ -21,7 +21,7 @@ import {
   ReadTextFileResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
-  CancelNotification,
+  CancelledNotification,
   SessionNotification,
   PROTOCOL_VERSION,
 } from "./acp.js";
@@ -75,7 +75,7 @@ describe("Connection", () => {
       async prompt(_: PromptRequest): Promise<PromptResponse> {
         throw new Error("Prompt failed");
       }
-      async cancel(_: CancelNotification): Promise<void> {
+      async cancel(_: CancelledNotification): Promise<void> {
         // no-op
       }
     }
@@ -167,7 +167,7 @@ describe("Connection", () => {
       async prompt(_: PromptRequest): Promise<PromptResponse> {
         return { stopReason: "end_turn" };
       }
-      async cancel(_: CancelNotification): Promise<void> {
+      async cancel(_: CancelledNotification): Promise<void> {
         // no-op
       }
     }
@@ -273,8 +273,8 @@ describe("Connection", () => {
         messageLog.push(`prompt called: ${params.sessionId}`);
         return { stopReason: "end_turn" };
       }
-      async cancel(params: CancelNotification): Promise<void> {
-        messageLog.push(`canceled called: ${params.sessionId}`);
+      async cancel(params: CancelledNotification): Promise<void> {
+        messageLog.push(`cancelled called: ${params.sessionId}`);
       }
     }
 
@@ -404,8 +404,8 @@ describe("Connection", () => {
       async prompt(_: PromptRequest): Promise<PromptResponse> {
         return { stopReason: "end_turn" };
       }
-      async cancel(params: CancelNotification): Promise<void> {
-        notificationLog.push(`canceled: ${params.sessionId}`);
+      async cancel(params: CancelledNotification): Promise<void> {
+        notificationLog.push(`cancelled: ${params.sessionId}`);
       }
     }
 
@@ -447,7 +447,7 @@ describe("Connection", () => {
 
     // Verify notifications were received
     expect(notificationLog).toContain("agent message: Hello from agent");
-    expect(notificationLog).toContain("canceled: test-session");
+    expect(notificationLog).toContain("cancelled: test-session");
   });
 
   it("handles initialize method", async () => {
@@ -503,7 +503,7 @@ describe("Connection", () => {
       async prompt(_: PromptRequest): Promise<PromptResponse> {
         return { stopReason: "end_turn" };
       }
-      async cancel(_: CancelNotification): Promise<void> {
+      async cancel(_: CancelledNotification): Promise<void> {
         // no-op
       }
     }

--- a/typescript/schema.ts
+++ b/typescript/schema.ts
@@ -185,7 +185,7 @@ export const readTextFileResponseSchema = z.object({
 
 export const requestPermissionOutcomeSchema = z.union([
   z.object({
-    outcome: z.literal("canceled"),
+    outcome: z.literal("cancelled"),
   }),
   z.object({
     optionId: z.string(),
@@ -214,7 +214,7 @@ export const stopReasonSchema = z.union([
   z.literal("max_tokens"),
   z.literal("max_turn_requests"),
   z.literal("refusal"),
-  z.literal("canceled"),
+  z.literal("cancelled"),
 ]);
 
 export const toolCallLocationSchema = z.object({


### PR DESCRIPTION
Unfortunately, we had to revert this because it introduces a breaking change and we don't think it's worth it until we need to make a more fundamental change.

Reverts zed-industries/agent-client-protocol#19