### PR TITLE
Preserve existing Error values when converting from anyhow::Error.

### DIFF
--- a/rust/error.rs
+++ b/rust/error.rs
@@ -206,7 +206,10 @@ impl Display for Error {
 
 impl From<anyhow::Error> for Error {
     fn from(error: anyhow::Error) -> Self {
-        Error::into_internal_error(&*error)
+        match error.downcast::<Self>() {
+            Ok(error) => error,
+            Err(error) => Error::into_internal_error(&*error),
+        }
     }
 }
 


### PR DESCRIPTION
Falls back to internal error conversion otherwise.

