### PR TITLE
Use stream reader instead of async iteration for reading messages

### DIFF
--- a/typescript/acp.test.ts
+++ b/typescript/acp.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { TransformStream } from "node:stream/web";
 import {
   Agent,
   ClientSideConnection,

--- a/typescript/examples/agent.ts
+++ b/typescript/examples/agent.ts
@@ -2,7 +2,6 @@
 
 import { AgentSideConnection, Agent, PROTOCOL_VERSION } from "../acp.js";
 import * as schema from "../schema.js";
-import { WritableStream, ReadableStream } from "node:stream/web";
 import { Readable, Writable } from "node:stream";
 
 interface AgentSession {

--- a/typescript/examples/client.ts
+++ b/typescript/examples/client.ts
@@ -3,7 +3,6 @@
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { WritableStream, ReadableStream } from "node:stream/web";
 import { Writable, Readable } from "node:stream";
 import readline from "node:readline/promises";
 


### PR DESCRIPTION
This makes the TS library not dependent on node types so it can also run
in the browser.

It is likely the previous code would be ok, but this method is supported
in more environments

Signed-off-by: Ben Brandt <benjamin.j.brandt@gmail.com>
