### PR TITLE
feat(rust-only): More convenient builder method params

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -10,7 +10,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ClientCapabilities, ContentBlock, ExtNotification, ExtRequest, ExtResponse, Meta,
+    ClientCapabilities, ContentBlock, ExtNotification, ExtRequest, ExtResponse, IntoOption, Meta,
     ProtocolVersion, SessionId,
 };
 
@@ -65,8 +65,8 @@ impl InitializeRequest {
 
     /// Information about the Client name and version sent to the Agent.
     #[must_use]
-    pub fn client_info(mut self, client_info: Implementation) -> Self {
-        self.client_info = Some(client_info);
+    pub fn client_info(mut self, client_info: impl IntoOption<Implementation>) -> Self {
+        self.client_info = client_info.into_option();
         self
     }
 
@@ -76,8 +76,8 @@ impl InitializeRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -145,8 +145,8 @@ impl InitializeResponse {
 
     /// Information about the Agent name and version sent to the Client.
     #[must_use]
-    pub fn agent_info(mut self, agent_info: Implementation) -> Self {
-        self.agent_info = Some(agent_info);
+    pub fn agent_info(mut self, agent_info: impl IntoOption<Implementation>) -> Self {
+        self.agent_info = agent_info.into_option();
         self
     }
 
@@ -156,8 +156,8 @@ impl InitializeResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -204,8 +204,8 @@ impl Implementation {
     ///
     /// If not provided, the name should be used for display.
     #[must_use]
-    pub fn title(mut self, title: impl Into<String>) -> Self {
-        self.title = Some(title.into());
+    pub fn title(mut self, title: impl IntoOption<String>) -> Self {
+        self.title = title.into_option();
         self
     }
 
@@ -215,8 +215,8 @@ impl Implementation {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -253,8 +253,8 @@ impl AuthenticateRequest {
     }
 
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -281,8 +281,8 @@ impl AuthenticateResponse {
     }
 
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -331,8 +331,8 @@ impl AuthMethod {
 
     /// Optional description providing more details about this authentication method.
     #[must_use]
-    pub fn description(mut self, description: impl Into<String>) -> Self {
-        self.description = Some(description.into());
+    pub fn description(mut self, description: impl IntoOption<String>) -> Self {
+        self.description = description.into_option();
         self
     }
 
@@ -342,8 +342,8 @@ impl AuthMethod {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -393,8 +393,8 @@ impl NewSessionRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -449,8 +449,8 @@ impl NewSessionResponse {
     ///
     /// See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
     #[must_use]
-    pub fn modes(mut self, modes: SessionModeState) -> Self {
-        self.modes = Some(modes);
+    pub fn modes(mut self, modes: impl IntoOption<SessionModeState>) -> Self {
+        self.modes = modes.into_option();
         self
     }
 
@@ -461,8 +461,8 @@ impl NewSessionResponse {
     /// Initial model state if supported by the Agent
     #[cfg(feature = "unstable_session_model")]
     #[must_use]
-    pub fn models(mut self, models: SessionModelState) -> Self {
-        self.models = Some(models);
+    pub fn models(mut self, models: impl IntoOption<SessionModelState>) -> Self {
+        self.models = models.into_option();
         self
     }
 
@@ -472,8 +472,8 @@ impl NewSessionResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -528,8 +528,8 @@ impl LoadSessionRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -572,8 +572,8 @@ impl LoadSessionResponse {
     ///
     /// See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
     #[must_use]
-    pub fn modes(mut self, modes: SessionModeState) -> Self {
-        self.modes = Some(modes);
+    pub fn modes(mut self, modes: impl IntoOption<SessionModeState>) -> Self {
+        self.modes = modes.into_option();
         self
     }
 
@@ -584,8 +584,8 @@ impl LoadSessionResponse {
     /// Initial model state if supported by the Agent
     #[cfg(feature = "unstable_session_model")]
     #[must_use]
-    pub fn models(mut self, models: SessionModelState) -> Self {
-        self.models = Some(models);
+    pub fn models(mut self, models: impl IntoOption<SessionModelState>) -> Self {
+        self.models = models.into_option();
         self
     }
 
@@ -595,8 +595,8 @@ impl LoadSessionResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -627,7 +627,7 @@ pub struct ForkSessionRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[serde(skip_serializing_if = "Option::is_none", rename = "_meta")]
-    pub meta: Option<serde_json::Value>,
+    pub meta: Option<Meta>,
 }
 
 #[cfg(feature = "unstable_session_fork")]
@@ -645,8 +645,8 @@ impl ForkSessionRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: serde_json::Value) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -683,7 +683,7 @@ pub struct ForkSessionResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[serde(skip_serializing_if = "Option::is_none", rename = "_meta")]
-    pub meta: Option<serde_json::Value>,
+    pub meta: Option<Meta>,
 }
 
 #[cfg(feature = "unstable_session_fork")]
@@ -703,8 +703,8 @@ impl ForkSessionResponse {
     ///
     /// See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
     #[must_use]
-    pub fn modes(mut self, modes: SessionModeState) -> Self {
-        self.modes = Some(modes);
+    pub fn modes(mut self, modes: impl IntoOption<SessionModeState>) -> Self {
+        self.modes = modes.into_option();
         self
     }
 
@@ -715,8 +715,8 @@ impl ForkSessionResponse {
     /// Initial model state if supported by the Agent
     #[cfg(feature = "unstable_session_model")]
     #[must_use]
-    pub fn models(mut self, models: SessionModelState) -> Self {
-        self.models = Some(models);
+    pub fn models(mut self, models: impl IntoOption<SessionModelState>) -> Self {
+        self.models = models.into_option();
         self
     }
 
@@ -726,8 +726,8 @@ impl ForkSessionResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: serde_json::Value) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -771,15 +771,15 @@ impl ListSessionsRequest {
 
     /// Filter sessions by working directory. Must be an absolute path.
     #[must_use]
-    pub fn cwd(mut self, cwd: impl Into<PathBuf>) -> Self {
-        self.cwd = Some(cwd.into());
+    pub fn cwd(mut self, cwd: impl IntoOption<PathBuf>) -> Self {
+        self.cwd = cwd.into_option();
         self
     }
 
     /// Opaque cursor token from a previous response's nextCursor field for cursor-based pagination
     #[must_use]
-    pub fn cursor(mut self, cursor: impl Into<String>) -> Self {
-        self.cursor = Some(cursor.into());
+    pub fn cursor(mut self, cursor: impl IntoOption<String>) -> Self {
+        self.cursor = cursor.into_option();
         self
     }
 
@@ -789,8 +789,8 @@ impl ListSessionsRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -833,8 +833,8 @@ impl ListSessionsResponse {
     }
 
     #[must_use]
-    pub fn next_cursor(mut self, next_cursor: impl Into<String>) -> Self {
-        self.next_cursor = Some(next_cursor.into());
+    pub fn next_cursor(mut self, next_cursor: impl IntoOption<String>) -> Self {
+        self.next_cursor = next_cursor.into_option();
         self
     }
 
@@ -844,8 +844,8 @@ impl ListSessionsResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -893,15 +893,15 @@ impl SessionInfo {
 
     /// Human-readable title for the session
     #[must_use]
-    pub fn title(mut self, title: impl Into<String>) -> Self {
-        self.title = Some(title.into());
+    pub fn title(mut self, title: impl IntoOption<String>) -> Self {
+        self.title = title.into_option();
         self
     }
 
     /// ISO 8601 timestamp of last activity
     #[must_use]
-    pub fn updated_at(mut self, updated_at: impl Into<String>) -> Self {
-        self.updated_at = Some(updated_at.into());
+    pub fn updated_at(mut self, updated_at: impl IntoOption<String>) -> Self {
+        self.updated_at = updated_at.into_option();
         self
     }
 
@@ -911,8 +911,8 @@ impl SessionInfo {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -956,8 +956,8 @@ impl SessionModeState {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -993,8 +993,8 @@ impl SessionMode {
     }
 
     #[must_use]
-    pub fn description(mut self, description: impl Into<String>) -> Self {
-        self.description = Some(description.into());
+    pub fn description(mut self, description: impl IntoOption<String>) -> Self {
+        self.description = description.into_option();
         self
     }
 
@@ -1004,8 +1004,8 @@ impl SessionMode {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1053,8 +1053,8 @@ impl SetSessionModeRequest {
     }
 
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1076,8 +1076,8 @@ impl SetSessionModeResponse {
     }
 
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1152,8 +1152,8 @@ impl McpServerHttp {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1201,8 +1201,8 @@ impl McpServerSse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1260,8 +1260,8 @@ impl McpServerStdio {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1299,8 +1299,8 @@ impl EnvVariable {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1338,8 +1338,8 @@ impl HttpHeader {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1397,8 +1397,8 @@ impl PromptRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1437,8 +1437,8 @@ impl PromptResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1512,8 +1512,8 @@ impl SessionModelState {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1576,8 +1576,8 @@ impl ModelInfo {
 
     /// Optional description of the model.
     #[must_use]
-    pub fn description(mut self, description: impl Into<String>) -> Self {
-        self.description = Some(description.into());
+    pub fn description(mut self, description: impl IntoOption<String>) -> Self {
+        self.description = description.into_option();
         self
     }
 
@@ -1587,8 +1587,8 @@ impl ModelInfo {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1634,8 +1634,8 @@ impl SetSessionModelRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1673,8 +1673,8 @@ impl SetSessionModelResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1744,8 +1744,8 @@ impl AgentCapabilities {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1796,16 +1796,16 @@ impl SessionCapabilities {
     #[cfg(feature = "unstable_session_list")]
     /// Whether the agent supports `session/list`.
     #[must_use]
-    pub fn list(mut self, list: SessionListCapabilities) -> Self {
-        self.list = Some(list);
+    pub fn list(mut self, list: impl IntoOption<SessionListCapabilities>) -> Self {
+        self.list = list.into_option();
         self
     }
 
     #[cfg(feature = "unstable_session_fork")]
     /// Whether the agent supports `session/fork`.
     #[must_use]
-    pub fn fork(mut self, fork: SessionForkCapabilities) -> Self {
-        self.fork = Some(fork);
+    pub fn fork(mut self, fork: impl IntoOption<SessionForkCapabilities>) -> Self {
+        self.fork = fork.into_option();
         self
     }
 
@@ -1815,8 +1815,8 @@ impl SessionCapabilities {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1851,8 +1851,8 @@ impl SessionListCapabilities {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1874,7 +1874,7 @@ pub struct SessionForkCapabilities {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[serde(skip_serializing_if = "Option::is_none", rename = "_meta")]
-    pub meta: Option<serde_json::Value>,
+    pub meta: Option<Meta>,
 }
 
 #[cfg(feature = "unstable_session_fork")]
@@ -1890,8 +1890,8 @@ impl SessionForkCapabilities {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: serde_json::Value) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1969,8 +1969,8 @@ impl PromptCapabilities {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -2021,8 +2021,8 @@ impl McpCapabilities {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -2348,8 +2348,8 @@ impl CancelNotification {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,8 +10,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ContentBlock, ExtNotification, ExtRequest, ExtResponse, Meta, Plan, SessionId, SessionModeId,
-    ToolCall, ToolCallUpdate,
+    ContentBlock, ExtNotification, ExtRequest, ExtResponse, IntoOption, Meta, Plan, SessionId,
+    SessionModeId, ToolCall, ToolCallUpdate,
 };
 
 // Session updates
@@ -55,8 +55,8 @@ impl SessionNotification {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -125,8 +125,8 @@ impl CurrentModeUpdate {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -162,8 +162,8 @@ impl ContentChunk {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -199,8 +199,8 @@ impl AvailableCommandsUpdate {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -237,8 +237,8 @@ impl AvailableCommand {
 
     /// Input for the command if required
     #[must_use]
-    pub fn input(mut self, input: AvailableCommandInput) -> Self {
-        self.input = Some(input);
+    pub fn input(mut self, input: impl IntoOption<AvailableCommandInput>) -> Self {
+        self.input = input.into_option();
         self
     }
 
@@ -248,8 +248,8 @@ impl AvailableCommand {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -293,8 +293,8 @@ impl UnstructuredCommandInput {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -347,8 +347,8 @@ impl RequestPermissionRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -393,8 +393,8 @@ impl PermissionOption {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -462,8 +462,8 @@ impl RequestPermissionResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -518,8 +518,8 @@ impl SelectedPermissionOutcome {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -569,8 +569,8 @@ impl WriteTextFileRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -602,8 +602,8 @@ impl WriteTextFileResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -650,15 +650,15 @@ impl ReadTextFileRequest {
 
     /// Line number to start reading from (1-based).
     #[must_use]
-    pub fn line(mut self, line: u32) -> Self {
-        self.line = Some(line);
+    pub fn line(mut self, line: impl IntoOption<u32>) -> Self {
+        self.line = line.into_option();
         self
     }
 
     /// Maximum number of lines to read.
     #[must_use]
-    pub fn limit(mut self, limit: u32) -> Self {
-        self.limit = Some(limit);
+    pub fn limit(mut self, limit: impl IntoOption<u32>) -> Self {
+        self.limit = limit.into_option();
         self
     }
 
@@ -668,8 +668,8 @@ impl ReadTextFileRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -704,8 +704,8 @@ impl ReadTextFileResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -791,8 +791,8 @@ impl CreateTerminalRequest {
 
     /// Working directory for the command (absolute path).
     #[must_use]
-    pub fn cwd(mut self, cwd: impl Into<PathBuf>) -> Self {
-        self.cwd = Some(cwd.into());
+    pub fn cwd(mut self, cwd: impl IntoOption<PathBuf>) -> Self {
+        self.cwd = cwd.into_option();
         self
     }
 
@@ -805,8 +805,8 @@ impl CreateTerminalRequest {
     /// string output, even if this means the retained output is slightly less than the
     /// specified limit.
     #[must_use]
-    pub fn output_byte_limit(mut self, output_byte_limit: u64) -> Self {
-        self.output_byte_limit = Some(output_byte_limit);
+    pub fn output_byte_limit(mut self, output_byte_limit: impl IntoOption<u64>) -> Self {
+        self.output_byte_limit = output_byte_limit.into_option();
         self
     }
 
@@ -816,8 +816,8 @@ impl CreateTerminalRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -854,8 +854,8 @@ impl CreateTerminalResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -895,8 +895,8 @@ impl TerminalOutputRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -934,8 +934,8 @@ impl TerminalOutputResponse {
 
     /// Exit status if the command has completed.
     #[must_use]
-    pub fn exit_status(mut self, exit_status: TerminalExitStatus) -> Self {
-        self.exit_status = Some(exit_status);
+    pub fn exit_status(mut self, exit_status: impl IntoOption<TerminalExitStatus>) -> Self {
+        self.exit_status = exit_status.into_option();
         self
     }
 
@@ -945,8 +945,8 @@ impl TerminalOutputResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -986,8 +986,8 @@ impl ReleaseTerminalRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1019,8 +1019,8 @@ impl ReleaseTerminalResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1060,8 +1060,8 @@ impl KillTerminalCommandRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1093,8 +1093,8 @@ impl KillTerminalCommandResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1134,8 +1134,8 @@ impl WaitForTerminalExitRequest {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1173,8 +1173,8 @@ impl WaitForTerminalExitResponse {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1205,15 +1205,15 @@ impl TerminalExitStatus {
 
     /// The process exit code (may be null if terminated by signal).
     #[must_use]
-    pub fn exit_code(mut self, exit_code: u32) -> Self {
-        self.exit_code = Some(exit_code);
+    pub fn exit_code(mut self, exit_code: impl IntoOption<u32>) -> Self {
+        self.exit_code = exit_code.into_option();
         self
     }
 
     /// The signal that terminated the process (may be null if exited normally).
     #[must_use]
-    pub fn signal(mut self, signal: impl Into<String>) -> Self {
-        self.signal = Some(signal.into());
+    pub fn signal(mut self, signal: impl IntoOption<String>) -> Self {
+        self.signal = signal.into_option();
         self
     }
 
@@ -1223,8 +1223,8 @@ impl TerminalExitStatus {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1284,8 +1284,8 @@ impl ClientCapabilities {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -1339,8 +1339,8 @@ impl FileSystemCapability {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }

--- a/src/content.rs
+++ b/src/content.rs
@@ -12,7 +12,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::Meta;
+use crate::{IntoOption, Meta};
 
 /// Content blocks represent displayable information in the Agent Client Protocol.
 ///
@@ -84,8 +84,8 @@ impl TextContent {
     }
 
     #[must_use]
-    pub fn annotations(mut self, annotations: Annotations) -> Self {
-        self.annotations = Some(annotations);
+    pub fn annotations(mut self, annotations: impl IntoOption<Annotations>) -> Self {
+        self.annotations = annotations.into_option();
         self
     }
 
@@ -95,8 +95,8 @@ impl TextContent {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -139,14 +139,14 @@ impl ImageContent {
     }
 
     #[must_use]
-    pub fn annotations(mut self, annotations: Annotations) -> Self {
-        self.annotations = Some(annotations);
+    pub fn annotations(mut self, annotations: impl IntoOption<Annotations>) -> Self {
+        self.annotations = annotations.into_option();
         self
     }
 
     #[must_use]
-    pub fn uri(mut self, uri: impl Into<String>) -> Self {
-        self.uri = Some(uri.into());
+    pub fn uri(mut self, uri: impl IntoOption<String>) -> Self {
+        self.uri = uri.into_option();
         self
     }
 
@@ -156,8 +156,8 @@ impl ImageContent {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -191,8 +191,8 @@ impl AudioContent {
     }
 
     #[must_use]
-    pub fn annotations(mut self, annotations: Annotations) -> Self {
-        self.annotations = Some(annotations);
+    pub fn annotations(mut self, annotations: impl IntoOption<Annotations>) -> Self {
+        self.annotations = annotations.into_option();
         self
     }
 
@@ -202,8 +202,8 @@ impl AudioContent {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -235,8 +235,8 @@ impl EmbeddedResource {
     }
 
     #[must_use]
-    pub fn annotations(mut self, annotations: Annotations) -> Self {
-        self.annotations = Some(annotations);
+    pub fn annotations(mut self, annotations: impl IntoOption<Annotations>) -> Self {
+        self.annotations = annotations.into_option();
         self
     }
 
@@ -246,8 +246,8 @@ impl EmbeddedResource {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -290,8 +290,8 @@ impl TextResourceContents {
     }
 
     #[must_use]
-    pub fn mime_type(mut self, mime_type: impl Into<String>) -> Self {
-        self.mime_type = Some(mime_type.into());
+    pub fn mime_type(mut self, mime_type: impl IntoOption<String>) -> Self {
+        self.mime_type = mime_type.into_option();
         self
     }
 
@@ -301,8 +301,8 @@ impl TextResourceContents {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -336,8 +336,8 @@ impl BlobResourceContents {
     }
 
     #[must_use]
-    pub fn mime_type(mut self, mime_type: impl Into<String>) -> Self {
-        self.mime_type = Some(mime_type.into());
+    pub fn mime_type(mut self, mime_type: impl IntoOption<String>) -> Self {
+        self.mime_type = mime_type.into_option();
         self
     }
 
@@ -347,8 +347,8 @@ impl BlobResourceContents {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -394,32 +394,32 @@ impl ResourceLink {
     }
 
     #[must_use]
-    pub fn annotations(mut self, annotations: Annotations) -> Self {
-        self.annotations = Some(annotations);
+    pub fn annotations(mut self, annotations: impl IntoOption<Annotations>) -> Self {
+        self.annotations = annotations.into_option();
         self
     }
 
     #[must_use]
-    pub fn description(mut self, description: impl Into<String>) -> Self {
-        self.description = Some(description.into());
+    pub fn description(mut self, description: impl IntoOption<String>) -> Self {
+        self.description = description.into_option();
         self
     }
 
     #[must_use]
-    pub fn mime_type(mut self, mime_type: impl Into<String>) -> Self {
-        self.mime_type = Some(mime_type.into());
+    pub fn mime_type(mut self, mime_type: impl IntoOption<String>) -> Self {
+        self.mime_type = mime_type.into_option();
         self
     }
 
     #[must_use]
-    pub fn size(mut self, size: i64) -> Self {
-        self.size = Some(size);
+    pub fn size(mut self, size: impl IntoOption<i64>) -> Self {
+        self.size = size.into_option();
         self
     }
 
     #[must_use]
-    pub fn title(mut self, title: impl Into<String>) -> Self {
-        self.title = Some(title.into());
+    pub fn title(mut self, title: impl IntoOption<String>) -> Self {
+        self.title = title.into_option();
         self
     }
 
@@ -429,8 +429,8 @@ impl ResourceLink {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -462,20 +462,20 @@ impl Annotations {
     }
 
     #[must_use]
-    pub fn audience(mut self, audience: Vec<Role>) -> Self {
-        self.audience = Some(audience);
+    pub fn audience(mut self, audience: impl IntoOption<Vec<Role>>) -> Self {
+        self.audience = audience.into_option();
         self
     }
 
     #[must_use]
-    pub fn last_modified(mut self, last_modified: impl Into<String>) -> Self {
-        self.last_modified = Some(last_modified.into());
+    pub fn last_modified(mut self, last_modified: impl IntoOption<String>) -> Self {
+        self.last_modified = last_modified.into_option();
         self
     }
 
     #[must_use]
-    pub fn priority(mut self, priority: f64) -> Self {
-        self.priority = Some(priority);
+    pub fn priority(mut self, priority: impl IntoOption<f64>) -> Self {
+        self.priority = priority.into_option();
         self
     }
 
@@ -485,8 +485,8 @@ impl Annotations {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@ use std::{fmt::Display, str};
 use schemars::{JsonSchema, Schema};
 use serde::{Deserialize, Serialize};
 
+use crate::IntoOption;
+
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// JSON-RPC error object.
@@ -55,8 +57,8 @@ impl Error {
     /// This method is chainable and allows attaching context-specific information
     /// to help with debugging or provide more details about the error.
     #[must_use]
-    pub fn data(mut self, data: impl Into<serde_json::Value>) -> Self {
-        self.data = Some(data.into());
+    pub fn data(mut self, data: impl IntoOption<serde_json::Value>) -> Self {
+        self.data = data.into_option();
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,12 @@ pub use version::*;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{
+    borrow::Cow,
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 /// A unique identifier for a conversation session between a client and agent.
 ///
@@ -91,5 +96,96 @@ pub struct SessionId(pub Arc<str>);
 impl SessionId {
     pub fn new(id: impl Into<Arc<str>>) -> Self {
         Self(id.into())
+    }
+}
+
+/// Utility trait for builder methods for optional values.
+/// This allows the caller to either pass in the value itself without wrapping it in `Some`,
+/// or to just pass in an Option if that is what they have.
+pub trait IntoOption<T> {
+    fn into_option(self) -> Option<T>;
+}
+
+impl<T> IntoOption<T> for Option<T> {
+    fn into_option(self) -> Option<T> {
+        self
+    }
+}
+
+impl<T> IntoOption<T> for T {
+    fn into_option(self) -> Option<T> {
+        Some(self)
+    }
+}
+
+impl IntoOption<String> for &str {
+    fn into_option(self) -> Option<String> {
+        Some(self.into())
+    }
+}
+
+impl IntoOption<String> for &mut str {
+    fn into_option(self) -> Option<String> {
+        Some(self.into())
+    }
+}
+
+impl IntoOption<String> for &String {
+    fn into_option(self) -> Option<String> {
+        Some(self.into())
+    }
+}
+
+impl IntoOption<String> for Box<str> {
+    fn into_option(self) -> Option<String> {
+        Some(self.into())
+    }
+}
+
+impl IntoOption<String> for Cow<'_, str> {
+    fn into_option(self) -> Option<String> {
+        Some(self.into())
+    }
+}
+
+impl IntoOption<String> for Arc<str> {
+    fn into_option(self) -> Option<String> {
+        Some(self.to_string())
+    }
+}
+
+impl<T: ?Sized + AsRef<OsStr>> IntoOption<PathBuf> for &T {
+    fn into_option(self) -> Option<PathBuf> {
+        Some(self.into())
+    }
+}
+
+impl IntoOption<PathBuf> for Box<Path> {
+    fn into_option(self) -> Option<PathBuf> {
+        Some(self.into())
+    }
+}
+
+impl IntoOption<PathBuf> for Cow<'_, Path> {
+    fn into_option(self) -> Option<PathBuf> {
+        Some(self.into())
+    }
+}
+
+impl IntoOption<serde_json::Value> for &str {
+    fn into_option(self) -> Option<serde_json::Value> {
+        Some(self.into())
+    }
+}
+
+impl IntoOption<serde_json::Value> for String {
+    fn into_option(self) -> Option<serde_json::Value> {
+        Some(self.into())
+    }
+}
+
+impl IntoOption<serde_json::Value> for Cow<'_, str> {
+    fn into_option(self) -> Option<serde_json::Value> {
+        Some(self.into())
     }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -8,7 +8,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::Meta;
+use crate::{IntoOption, Meta};
 
 /// An execution plan for accomplishing complex tasks.
 ///
@@ -50,8 +50,8 @@ impl Plan {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -101,8 +101,8 @@ impl PlanEntry {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }

--- a/src/tool_call.rs
+++ b/src/tool_call.rs
@@ -10,7 +10,7 @@ use derive_more::{Display, From};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{ContentBlock, Error, Meta, TerminalId};
+use crate::{ContentBlock, Error, IntoOption, Meta, TerminalId};
 
 /// Represents a tool call that the language model has requested.
 ///
@@ -102,15 +102,15 @@ impl ToolCall {
 
     /// Raw input parameters sent to the tool.
     #[must_use]
-    pub fn raw_input(mut self, raw_input: serde_json::Value) -> Self {
-        self.raw_input = Some(raw_input);
+    pub fn raw_input(mut self, raw_input: impl IntoOption<serde_json::Value>) -> Self {
+        self.raw_input = raw_input.into_option();
         self
     }
 
     /// Raw output returned by the tool.
     #[must_use]
-    pub fn raw_output(mut self, raw_output: serde_json::Value) -> Self {
-        self.raw_output = Some(raw_output);
+    pub fn raw_output(mut self, raw_output: impl IntoOption<serde_json::Value>) -> Self {
+        self.raw_output = raw_output.into_option();
         self
     }
 
@@ -120,8 +120,8 @@ impl ToolCall {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 
@@ -192,8 +192,8 @@ impl ToolCallUpdate {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -239,50 +239,50 @@ impl ToolCallUpdateFields {
 
     /// Update the tool kind.
     #[must_use]
-    pub fn kind(mut self, kind: ToolKind) -> Self {
-        self.kind = Some(kind);
+    pub fn kind(mut self, kind: impl IntoOption<ToolKind>) -> Self {
+        self.kind = kind.into_option();
         self
     }
 
     /// Update the execution status.
     #[must_use]
-    pub fn status(mut self, status: ToolCallStatus) -> Self {
-        self.status = Some(status);
+    pub fn status(mut self, status: impl IntoOption<ToolCallStatus>) -> Self {
+        self.status = status.into_option();
         self
     }
 
     /// Update the human-readable title.
     #[must_use]
-    pub fn title(mut self, title: impl Into<String>) -> Self {
-        self.title = Some(title.into());
+    pub fn title(mut self, title: impl IntoOption<String>) -> Self {
+        self.title = title.into_option();
         self
     }
 
     /// Replace the content collection.
     #[must_use]
-    pub fn content(mut self, content: Vec<ToolCallContent>) -> Self {
-        self.content = Some(content);
+    pub fn content(mut self, content: impl IntoOption<Vec<ToolCallContent>>) -> Self {
+        self.content = content.into_option();
         self
     }
 
     /// Replace the locations collection.
     #[must_use]
-    pub fn locations(mut self, locations: Vec<ToolCallLocation>) -> Self {
-        self.locations = Some(locations);
+    pub fn locations(mut self, locations: impl IntoOption<Vec<ToolCallLocation>>) -> Self {
+        self.locations = locations.into_option();
         self
     }
 
     /// Update the raw input.
     #[must_use]
-    pub fn raw_input(mut self, raw_input: serde_json::Value) -> Self {
-        self.raw_input = Some(raw_input);
+    pub fn raw_input(mut self, raw_input: impl IntoOption<serde_json::Value>) -> Self {
+        self.raw_input = raw_input.into_option();
         self
     }
 
     /// Update the raw output.
     #[must_use]
-    pub fn raw_output(mut self, raw_output: serde_json::Value) -> Self {
-        self.raw_output = Some(raw_output);
+    pub fn raw_output(mut self, raw_output: impl IntoOption<serde_json::Value>) -> Self {
+        self.raw_output = raw_output.into_option();
         self
     }
 }
@@ -500,8 +500,8 @@ impl Content {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -540,8 +540,8 @@ impl Terminal {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -582,8 +582,8 @@ impl Diff {
 
     /// The original content (None for new files).
     #[must_use]
-    pub fn old_text(mut self, old_text: impl Into<String>) -> Self {
-        self.old_text = Some(old_text.into());
+    pub fn old_text(mut self, old_text: impl IntoOption<String>) -> Self {
+        self.old_text = old_text.into_option();
         self
     }
 
@@ -593,8 +593,8 @@ impl Diff {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }
@@ -634,8 +634,8 @@ impl ToolCallLocation {
 
     /// Optional line number within the file.
     #[must_use]
-    pub fn line(mut self, line: u32) -> Self {
-        self.line = Some(line);
+    pub fn line(mut self, line: impl IntoOption<u32>) -> Self {
+        self.line = line.into_option();
         self
     }
 
@@ -645,8 +645,8 @@ impl ToolCallLocation {
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
     #[must_use]
-    pub fn meta(mut self, meta: Meta) -> Self {
-        self.meta = Some(meta);
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
         self
     }
 }


### PR DESCRIPTION
This is a Rust-only feature, but for optinal fields, the caller can now pass in either the value itself, or an option of that value, and we'll take care of the rest. It provides a lot of flexibility when constructing these values, as it turned out our callers often had options, and the `(mut self, T) -> Self` convention made this a real pain if you had to optionally call the builder method. Now you can call it either way and it reads really nice!
