### PR TITLE
Update link to example implementations in TypeScript docs

### DIFF
--- a/docs/libraries/typescript.mdx
+++ b/docs/libraries/typescript.mdx
@@ -19,7 +19,7 @@ class or the
 [ClientSideConnection](https://agentclientprotocol.github.io/typescript-sdk/classes/ClientSideConnection.html)
 class to establish communication with the ACP counterpart.
 
-You can find example implementations of both sides in the [main repository](https://github.com/agentclientprotocol/typescript-sdk/tree/main/typescript/examples). These can be run from your terminal or from an ACP Client like [Zed](https://zed.dev), making them great starting points for your own integration!
+You can find example implementations of both sides in the [main repository](https://github.com/agentclientprotocol/typescript-sdk/tree/main/src/examples). These can be run from your terminal or from an ACP Client like [Zed](https://zed.dev), making them great starting points for your own integration!
 
 Browse the [TypeScript library reference](https://agentclientprotocol.github.io/typescript-sdk) for detailed API documentation.
 


### PR DESCRIPTION
Spotted a broken link while browsing the TypeScript docs.