### PR TITLE
docs: add Atlassian Rovo Dev CLI to agents list

### DIFF
--- a/docs/overview/agents.mdx
+++ b/docs/overview/agents.mdx
@@ -5,6 +5,7 @@ description: "Agents implementing the Agent Client Protocol"
 
 The following agents can be used with an ACP Client:
 
+- [Atlassian Rovo Dev CLI](https://support.atlassian.com/rovo/docs/use-rovo-dev-cli/)
 - [Augment Code](https://docs.augmentcode.com/cli/acp)
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) (via [Zed's SDK adapter](https://github.com/zed-industries/claude-code-acp))
 - [Codex CLI](https://developers.openai.com/codex/cli) (via [Zed's adapter](https://github.com/zed-industries/codex-acp))


### PR DESCRIPTION
Added Atlassian Rovo Dev CLI to the list of agents that can be used with an ACP Client in the agents overview documentation.