### PR TITLE
Rust: Allow Agents to hold onto a Client and vice versa

### DIFF
--- a/rust/examples/agent.rs
+++ b/rust/examples/agent.rs
@@ -171,10 +171,14 @@ async fn main() -> anyhow::Result<()> {
         .run_until(async move {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             // Start up the ExampleAgent connected to stdio.
-            let (conn, handle_io) =
-                acp::AgentSideConnection::new(ExampleAgent::new(tx), outgoing, incoming, |fut| {
+            let (conn, handle_io) = acp::AgentSideConnection::new(
+                move |_| ExampleAgent::new(tx),
+                outgoing,
+                incoming,
+                |fut| {
                     tokio::task::spawn_local(fut);
-                });
+                },
+            );
             // Kick off a background task to send the ExampleAgent's session notifications to the client.
             tokio::task::spawn_local(async move {
                 while let Some((session_notification, tx)) = rx.recv().await {

--- a/rust/examples/client.rs
+++ b/rust/examples/client.rs
@@ -142,10 +142,14 @@ async fn main() -> anyhow::Result<()> {
     local_set
         .run_until(async move {
             // Set up the ExampleClient connected to the agent's stdio.
-            let (conn, handle_io) =
-                acp::ClientSideConnection::new(ExampleClient {}, outgoing, incoming, |fut| {
+            let (conn, handle_io) = acp::ClientSideConnection::new(
+                |_| ExampleClient {},
+                outgoing,
+                incoming,
+                |fut| {
                     tokio::task::spawn_local(fut);
-                });
+                },
+            );
 
             // Handle I/O in the background.
             tokio::task::spawn_local(handle_io);


### PR DESCRIPTION
- Replace ClientSideConnection/AgentSideConnection structs with type aliases to RpcConnection
- RpcConnection::new now accepts a handler factory FnOnce(Rc<Self>) and returns Rc<Self>

Before, there wasn't a way for an Agent to hold onto a way to
communicate with the Client and vice versa.

Now they can. This matches the behavior in the TS SDK

