### PR TITLE
docs: Add Obsidian as a client via the Agent Client plugin

### DIFF
--- a/docs/overview/clients.mdx
+++ b/docs/overview/clients.mdx
@@ -15,3 +15,5 @@ The following clients can be used with an ACP Agent:
   - through the [yetone/avante.nvim](https://github.com/yetone/avante.nvim) plugin
 - [Sidequery _(coming soon)_](https://sidequery.dev)
 - [Web Browser with AI SDK](https://github.com/mcpc-tech/ai-elements-remix-template) (powered by [@mcpc/acp-ai-provider](https://github.com/mcpc-tech/mcpc/tree/main/packages/acp-ai-provider))
+- [Obsidian](https://obsidian.md)
+  - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin


### PR DESCRIPTION
https://github.com/user-attachments/assets/567f22dc-dd32-446d-8fc5-c8cdec8b2744

Thank you for your work on ACP — it’s been inspiring to see how open and extensible the protocol is.  
I’d like to add Obsidian as a client via the Agent Client plugin.

## Changes

- Added Obsidian and its Agent Client plugin to `docs/overview/clients.mdx`

## About the Agent Client plugin

The [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin enables Obsidian users to interact directly with ACP-compatible agents. It provides features such as easy note mentioning and the ability to save conversations as markdown notes, making it more comfortable to interact with agents through your vault compared to using them via CLI.

## Why?

While Obsidian is not a code editor, this addition may seem slightly outside the protocol's original scope. However, there are many users who combine Obsidian with coding agents in their workflow, and ACP will certainly make this combination more powerful and convenient. I hope you will consider this addition.
