### PR TITLE
add fast-agent to agents list

### DIFF
--- a/docs/overview/agents.mdx
+++ b/docs/overview/agents.mdx
@@ -10,6 +10,7 @@ The following agents can be used with an ACP Client:
 - [Codex CLI](https://developers.openai.com/codex/cli) (via [Zed's adapter](https://github.com/zed-industries/codex-acp))
 - [Code Assistant](https://github.com/stippi/code-assistant?tab=readme-ov-file#configuration)
 - [Docker's cagent](https://github.com/docker/cagent)
+- [fast-agent](https://fast-agent.ai/acp)
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli)
 - [Goose](https://block.github.io/goose/docs/guides/acp-clients)
 - [JetBrains Junie _(coming soon)_](https://www.jetbrains.com/junie/)


### PR DESCRIPTION
Add fast-agent.ai to the Agents list -> link points to documentation site. 