### PR TITLE
docs(rfd): Draft: Session info update notification

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -97,7 +97,8 @@
               "rfds/session-fork",
               "rfds/request-cancellation",
               "rfds/session-resume",
-              "rfds/meta-propagation"
+              "rfds/meta-propagation",
+              "rfds/session-info-update"
             ]
           },
           { "group": "Preview", "pages": [] },

--- a/docs/rfds/session-info-update.mdx
+++ b/docs/rfds/session-info-update.mdx
@@ -3,7 +3,6 @@ title: "Session Info Update"
 ---
 
 - Author(s): [@ignatov](https://github.com/ignatov)
-- Champion: [@benbrandt](https://github.com/benbrandt)
 
 ## Elevator pitch
 

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -5,6 +5,13 @@ rss: true
 ---
 
 <Update label="December 3, 2025" tags={["RFD"]}>
+## session_info_update notification RFD moves to Draft stage
+
+The RFD for adding a new `session_info_update` variant on the `session/update` notification in the protocol has been moved to Draft stage. Please review the [RFD](./rfds/session-info-update) for more information on the current proposal and provide feedback as work on the implementation begins.
+
+</Update>
+
+<Update label="December 3, 2025" tags={["RFD"]}>
 ## _meta Propagation RFD moves to Draft stage
 
 The RFD for providing more guidance on how the `_meta` parameter should be used within the protocol has been moved to Draft stage. Please review the [RFD](./rfds/meta-propagation) for more information on the current proposal and provide feedback as work on the implementation begins.


### PR DESCRIPTION
- Adds session_info_update variant to SessionUpdate
- Enables real-time session metadata updates (title, _meta)
- Follows existing notification pattern (available_commands_update, current_mode_update)
- All fields optional for partial updates
- Must stay aligned with SessionInfo structure