### PR TITLE
Make `Agent` and `Client` dyn compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ version = "0.3.1-alpha.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
+ "async-trait",
  "env_logger",
  "futures",
  "futures-util",
@@ -113,6 +114,17 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,23 +33,23 @@ name = "client"
 path = "rust/example_client.rs"
 
 [dependencies]
-anyhow = "1.0"
-async-broadcast = "0.7.2"
+anyhow = "1"
+async-broadcast = "0.7"
+async-trait = "0.1"
 futures = { version = "0.3" }
 log = "0.4"
 parking_lot = "0.12"
-schemars = { version = "1.0" }
-serde = { version = "1.0", features = ["derive", "rc"] }
-serde_json = { version = "1.0", features = ["raw_value"] }
+schemars = { version = "1" }
+serde = { version = "1", features = ["derive", "rc"] }
+serde_json = { version = "1", features = ["raw_value"] }
 
 [dev-dependencies]
 env_logger = "0.11"
 futures-util = { version = "0.3", features = ["io"] }
 piper = "0.2"
-pretty_assertions = "1.4.1"
-rustyline = "17.0.1"
-tokio-util = { version = "0.7.16", features = ["compat"] }
-tokio = { version = "1.0", features = [
+pretty_assertions = "1"
+rustyline = "17"
+tokio = { version = "1", features = [
     "macros",
     "rt",
     "time",
@@ -59,3 +59,4 @@ tokio = { version = "1.0", features = [
     "process",
     "sync",
 ] }
+tokio-util = { version = "0.7", features = ["compat"] }

--- a/rust/acp.rs
+++ b/rust/acp.rs
@@ -166,6 +166,7 @@ impl ClientSideConnection {
     }
 }
 
+#[async_trait::async_trait(?Send)]
 impl Agent for ClientSideConnection {
     async fn initialize(&self, args: InitializeRequest) -> Result<InitializeResponse, Error> {
         self.conn
@@ -441,6 +442,7 @@ impl AgentSideConnection {
     }
 }
 
+#[async_trait::async_trait(?Send)]
 impl Client for AgentSideConnection {
     async fn request_permission(
         &self,

--- a/rust/agent.rs
+++ b/rust/agent.rs
@@ -20,6 +20,7 @@ use crate::{
 ///
 /// Agents are programs that use generative AI to autonomously modify code. They handle
 /// requests from clients and execute tasks using language models and tools.
+#[async_trait::async_trait(?Send)]
 pub trait Agent {
     /// Establishes the connection with a client and negotiates protocol capabilities.
     ///
@@ -31,10 +32,7 @@ pub trait Agent {
     /// The agent should respond with its supported protocol version and capabilities.
     ///
     /// See protocol docs: [Initialization](https://agentclientprotocol.com/protocol/initialization)
-    fn initialize(
-        &self,
-        args: InitializeRequest,
-    ) -> impl Future<Output = Result<InitializeResponse, Error>>;
+    async fn initialize(&self, args: InitializeRequest) -> Result<InitializeResponse, Error>;
 
     /// Authenticates the client using the specified authentication method.
     ///
@@ -45,10 +43,7 @@ pub trait Agent {
     /// `new_session` without receiving an `auth_required` error.
     ///
     /// See protocol docs: [Initialization](https://agentclientprotocol.com/protocol/initialization)
-    fn authenticate(
-        &self,
-        args: AuthenticateRequest,
-    ) -> impl Future<Output = Result<AuthenticateResponse, Error>>;
+    async fn authenticate(&self, args: AuthenticateRequest) -> Result<AuthenticateResponse, Error>;
 
     /// Creates a new conversation session with the agent.
     ///
@@ -62,10 +57,7 @@ pub trait Agent {
     /// May return an `auth_required` error if the agent requires authentication.
     ///
     /// See protocol docs: [Session Setup](https://agentclientprotocol.com/protocol/session-setup)
-    fn new_session(
-        &self,
-        args: NewSessionRequest,
-    ) -> impl Future<Output = Result<NewSessionResponse, Error>>;
+    async fn new_session(&self, args: NewSessionRequest) -> Result<NewSessionResponse, Error>;
 
     /// Loads an existing session to resume a previous conversation.
     ///
@@ -77,10 +69,7 @@ pub trait Agent {
     /// - Stream the entire conversation history back to the client via notifications
     ///
     /// See protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/session-setup#loading-sessions)
-    fn load_session(
-        &self,
-        args: LoadSessionRequest,
-    ) -> impl Future<Output = Result<LoadSessionResponse, Error>>;
+    async fn load_session(&self, args: LoadSessionRequest) -> Result<LoadSessionResponse, Error>;
 
     /// Sets the current mode for a session.
     ///
@@ -95,10 +84,10 @@ pub trait Agent {
     /// idle or actively generating a response.
     ///
     /// See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
-    fn set_session_mode(
+    async fn set_session_mode(
         &self,
         args: SetSessionModeRequest,
-    ) -> impl Future<Output = Result<SetSessionModeResponse, Error>>;
+    ) -> Result<SetSessionModeResponse, Error>;
 
     /// Processes a user prompt within a session.
     ///
@@ -111,7 +100,7 @@ pub trait Agent {
     /// - Returns when the turn is complete with a stop reason
     ///
     /// See protocol docs: [Prompt Turn](https://agentclientprotocol.com/protocol/prompt-turn)
-    fn prompt(&self, args: PromptRequest) -> impl Future<Output = Result<PromptResponse, Error>>;
+    async fn prompt(&self, args: PromptRequest) -> Result<PromptResponse, Error>;
 
     /// Cancels ongoing operations for a session.
     ///
@@ -124,7 +113,7 @@ pub trait Agent {
     /// - Respond to the original `session/prompt` request with `StopReason::Cancelled`
     ///
     /// See protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/prompt-turn#cancellation)
-    fn cancel(&self, args: CancelNotification) -> impl Future<Output = Result<(), Error>>;
+    async fn cancel(&self, args: CancelNotification) -> Result<(), Error>;
 
     /// Handles extension method requests from the client.
     ///
@@ -132,7 +121,7 @@ pub trait Agent {
     /// protocol compatibility.
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    fn ext_method(&self, args: ExtRequest) -> impl Future<Output = Result<ExtResponse, Error>>;
+    async fn ext_method(&self, args: ExtRequest) -> Result<ExtResponse, Error>;
 
     /// Handles extension notifications from the client.
     ///
@@ -140,7 +129,7 @@ pub trait Agent {
     /// while maintaining protocol compatibility.
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    fn ext_notification(&self, args: ExtNotification) -> impl Future<Output = Result<(), Error>>;
+    async fn ext_notification(&self, args: ExtNotification) -> Result<(), Error>;
 }
 
 // Initialize

--- a/rust/client.rs
+++ b/rust/client.rs
@@ -19,6 +19,7 @@ use crate::{ExtResponse, SessionModeId};
 /// Clients are typically code editors (IDEs, text editors) that provide the interface
 /// between users and AI agents. They manage the environment, handle user interactions,
 /// and control access to resources.
+#[async_trait::async_trait(?Send)]
 pub trait Client {
     /// Requests permission from the user for a tool call operation.
     ///
@@ -30,10 +31,10 @@ pub trait Client {
     /// respond to this request with `RequestPermissionOutcome::Cancelled`.
     ///
     /// See protocol docs: [Requesting Permission](https://agentclientprotocol.com/protocol/tool-calls#requesting-permission)
-    fn request_permission(
+    async fn request_permission(
         &self,
         args: RequestPermissionRequest,
-    ) -> impl Future<Output = Result<RequestPermissionResponse, Error>>;
+    ) -> Result<RequestPermissionResponse, Error>;
 
     /// Writes content to a text file in the client's file system.
     ///
@@ -41,10 +42,10 @@ pub trait Client {
     /// Allows the agent to create or modify files within the client's environment.
     ///
     /// See protocol docs: [Client](https://agentclientprotocol.com/protocol/overview#client)
-    fn write_text_file(
+    async fn write_text_file(
         &self,
         args: WriteTextFileRequest,
-    ) -> impl Future<Output = Result<WriteTextFileResponse, Error>>;
+    ) -> Result<WriteTextFileResponse, Error>;
 
     /// Reads content from a text file in the client's file system.
     ///
@@ -52,10 +53,10 @@ pub trait Client {
     /// Allows the agent to access file contents within the client's environment.
     ///
     /// See protocol docs: [Client](https://agentclientprotocol.com/protocol/overview#client)
-    fn read_text_file(
+    async fn read_text_file(
         &self,
         args: ReadTextFileRequest,
-    ) -> impl Future<Output = Result<ReadTextFileResponse, Error>>;
+    ) -> Result<ReadTextFileResponse, Error>;
 
     /// Handles session update notifications from the agent.
     ///
@@ -68,10 +69,7 @@ pub trait Client {
     /// updates before responding with the cancelled stop reason.
     ///
     /// See protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protocol/prompt-turn#3-agent-reports-output)
-    fn session_notification(
-        &self,
-        args: SessionNotification,
-    ) -> impl Future<Output = Result<(), Error>>;
+    async fn session_notification(&self, args: SessionNotification) -> Result<(), Error>;
 
     /// Executes a command in a new terminal
     ///
@@ -87,10 +85,10 @@ pub trait Client {
     /// method.
     ///
     /// See protocol docs: [Terminals](https://agentclientprotocol.com/protocol/terminals)
-    fn create_terminal(
+    async fn create_terminal(
         &self,
         args: CreateTerminalRequest,
-    ) -> impl Future<Output = Result<CreateTerminalResponse, Error>>;
+    ) -> Result<CreateTerminalResponse, Error>;
 
     /// Gets the terminal output and exit status
     ///
@@ -98,10 +96,10 @@ pub trait Client {
     /// If the command has already exited, the exit status is included.
     ///
     /// See protocol docs: [Terminals](https://agentclientprotocol.com/protocol/terminals)
-    fn terminal_output(
+    async fn terminal_output(
         &self,
         args: TerminalOutputRequest,
-    ) -> impl Future<Output = Result<TerminalOutputResponse, Error>>;
+    ) -> Result<TerminalOutputResponse, Error>;
 
     /// Releases a terminal
     ///
@@ -115,18 +113,18 @@ pub trait Client {
     /// the terminal, allowing the Agent to call `terminal/output` and other methods.
     ///
     /// See protocol docs: [Terminals](https://agentclientprotocol.com/protocol/terminals)
-    fn release_terminal(
+    async fn release_terminal(
         &self,
         args: ReleaseTerminalRequest,
-    ) -> impl Future<Output = Result<ReleaseTerminalResponse, Error>>;
+    ) -> Result<ReleaseTerminalResponse, Error>;
 
     /// Waits for the terminal command to exit and return its exit status
     ///
     /// See protocol docs: [Terminals](https://agentclientprotocol.com/protocol/terminals)
-    fn wait_for_terminal_exit(
+    async fn wait_for_terminal_exit(
         &self,
         args: WaitForTerminalExitRequest,
-    ) -> impl Future<Output = Result<WaitForTerminalExitResponse, Error>>;
+    ) -> Result<WaitForTerminalExitResponse, Error>;
 
     /// Kills the terminal command without releasing the terminal
     ///
@@ -140,10 +138,10 @@ pub trait Client {
     /// Note: `terminal/release` when `TerminalId` is no longer needed.
     ///
     /// See protocol docs: [Terminals](https://agentclientprotocol.com/protocol/terminals)
-    fn kill_terminal_command(
+    async fn kill_terminal_command(
         &self,
         args: KillTerminalCommandRequest,
-    ) -> impl Future<Output = Result<KillTerminalCommandResponse, Error>>;
+    ) -> Result<KillTerminalCommandResponse, Error>;
 
     /// Handles extension method requests from the agent.
     ///
@@ -152,7 +150,7 @@ pub trait Client {
     /// protocol compatibility.
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    fn ext_method(&self, args: ExtRequest) -> impl Future<Output = Result<ExtResponse, Error>>;
+    async fn ext_method(&self, args: ExtRequest) -> Result<ExtResponse, Error>;
 
     /// Handles extension notifications from the agent.
     ///
@@ -161,7 +159,7 @@ pub trait Client {
     /// while maintaining protocol compatibility.
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    fn ext_notification(&self, args: ExtNotification) -> impl Future<Output = Result<(), Error>>;
+    async fn ext_notification(&self, args: ExtNotification) -> Result<(), Error>;
 }
 
 // Session updates

--- a/rust/example_agent.rs
+++ b/rust/example_agent.rs
@@ -38,6 +38,7 @@ impl ExampleAgent {
     }
 }
 
+#[async_trait::async_trait(?Send)]
 impl acp::Agent for ExampleAgent {
     async fn initialize(
         &self,

--- a/rust/example_client.rs
+++ b/rust/example_client.rs
@@ -20,6 +20,7 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 struct ExampleClient {}
 
+#[async_trait::async_trait(?Send)]
 impl acp::Client for ExampleClient {
     async fn request_permission(
         &self,

--- a/rust/rpc_tests.rs
+++ b/rust/rpc_tests.rs
@@ -40,6 +40,7 @@ macro_rules! raw_json {
     }};
 }
 
+#[async_trait::async_trait(?Send)]
 impl Client for TestClient {
     async fn request_permission(
         &self,
@@ -162,6 +163,7 @@ impl TestAgent {
     }
 }
 
+#[async_trait::async_trait(?Send)]
 impl Agent for TestAgent {
     async fn initialize(&self, arguments: InitializeRequest) -> Result<InitializeResponse, Error> {
         Ok(InitializeResponse {


### PR DESCRIPTION
For now, we still won't require Send/Sync

Signed-off-by: Ben Brandt <benjamin.j.brandt@gmail.com>
