### PR TITLE
feat!(rust-only): Provide nicer interface to `ErrorCode` and add them to the docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "strum",
 ]
 
 [[package]]
@@ -45,6 +46,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "itoa"
@@ -179,6 +186,27 @@ dependencies = [
  "ryu",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ derive_more = { version = "2", features = ["from", "display"] }
 schemars = { version = "1" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["raw_value"] }
+strum = { version = "0.27", features = ["derive"] }
 
 [lints.rust]
 future_incompatible = { level = "warn", priority = -1 }

--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -1297,7 +1297,7 @@ See protocol docs: [Content](https://agentclientprotocol.com/protocol/content)
 
 **Type:** Union
 
-<ResponseField name="text">
+<ResponseField name="text" type="object">
 Text content. May be plain text or formatted with Markdown.
 
 All agents MUST support text content blocks in prompts.
@@ -1323,7 +1323,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="image">
+<ResponseField name="image" type="object">
 Images for visual context or analysis.
 
 Requires the `image` prompt capability when included in prompts.
@@ -1352,7 +1352,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="audio">
+<ResponseField name="audio" type="object">
 Audio data for transcription or analysis.
 
 Requires the `audio` prompt capability when included in prompts.
@@ -1379,7 +1379,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="resource_link">
+<ResponseField name="resource_link" type="object">
 References to resources that the agent can access.
 
 All agents MUST support resource links in prompts.
@@ -1414,7 +1414,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="resource">
+<ResponseField name="resource" type="object">
 Complete resource contents embedded directly in the message.
 
 Preferred for including context as it avoids extra round-trips.
@@ -1622,7 +1622,7 @@ See protocol docs: [JSON-RPC Error Object](https://www.jsonrpc.org/specification
 
 **Properties:**
 
-<ResponseField name="code" type={"int32"} required>
+<ResponseField name="code" type={<a href="#errorcode">ErrorCode</a>} required>
   A number indicating the error type that occurred. This must be an integer as
   defined in the JSON-RPC specification.
 </ResponseField>
@@ -1634,6 +1634,50 @@ See protocol docs: [JSON-RPC Error Object](https://www.jsonrpc.org/specification
 <ResponseField name="message" type={"string"} required>
   A string providing a short description of the error. The message should be
   limited to a concise single sentence.
+</ResponseField>
+
+## <span class="font-mono">ErrorCode</span>
+
+Predefined error codes for common JSON-RPC and ACP-specific errors.
+
+These codes follow the JSON-RPC 2.0 specification for standard errors
+and use the reserved range (-32000 to -32099) for protocol-specific errors.
+
+**Type:** Union
+
+<ResponseField name="-32700" type="int32">
+  **Parse error**: Invalid JSON was received by the server. An error occurred on
+  the server while parsing the JSON text.
+</ResponseField>
+
+<ResponseField name="-32600" type="int32">
+  **Invalid request**: The JSON sent is not a valid Request object.
+</ResponseField>
+
+<ResponseField name="-32601" type="int32">
+  **Method not found**: The method does not exist or is not available.
+</ResponseField>
+
+<ResponseField name="-32602" type="int32">
+  **Invalid params**: Invalid method parameter(s).
+</ResponseField>
+
+<ResponseField name="-32603" type="int32">
+  **Internal error**: Internal JSON-RPC error. Reserved for
+  implementation-defined server errors.
+</ResponseField>
+
+<ResponseField name="-32000" type="int32">
+  **Authentication required**: Authentication is required before this operation
+  can be performed.
+</ResponseField>
+
+<ResponseField name="-32002" type="int32">
+  **Resource not found**: A given resource, such as a file, was not found.
+</ResponseField>
+
+<ResponseField name="integer" type="int32">
+  Other undefined error code.
 </ResponseField>
 
 ## <span class="font-mono">ExtNotification</span>
@@ -1814,7 +1858,7 @@ See protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/sessio
 
 **Type:** Union
 
-<ResponseField name="http">
+<ResponseField name="http" type="object">
 HTTP transport configuration
 
 Only available when the Agent capabilities indicate `mcp_capabilities.http` is `true`.
@@ -1844,7 +1888,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="sse">
+<ResponseField name="sse" type="object">
 SSE transport configuration
 
 Only available when the Agent capabilities indicate `mcp_capabilities.sse` is `true`.
@@ -2026,19 +2070,19 @@ Helps clients choose appropriate icons and UI treatment.
 
 **Type:** Union
 
-<ResponseField name="allow_once">
+<ResponseField name="allow_once" type="string">
   Allow this operation only this time.
 </ResponseField>
 
-<ResponseField name="allow_always">
+<ResponseField name="allow_always" type="string">
   Allow this operation and remember the choice.
 </ResponseField>
 
-<ResponseField name="reject_once">
+<ResponseField name="reject_once" type="string">
   Reject this operation only this time.
 </ResponseField>
 
-<ResponseField name="reject_always">
+<ResponseField name="reject_always" type="string">
   Reject this operation and remember the choice.
 </ResponseField>
 
@@ -2113,15 +2157,15 @@ See protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/agent
 
 **Type:** Union
 
-<ResponseField name="high">
+<ResponseField name="high" type="string">
   High priority task - critical to the overall goal.
 </ResponseField>
 
-<ResponseField name="medium">
+<ResponseField name="medium" type="string">
   Medium priority task - important but not critical.
 </ResponseField>
 
-<ResponseField name="low">
+<ResponseField name="low" type="string">
   Low priority task - nice to have but not essential.
 </ResponseField>
 
@@ -2134,13 +2178,15 @@ See protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/agent
 
 **Type:** Union
 
-<ResponseField name="pending">The task has not started yet.</ResponseField>
+<ResponseField name="pending" type="string">
+  The task has not started yet.
+</ResponseField>
 
-<ResponseField name="in_progress">
+<ResponseField name="in_progress" type="string">
   The task is currently being worked on.
 </ResponseField>
 
-<ResponseField name="completed">
+<ResponseField name="completed" type="string">
   The task has been successfully completed.
 </ResponseField>
 
@@ -2221,11 +2267,17 @@ The Server MUST reply with the same value in the Response object if included. Th
 
 **Type:** Union
 
-<ResponseField name="null">{""}</ResponseField>
+<ResponseField name="null" type="null">
+  {""}
+</ResponseField>
 
-<ResponseField name="Variant">{""}</ResponseField>
+<ResponseField name="integer" type="int64">
+  {""}
+</ResponseField>
 
-<ResponseField name="Variant">{""}</ResponseField>
+<ResponseField name="string" type="string">
+  {""}
+</ResponseField>
 
 ## <span class="font-mono">RequestPermissionOutcome</span>
 
@@ -2233,7 +2285,7 @@ The outcome of a permission request.
 
 **Type:** Union
 
-<ResponseField name="cancelled">
+<ResponseField name="cancelled" type="object">
 The prompt turn was cancelled before the user responded.
 
 When a client sends a `session/cancel` notification to cancel an ongoing
@@ -2249,7 +2301,7 @@ See protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/promp
 </Expandable>
 </ResponseField>
 
-<ResponseField name="selected">
+<ResponseField name="selected" type="object">
 The user selected one of the provided options.
 
 <Expandable title="Properties">
@@ -2433,7 +2485,7 @@ See protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protoc
 
 **Type:** Union
 
-<ResponseField name="user_message_chunk">
+<ResponseField name="user_message_chunk" type="object">
 A chunk of the user's message being streamed.
 
 <Expandable title="Properties">
@@ -2455,7 +2507,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="agent_message_chunk">
+<ResponseField name="agent_message_chunk" type="object">
 A chunk of the agent's response being streamed.
 
 <Expandable title="Properties">
@@ -2477,7 +2529,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="agent_thought_chunk">
+<ResponseField name="agent_thought_chunk" type="object">
 A chunk of the agent's internal reasoning being streamed.
 
 <Expandable title="Properties">
@@ -2499,7 +2551,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="tool_call">
+<ResponseField name="tool_call" type="object">
 Notification that a new tool call has been initiated.
 
 <Expandable title="Properties">
@@ -2544,7 +2596,7 @@ Enables "follow-along" features in clients.
 </Expandable>
 </ResponseField>
 
-<ResponseField name="tool_call_update">
+<ResponseField name="tool_call_update" type="object">
 Update on the status or results of a tool call.
 
 <Expandable title="Properties">
@@ -2587,7 +2639,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="plan">
+<ResponseField name="plan" type="object">
 The agent's execution plan for complex tasks.
 See protocol docs: [Agent Plan](https://agentclientprotocol.com/protocol/agent-plan)
 
@@ -2614,7 +2666,7 @@ with their current status. The client replaces the entire plan with each update.
 </Expandable>
 </ResponseField>
 
-<ResponseField name="available_commands_update">
+<ResponseField name="available_commands_update" type="object">
 Available commands are ready or have changed
 
 <Expandable title="Properties">
@@ -2636,7 +2688,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="current_mode_update">
+<ResponseField name="current_mode_update" type="object">
 The current mode of the session has changed
 
 See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
@@ -2668,24 +2720,26 @@ See protocol docs: [Stop Reasons](https://agentclientprotocol.com/protocol/promp
 
 **Type:** Union
 
-<ResponseField name="end_turn">The turn ended successfully.</ResponseField>
+<ResponseField name="end_turn" type="string">
+  The turn ended successfully.
+</ResponseField>
 
-<ResponseField name="max_tokens">
+<ResponseField name="max_tokens" type="string">
   The turn ended because the agent reached the maximum number of tokens.
 </ResponseField>
 
-<ResponseField name="max_turn_requests">
+<ResponseField name="max_turn_requests" type="string">
   The turn ended because the agent reached the maximum number of allowed agent
   requests between user turns.
 </ResponseField>
 
-<ResponseField name="refusal">
+<ResponseField name="refusal" type="string">
   The turn ended because the agent refused to continue. The user prompt and
   everything that comes after it won't be included in the next prompt, so this
   should be reflected in the UI.
 </ResponseField>
 
-<ResponseField name="cancelled">
+<ResponseField name="cancelled" type="string">
 The turn was cancelled by the client via `session/cancel`.
 
 This stop reason MUST be returned when the client sends a `session/cancel`
@@ -2847,7 +2901,7 @@ See protocol docs: [Content](https://agentclientprotocol.com/protocol/tool-calls
 
 **Type:** Union
 
-<ResponseField name="content">
+<ResponseField name="content" type="object">
 Standard content block (text, images, resources).
 
 <Expandable title="Properties">
@@ -2869,7 +2923,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="diff">
+<ResponseField name="diff" type="object">
 File modification shown as a diff.
 
 <Expandable title="Properties">
@@ -2897,7 +2951,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="terminal">
+<ResponseField name="terminal" type="object">
 Embed a terminal created with `terminal/create` by its id.
 
 The terminal must be added before calling `terminal/release`.
@@ -2969,20 +3023,22 @@ See protocol docs: [Status](https://agentclientprotocol.com/protocol/tool-calls#
 
 **Type:** Union
 
-<ResponseField name="pending">
+<ResponseField name="pending" type="string">
   The tool call hasn't started running yet because the input is either streaming
   or we're awaiting approval.
 </ResponseField>
 
-<ResponseField name="in_progress">
+<ResponseField name="in_progress" type="string">
   The tool call is currently running.
 </ResponseField>
 
-<ResponseField name="completed">
+<ResponseField name="completed" type="string">
   The tool call completed successfully.
 </ResponseField>
 
-<ResponseField name="failed">The tool call failed with an error.</ResponseField>
+<ResponseField name="failed" type="string">
+  The tool call failed with an error.
+</ResponseField>
 
 ## <span class="font-mono">ToolCallUpdate</span>
 
@@ -3041,27 +3097,45 @@ See protocol docs: [Creating](https://agentclientprotocol.com/protocol/tool-call
 
 **Type:** Union
 
-<ResponseField name="read">Reading files or data.</ResponseField>
+<ResponseField name="read" type="string">
+  Reading files or data.
+</ResponseField>
 
-<ResponseField name="edit">Modifying files or content.</ResponseField>
+<ResponseField name="edit" type="string">
+  Modifying files or content.
+</ResponseField>
 
-<ResponseField name="delete">Removing files or data.</ResponseField>
+<ResponseField name="delete" type="string">
+  Removing files or data.
+</ResponseField>
 
-<ResponseField name="move">Moving or renaming files.</ResponseField>
+<ResponseField name="move" type="string">
+  Moving or renaming files.
+</ResponseField>
 
-<ResponseField name="search">Searching for information.</ResponseField>
+<ResponseField name="search" type="string">
+  Searching for information.
+</ResponseField>
 
-<ResponseField name="execute">Running commands or code.</ResponseField>
+<ResponseField name="execute" type="string">
+  Running commands or code.
+</ResponseField>
 
-<ResponseField name="think">Internal reasoning or planning.</ResponseField>
+<ResponseField name="think" type="string">
+  Internal reasoning or planning.
+</ResponseField>
 
-<ResponseField name="fetch">Retrieving external data.</ResponseField>
+<ResponseField name="fetch" type="string">
+  Retrieving external data.
+</ResponseField>
 
-<ResponseField name="switch_mode">
+<ResponseField name="switch_mode" type="string">
   Switching the current session mode.
 </ResponseField>
 
-<ResponseField name="other">Other tool types (default).</ResponseField>
+<ResponseField name="other" type="string">
+  Other tool types (default).
+</ResponseField>
 
 ## <span class="font-mono">UnstructuredCommandInput</span>
 

--- a/docs/protocol/schema.unstable.mdx
+++ b/docs/protocol/schema.unstable.mdx
@@ -1440,7 +1440,7 @@ See protocol docs: [Content](https://agentclientprotocol.com/protocol/content)
 
 **Type:** Union
 
-<ResponseField name="text">
+<ResponseField name="text" type="object">
 Text content. May be plain text or formatted with Markdown.
 
 All agents MUST support text content blocks in prompts.
@@ -1466,7 +1466,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="image">
+<ResponseField name="image" type="object">
 Images for visual context or analysis.
 
 Requires the `image` prompt capability when included in prompts.
@@ -1495,7 +1495,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="audio">
+<ResponseField name="audio" type="object">
 Audio data for transcription or analysis.
 
 Requires the `audio` prompt capability when included in prompts.
@@ -1522,7 +1522,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="resource_link">
+<ResponseField name="resource_link" type="object">
 References to resources that the agent can access.
 
 All agents MUST support resource links in prompts.
@@ -1557,7 +1557,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="resource">
+<ResponseField name="resource" type="object">
 Complete resource contents embedded directly in the message.
 
 Preferred for including context as it avoids extra round-trips.
@@ -1765,7 +1765,7 @@ See protocol docs: [JSON-RPC Error Object](https://www.jsonrpc.org/specification
 
 **Properties:**
 
-<ResponseField name="code" type={"int32"} required>
+<ResponseField name="code" type={<a href="#errorcode">ErrorCode</a>} required>
   A number indicating the error type that occurred. This must be an integer as
   defined in the JSON-RPC specification.
 </ResponseField>
@@ -1777,6 +1777,50 @@ See protocol docs: [JSON-RPC Error Object](https://www.jsonrpc.org/specification
 <ResponseField name="message" type={"string"} required>
   A string providing a short description of the error. The message should be
   limited to a concise single sentence.
+</ResponseField>
+
+## <span class="font-mono">ErrorCode</span>
+
+Predefined error codes for common JSON-RPC and ACP-specific errors.
+
+These codes follow the JSON-RPC 2.0 specification for standard errors
+and use the reserved range (-32000 to -32099) for protocol-specific errors.
+
+**Type:** Union
+
+<ResponseField name="-32700" type="int32">
+  **Parse error**: Invalid JSON was received by the server. An error occurred on
+  the server while parsing the JSON text.
+</ResponseField>
+
+<ResponseField name="-32600" type="int32">
+  **Invalid request**: The JSON sent is not a valid Request object.
+</ResponseField>
+
+<ResponseField name="-32601" type="int32">
+  **Method not found**: The method does not exist or is not available.
+</ResponseField>
+
+<ResponseField name="-32602" type="int32">
+  **Invalid params**: Invalid method parameter(s).
+</ResponseField>
+
+<ResponseField name="-32603" type="int32">
+  **Internal error**: Internal JSON-RPC error. Reserved for
+  implementation-defined server errors.
+</ResponseField>
+
+<ResponseField name="-32000" type="int32">
+  **Authentication required**: Authentication is required before this operation
+  can be performed.
+</ResponseField>
+
+<ResponseField name="-32002" type="int32">
+  **Resource not found**: A given resource, such as a file, was not found.
+</ResponseField>
+
+<ResponseField name="integer" type="int32">
+  Other undefined error code.
 </ResponseField>
 
 ## <span class="font-mono">ExtNotification</span>
@@ -1957,7 +2001,7 @@ See protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/sessio
 
 **Type:** Union
 
-<ResponseField name="http">
+<ResponseField name="http" type="object">
 HTTP transport configuration
 
 Only available when the Agent capabilities indicate `mcp_capabilities.http` is `true`.
@@ -1987,7 +2031,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="sse">
+<ResponseField name="sse" type="object">
 SSE transport configuration
 
 Only available when the Agent capabilities indicate `mcp_capabilities.sse` is `true`.
@@ -2209,19 +2253,19 @@ Helps clients choose appropriate icons and UI treatment.
 
 **Type:** Union
 
-<ResponseField name="allow_once">
+<ResponseField name="allow_once" type="string">
   Allow this operation only this time.
 </ResponseField>
 
-<ResponseField name="allow_always">
+<ResponseField name="allow_always" type="string">
   Allow this operation and remember the choice.
 </ResponseField>
 
-<ResponseField name="reject_once">
+<ResponseField name="reject_once" type="string">
   Reject this operation only this time.
 </ResponseField>
 
-<ResponseField name="reject_always">
+<ResponseField name="reject_always" type="string">
   Reject this operation and remember the choice.
 </ResponseField>
 
@@ -2296,15 +2340,15 @@ See protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/agent
 
 **Type:** Union
 
-<ResponseField name="high">
+<ResponseField name="high" type="string">
   High priority task - critical to the overall goal.
 </ResponseField>
 
-<ResponseField name="medium">
+<ResponseField name="medium" type="string">
   Medium priority task - important but not critical.
 </ResponseField>
 
-<ResponseField name="low">
+<ResponseField name="low" type="string">
   Low priority task - nice to have but not essential.
 </ResponseField>
 
@@ -2317,13 +2361,15 @@ See protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/agent
 
 **Type:** Union
 
-<ResponseField name="pending">The task has not started yet.</ResponseField>
+<ResponseField name="pending" type="string">
+  The task has not started yet.
+</ResponseField>
 
-<ResponseField name="in_progress">
+<ResponseField name="in_progress" type="string">
   The task is currently being worked on.
 </ResponseField>
 
-<ResponseField name="completed">
+<ResponseField name="completed" type="string">
   The task has been successfully completed.
 </ResponseField>
 
@@ -2404,11 +2450,17 @@ The Server MUST reply with the same value in the Response object if included. Th
 
 **Type:** Union
 
-<ResponseField name="null">{""}</ResponseField>
+<ResponseField name="null" type="null">
+  {""}
+</ResponseField>
 
-<ResponseField name="Variant">{""}</ResponseField>
+<ResponseField name="integer" type="int64">
+  {""}
+</ResponseField>
 
-<ResponseField name="Variant">{""}</ResponseField>
+<ResponseField name="string" type="string">
+  {""}
+</ResponseField>
 
 ## <span class="font-mono">RequestPermissionOutcome</span>
 
@@ -2416,7 +2468,7 @@ The outcome of a permission request.
 
 **Type:** Union
 
-<ResponseField name="cancelled">
+<ResponseField name="cancelled" type="object">
 The prompt turn was cancelled before the user responded.
 
 When a client sends a `session/cancel` notification to cancel an ongoing
@@ -2432,7 +2484,7 @@ See protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/promp
 </Expandable>
 </ResponseField>
 
-<ResponseField name="selected">
+<ResponseField name="selected" type="object">
 The user selected one of the provided options.
 
 <Expandable title="Properties">
@@ -2705,7 +2757,7 @@ See protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protoc
 
 **Type:** Union
 
-<ResponseField name="user_message_chunk">
+<ResponseField name="user_message_chunk" type="object">
 A chunk of the user's message being streamed.
 
 <Expandable title="Properties">
@@ -2727,7 +2779,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="agent_message_chunk">
+<ResponseField name="agent_message_chunk" type="object">
 A chunk of the agent's response being streamed.
 
 <Expandable title="Properties">
@@ -2749,7 +2801,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="agent_thought_chunk">
+<ResponseField name="agent_thought_chunk" type="object">
 A chunk of the agent's internal reasoning being streamed.
 
 <Expandable title="Properties">
@@ -2771,7 +2823,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="tool_call">
+<ResponseField name="tool_call" type="object">
 Notification that a new tool call has been initiated.
 
 <Expandable title="Properties">
@@ -2816,7 +2868,7 @@ Enables "follow-along" features in clients.
 </Expandable>
 </ResponseField>
 
-<ResponseField name="tool_call_update">
+<ResponseField name="tool_call_update" type="object">
 Update on the status or results of a tool call.
 
 <Expandable title="Properties">
@@ -2859,7 +2911,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="plan">
+<ResponseField name="plan" type="object">
 The agent's execution plan for complex tasks.
 See protocol docs: [Agent Plan](https://agentclientprotocol.com/protocol/agent-plan)
 
@@ -2886,7 +2938,7 @@ with their current status. The client replaces the entire plan with each update.
 </Expandable>
 </ResponseField>
 
-<ResponseField name="available_commands_update">
+<ResponseField name="available_commands_update" type="object">
 Available commands are ready or have changed
 
 <Expandable title="Properties">
@@ -2908,7 +2960,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="current_mode_update">
+<ResponseField name="current_mode_update" type="object">
 The current mode of the session has changed
 
 See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
@@ -2940,24 +2992,26 @@ See protocol docs: [Stop Reasons](https://agentclientprotocol.com/protocol/promp
 
 **Type:** Union
 
-<ResponseField name="end_turn">The turn ended successfully.</ResponseField>
+<ResponseField name="end_turn" type="string">
+  The turn ended successfully.
+</ResponseField>
 
-<ResponseField name="max_tokens">
+<ResponseField name="max_tokens" type="string">
   The turn ended because the agent reached the maximum number of tokens.
 </ResponseField>
 
-<ResponseField name="max_turn_requests">
+<ResponseField name="max_turn_requests" type="string">
   The turn ended because the agent reached the maximum number of allowed agent
   requests between user turns.
 </ResponseField>
 
-<ResponseField name="refusal">
+<ResponseField name="refusal" type="string">
   The turn ended because the agent refused to continue. The user prompt and
   everything that comes after it won't be included in the next prompt, so this
   should be reflected in the UI.
 </ResponseField>
 
-<ResponseField name="cancelled">
+<ResponseField name="cancelled" type="string">
 The turn was cancelled by the client via `session/cancel`.
 
 This stop reason MUST be returned when the client sends a `session/cancel`
@@ -3119,7 +3173,7 @@ See protocol docs: [Content](https://agentclientprotocol.com/protocol/tool-calls
 
 **Type:** Union
 
-<ResponseField name="content">
+<ResponseField name="content" type="object">
 Standard content block (text, images, resources).
 
 <Expandable title="Properties">
@@ -3141,7 +3195,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="diff">
+<ResponseField name="diff" type="object">
 File modification shown as a diff.
 
 <Expandable title="Properties">
@@ -3169,7 +3223,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="terminal">
+<ResponseField name="terminal" type="object">
 Embed a terminal created with `terminal/create` by its id.
 
 The terminal must be added before calling `terminal/release`.
@@ -3241,20 +3295,22 @@ See protocol docs: [Status](https://agentclientprotocol.com/protocol/tool-calls#
 
 **Type:** Union
 
-<ResponseField name="pending">
+<ResponseField name="pending" type="string">
   The tool call hasn't started running yet because the input is either streaming
   or we're awaiting approval.
 </ResponseField>
 
-<ResponseField name="in_progress">
+<ResponseField name="in_progress" type="string">
   The tool call is currently running.
 </ResponseField>
 
-<ResponseField name="completed">
+<ResponseField name="completed" type="string">
   The tool call completed successfully.
 </ResponseField>
 
-<ResponseField name="failed">The tool call failed with an error.</ResponseField>
+<ResponseField name="failed" type="string">
+  The tool call failed with an error.
+</ResponseField>
 
 ## <span class="font-mono">ToolCallUpdate</span>
 
@@ -3313,27 +3369,45 @@ See protocol docs: [Creating](https://agentclientprotocol.com/protocol/tool-call
 
 **Type:** Union
 
-<ResponseField name="read">Reading files or data.</ResponseField>
+<ResponseField name="read" type="string">
+  Reading files or data.
+</ResponseField>
 
-<ResponseField name="edit">Modifying files or content.</ResponseField>
+<ResponseField name="edit" type="string">
+  Modifying files or content.
+</ResponseField>
 
-<ResponseField name="delete">Removing files or data.</ResponseField>
+<ResponseField name="delete" type="string">
+  Removing files or data.
+</ResponseField>
 
-<ResponseField name="move">Moving or renaming files.</ResponseField>
+<ResponseField name="move" type="string">
+  Moving or renaming files.
+</ResponseField>
 
-<ResponseField name="search">Searching for information.</ResponseField>
+<ResponseField name="search" type="string">
+  Searching for information.
+</ResponseField>
 
-<ResponseField name="execute">Running commands or code.</ResponseField>
+<ResponseField name="execute" type="string">
+  Running commands or code.
+</ResponseField>
 
-<ResponseField name="think">Internal reasoning or planning.</ResponseField>
+<ResponseField name="think" type="string">
+  Internal reasoning or planning.
+</ResponseField>
 
-<ResponseField name="fetch">Retrieving external data.</ResponseField>
+<ResponseField name="fetch" type="string">
+  Retrieving external data.
+</ResponseField>
 
-<ResponseField name="switch_mode">
+<ResponseField name="switch_mode" type="string">
   Switching the current session mode.
 </ResponseField>
 
-<ResponseField name="other">Other tool types (default).</ResponseField>
+<ResponseField name="other" type="string">
+  Other tool types (default).
+</ResponseField>
 
 ## <span class="font-mono">UnstructuredCommandInput</span>
 

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -954,9 +954,12 @@
       "description": "JSON-RPC error object.\n\nRepresents an error that occurred during method execution, following the\nJSON-RPC 2.0 error object specification with optional additional data.\n\nSee protocol docs: [JSON-RPC Error Object](https://www.jsonrpc.org/specification#error_object)",
       "properties": {
         "code": {
-          "description": "A number indicating the error type that occurred.\nThis must be an integer as defined in the JSON-RPC specification.",
-          "format": "int32",
-          "type": "integer"
+          "allOf": [
+            {
+              "$ref": "#/$defs/ErrorCode"
+            }
+          ],
+          "description": "A number indicating the error type that occurred.\nThis must be an integer as defined in the JSON-RPC specification."
         },
         "data": {
           "description": "Optional primitive or structured value that contains additional information about the error.\nThis may include debugging information or context-specific details."
@@ -968,6 +971,58 @@
       },
       "required": ["code", "message"],
       "type": "object"
+    },
+    "ErrorCode": {
+      "anyOf": [
+        {
+          "const": -32700,
+          "description": "**Parse error**: Invalid JSON was received by the server.\nAn error occurred on the server while parsing the JSON text.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32600,
+          "description": "**Invalid request**: The JSON sent is not a valid Request object.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32601,
+          "description": "**Method not found**: The method does not exist or is not available.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32602,
+          "description": "**Invalid params**: Invalid method parameter(s).",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32603,
+          "description": "**Internal error**: Internal JSON-RPC error.\nReserved for implementation-defined server errors.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32000,
+          "description": "**Authentication required**: Authentication is required before this operation can be performed.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32002,
+          "description": "**Resource not found**: A given resource, such as a file, was not found.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "description": "Other undefined error code.",
+          "format": "int32",
+          "type": "integer"
+        }
+      ],
+      "description": "Predefined error codes for common JSON-RPC and ACP-specific errors.\n\nThese codes follow the JSON-RPC 2.0 specification for standard errors\nand use the reserved range (-32000 to -32099) for protocol-specific errors."
     },
     "ExtNotification": {
       "description": "Allows the Agent to send an arbitrary notification that is not part of the ACP spec.\nExtension notifications provide a way to send one-way messages for custom functionality\nwhile maintaining protocol compatibility.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)"

--- a/schema/schema.unstable.json
+++ b/schema/schema.unstable.json
@@ -976,9 +976,12 @@
       "description": "JSON-RPC error object.\n\nRepresents an error that occurred during method execution, following the\nJSON-RPC 2.0 error object specification with optional additional data.\n\nSee protocol docs: [JSON-RPC Error Object](https://www.jsonrpc.org/specification#error_object)",
       "properties": {
         "code": {
-          "description": "A number indicating the error type that occurred.\nThis must be an integer as defined in the JSON-RPC specification.",
-          "format": "int32",
-          "type": "integer"
+          "allOf": [
+            {
+              "$ref": "#/$defs/ErrorCode"
+            }
+          ],
+          "description": "A number indicating the error type that occurred.\nThis must be an integer as defined in the JSON-RPC specification."
         },
         "data": {
           "description": "Optional primitive or structured value that contains additional information about the error.\nThis may include debugging information or context-specific details."
@@ -990,6 +993,58 @@
       },
       "required": ["code", "message"],
       "type": "object"
+    },
+    "ErrorCode": {
+      "anyOf": [
+        {
+          "const": -32700,
+          "description": "**Parse error**: Invalid JSON was received by the server.\nAn error occurred on the server while parsing the JSON text.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32600,
+          "description": "**Invalid request**: The JSON sent is not a valid Request object.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32601,
+          "description": "**Method not found**: The method does not exist or is not available.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32602,
+          "description": "**Invalid params**: Invalid method parameter(s).",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32603,
+          "description": "**Internal error**: Internal JSON-RPC error.\nReserved for implementation-defined server errors.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32000,
+          "description": "**Authentication required**: Authentication is required before this operation can be performed.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "const": -32002,
+          "description": "**Resource not found**: A given resource, such as a file, was not found.",
+          "format": "int32",
+          "type": "integer"
+        },
+        {
+          "description": "Other undefined error code.",
+          "format": "int32",
+          "type": "integer"
+        }
+      ],
+      "description": "Predefined error codes for common JSON-RPC and ACP-specific errors.\n\nThese codes follow the JSON-RPC 2.0 specification for standard errors\nand use the reserved range (-32000 to -32099) for protocol-specific errors."
     },
     "ExtNotification": {
       "description": "Allows the Agent to send an arbitrary notification that is not part of the ACP spec.\nExtension notifications provide a way to send one-way messages for custom functionality\nwhile maintaining protocol compatibility.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)"

--- a/src/bin/generate.rs
+++ b/src/bin/generate.rs
@@ -289,6 +289,7 @@ and control access to resources."
             }
         }
 
+        #[expect(clippy::too_many_lines)]
         fn document_variant_table_row(&mut self, variant: &Value) {
             write!(&mut self.output, "<ResponseField name=\"").unwrap();
 
@@ -316,8 +317,34 @@ and control access to resources."
                 } else {
                     write!(&mut self.output, "Object").unwrap();
                 }
+            } else if let Some(title) = variant.get("title") {
+                if let Some(s) = title.as_str() {
+                    write!(&mut self.output, "{s}").unwrap();
+                } else {
+                    write!(&mut self.output, "{title}").unwrap();
+                }
+            } else if let Some(ty) = variant.get("type") {
+                if let Some(s) = ty.as_str() {
+                    write!(&mut self.output, "{s}").unwrap();
+                } else {
+                    write!(&mut self.output, "{ty}").unwrap();
+                }
             } else {
                 write!(&mut self.output, "Variant").unwrap();
+            }
+
+            if let Some(format) = variant.get("format") {
+                if let Some(s) = format.as_str() {
+                    write!(&mut self.output, "\" type=\"{s}").unwrap();
+                } else {
+                    write!(&mut self.output, "\" type=\"{format}").unwrap();
+                }
+            } else if let Some(ty) = variant.get("type") {
+                if let Some(s) = ty.as_str() {
+                    write!(&mut self.output, "\" type=\"{s}").unwrap();
+                } else {
+                    write!(&mut self.output, "\" type=\"{ty}").unwrap();
+                }
             }
 
             writeln!(&mut self.output, "\">").unwrap();


### PR DESCRIPTION
Breaking for Rust-side only, schema remains equivalent. But we now have a better description of the various error codes that can be used in the protocol and what they mean.
