### PR TITLE
Added aizen acp client

### DIFF
--- a/docs/overview/clients.mdx
+++ b/docs/overview/clients.mdx
@@ -5,8 +5,8 @@ description: "Clients implementing the Agent Client Protocol"
 
 The following clients can be used with an ACP Agent:
 
-- [aizen](https://aizen.win)
 - [AionUi](https://github.com/iOfficeAI/AionUi)
+- [aizen](https://aizen.win)
 - [DeepChat](https://github.com/ThinkInAIXYZ/deepchat)
 - Emacs via [agent-shell.el](https://github.com/xenodium/agent-shell)
 - [JetBrains _(coming soon)_](https://blog.jetbrains.com/ai/2025/10/jetbrains-zed-open-interoperability-for-ai-coding-agents-in-your-ide/)


### PR DESCRIPTION
I am a developer of Aizen. I would like to add my acp client to the clients section in the docs.