### PR TITLE
Provide more clarification on the text content type

### DIFF
--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -1230,9 +1230,10 @@ See protocol docs: [Content](https://agentclientprotocol.com/protocol/content)
 **Type:** Union
 
 <ResponseField name="text">
-Plain text content
+Text content. May be plain text or formatted with Markdown.
 
 All agents MUST support text content blocks in prompts.
+Clients SHOULD render this text as Markdown.
 
 <Expandable title="Properties">
 

--- a/rust/content.rs
+++ b/rust/content.rs
@@ -29,9 +29,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContentBlock {
-    /// Plain text content
+    /// Text content. May be plain text or formatted with Markdown.
     ///
     /// All agents MUST support text content blocks in prompts.
+    /// Clients SHOULD render this text as Markdown.
     Text(TextContent),
     /// Images for visual context or analysis.
     ///

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -650,7 +650,7 @@
       "description": "Content blocks represent displayable information in the Agent Client Protocol.\n\nThey provide a structured way to handle various types of user-facing content—whether\nit's text from language models, images for analysis, or embedded resources for context.\n\nContent blocks appear in:\n- User prompts sent via `session/prompt`\n- Language model output streamed through `session/update` notifications\n- Progress updates and results from tool calls\n\nThis structure is compatible with the Model Context Protocol (MCP), enabling\nagents to seamlessly forward content from MCP tool outputs without transformation.\n\nSee protocol docs: [Content](https://agentclientprotocol.com/protocol/content)",
       "oneOf": [
         {
-          "description": "Plain text content\n\nAll agents MUST support text content blocks in prompts.",
+          "description": "Text content. May be plain text or formatted with Markdown.\n\nAll agents MUST support text content blocks in prompts.\nClients SHOULD render this text as Markdown.",
           "properties": {
             "_meta": {
               "description": "Extension point for implementations"


### PR DESCRIPTION
We have received a few clarification questions on this. Elsewhere in the spec we are clear about Markdown support, making it clear here as well.
