### PR TITLE
fix: Remove incorrect discriminator on `McpServer` type

### DIFF
--- a/rust/agent.rs
+++ b/rust/agent.rs
@@ -961,7 +961,6 @@ impl SetSessionModeResponse {
 /// See protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/session-setup#mcp-servers)
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
-#[schemars(extend("discriminator" = {"propertyName": "type"}))]
 #[non_exhaustive]
 pub enum McpServer {
     /// HTTP transport configuration

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1344,10 +1344,7 @@
           "description": "Stdio transport configuration\n\nAll Agents MUST support this transport."
         }
       ],
-      "description": "Configuration for connecting to an MCP (Model Context Protocol) server.\n\nMCP servers provide tools and context that the agent can use when\nprocessing prompts.\n\nSee protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/session-setup#mcp-servers)",
-      "discriminator": {
-        "propertyName": "type"
-      }
+      "description": "Configuration for connecting to an MCP (Model Context Protocol) server.\n\nMCP servers provide tools and context that the agent can use when\nprocessing prompts.\n\nSee protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/session-setup#mcp-servers)"
     },
     "McpServerHttp": {
       "description": "HTTP transport configuration for MCP.",

--- a/schema/schema.unstable.json
+++ b/schema/schema.unstable.json
@@ -1423,10 +1423,7 @@
           "description": "Stdio transport configuration\n\nAll Agents MUST support this transport."
         }
       ],
-      "description": "Configuration for connecting to an MCP (Model Context Protocol) server.\n\nMCP servers provide tools and context that the agent can use when\nprocessing prompts.\n\nSee protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/session-setup#mcp-servers)",
-      "discriminator": {
-        "propertyName": "type"
-      }
+      "description": "Configuration for connecting to an MCP (Model Context Protocol) server.\n\nMCP servers provide tools and context that the agent can use when\nprocessing prompts.\n\nSee protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/session-setup#mcp-servers)"
     },
     "McpServerHttp": {
       "description": "HTTP transport configuration for MCP.",


### PR DESCRIPTION
This doesn't have a true discriminator because the stdio variant doesn't have a type field.
