### PR TITLE
Easier `new` methods for ExtRequest + ExtNotification

### DIFF
--- a/rust/ext.rs
+++ b/rust/ext.rs
@@ -16,10 +16,10 @@ pub struct ExtRequest {
 }
 
 impl ExtRequest {
-    pub fn new(method: impl Into<Arc<str>>, params: impl Into<Arc<RawValue>>) -> Self {
+    pub fn new(method: impl Into<Arc<str>>, params: Arc<RawValue>) -> Self {
         Self {
             method: method.into(),
-            params: params.into(),
+            params,
         }
     }
 }
@@ -37,10 +37,10 @@ pub struct ExtNotification {
 }
 
 impl ExtNotification {
-    pub fn new(method: impl Into<Arc<str>>, params: impl Into<Arc<RawValue>>) -> Self {
+    pub fn new(method: impl Into<Arc<str>>, params: Arc<RawValue>) -> Self {
         Self {
             method: method.into(),
-            params: params.into(),
+            params,
         }
     }
 }


### PR DESCRIPTION
In practice, this made things harder not easier. Using a more concrete type to make it easier to use `raw_json!`
