### PR TITLE
docs: Setup hidden unstable section for the docs website

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -70,7 +70,12 @@
               "protocol/slash-commands",
               "protocol/extensibility",
               "protocol/transports",
-              "protocol/schema"
+              "protocol/schema",
+              {
+                "group": "Unstable",
+                "hidden": true,
+                "pages": ["protocol/schema.unstable"]
+              }
             ]
           },
           {


### PR DESCRIPTION
Mintlify will make sure this isn't accessible in search, but will allow people to preview in-progress documentation for new features without confusing people about the current state  of things.
