### PR TITLE
Introduce helper methods to get the corresponding method name of a request

### DIFF
--- a/rust/agent.rs
+++ b/rust/agent.rs
@@ -1769,6 +1769,26 @@ pub enum ClientRequest {
     ExtMethodRequest(ExtRequest),
 }
 
+impl ClientRequest {
+    /// Returns the corresponding method name of the request.
+    #[must_use]
+    pub fn method(&self) -> &str {
+        match self {
+            Self::InitializeRequest(_) => AGENT_METHOD_NAMES.initialize,
+            Self::AuthenticateRequest(_) => AGENT_METHOD_NAMES.authenticate,
+            Self::NewSessionRequest(_) => AGENT_METHOD_NAMES.session_new,
+            Self::LoadSessionRequest(_) => AGENT_METHOD_NAMES.session_load,
+            #[cfg(feature = "unstable_session_list")]
+            Self::ListSessionsRequest(_) => AGENT_METHOD_NAMES.session_list,
+            Self::SetSessionModeRequest(_) => AGENT_METHOD_NAMES.session_set_mode,
+            Self::PromptRequest(_) => AGENT_METHOD_NAMES.session_prompt,
+            #[cfg(feature = "unstable_session_model")]
+            Self::SetSessionModelRequest(_) => AGENT_METHOD_NAMES.session_set_model,
+            Self::ExtMethodRequest(ext_request) => &ext_request.method,
+        }
+    }
+}
+
 /// All possible responses that an agent can send to a client.
 ///
 /// This enum is used internally for routing RPC responses. You typically won't need
@@ -1823,6 +1843,17 @@ pub enum ClientNotification {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     ExtNotification(ExtNotification),
+}
+
+impl ClientNotification {
+    /// Returns the corresponding method name of the notification.
+    #[must_use]
+    pub fn method(&self) -> &str {
+        match self {
+            Self::CancelNotification(_) => AGENT_METHOD_NAMES.session_cancel,
+            Self::ExtNotification(ext_notification) => &ext_notification.method,
+        }
+    }
 }
 
 /// Notification to cancel ongoing operations for a session.

--- a/rust/client.rs
+++ b/rust/client.rs
@@ -1288,6 +1288,24 @@ pub enum AgentRequest {
     ExtMethodRequest(ExtRequest),
 }
 
+impl AgentRequest {
+    /// Returns the corresponding method name of the request.
+    #[must_use]
+    pub fn method(&self) -> &str {
+        match self {
+            Self::WriteTextFileRequest(_) => CLIENT_METHOD_NAMES.fs_write_text_file,
+            Self::ReadTextFileRequest(_) => CLIENT_METHOD_NAMES.fs_read_text_file,
+            Self::RequestPermissionRequest(_) => CLIENT_METHOD_NAMES.session_request_permission,
+            Self::CreateTerminalRequest(_) => CLIENT_METHOD_NAMES.terminal_create,
+            Self::TerminalOutputRequest(_) => CLIENT_METHOD_NAMES.terminal_output,
+            Self::ReleaseTerminalRequest(_) => CLIENT_METHOD_NAMES.terminal_release,
+            Self::WaitForTerminalExitRequest(_) => CLIENT_METHOD_NAMES.terminal_wait_for_exit,
+            Self::KillTerminalCommandRequest(_) => CLIENT_METHOD_NAMES.terminal_kill,
+            Self::ExtMethodRequest(ext_request) => &ext_request.method,
+        }
+    }
+}
+
 /// All possible responses that a client can send to an agent.
 ///
 /// This enum is used internally for routing RPC responses. You typically won't need
@@ -1342,4 +1360,15 @@ pub enum AgentNotification {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     ExtNotification(ExtNotification),
+}
+
+impl AgentNotification {
+    /// Returns the corresponding method name of the notification.
+    #[must_use]
+    pub fn method(&self) -> &str {
+        match self {
+            Self::SessionNotification(_) => CLIENT_METHOD_NAMES.session_update,
+            Self::ExtNotification(ext_notification) => &ext_notification.method,
+        }
+    }
 }


### PR DESCRIPTION
Now that these are non-exhaustive, it would be nice to get a
non-fallible way to make sure we get all of them
