### PR TITLE
docs(rfd): Add session usage and context status RFD

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -112,7 +112,8 @@
               "rfds/meta-propagation",
               "rfds/session-info-update",
               "rfds/agent-telemetry-export",
-              "rfds/proxy-chains"
+              "rfds/proxy-chains",
+              "rfds/session-usage"
             ]
           },
           { "group": "Preview", "pages": [] },

--- a/docs/rfds/session-usage.mdx
+++ b/docs/rfds/session-usage.mdx
@@ -3,6 +3,7 @@ title: "Session Usage and Context Status"
 ---
 
 - Author(s): [@ahmedhesham6](https://github.com/ahmedhesham6)
+- Champion: [@benbrandt](https://github.com/benbrandt)
 
 ## Elevator pitch
 
@@ -47,16 +48,19 @@ We propose separating usage tracking into two distinct concerns:
 2. **Context window and cost** - Reported via `session/update` notifications with `sessionUpdate: "usage_update"` (session state)
 
 This separation reflects how users consume this information:
+
 - Token counts are tied to specific turns and useful immediately after a prompt
 - Context window and cost are cumulative session state that agents push proactively when available
 
 Agents send context updates at appropriate times:
+
 - On `session/new` response (if agent can query usage immediately)
 - On `session/load` / `session/resume` (for resumed/forked sessions)
 - After each `session/prompt` response (when usage data becomes available)
 - Anytime context window state changes significantly
 
 This approach provides flexibility for different agent implementations:
+
 - Agents that support getting current usage without a prompt can immediately send updates when creating, resuming, or forking chats
 - Agents that only provide usage when actively prompting can send updates after sending a new prompt
 
@@ -211,6 +215,7 @@ Different users care about different things at different times:
 - **Cumulative cost**: Session-level state that agents push when available
 
 Separating them allows:
+
 - Cleaner data model where per-turn data stays in turn responses
 - Agents to push context updates proactively when data becomes available
 - Clients to receive updates reactively without needing to poll
@@ -218,6 +223,7 @@ Separating them allows:
 ### Why is cost in session/update instead of PromptResponse?
 
 Cost is cumulative session state, similar to context window:
+
 - Users want to track total spending, not just per-turn costs
 - Keeps `PromptResponse` focused on per-turn token breakdown
 - Both cost and context window are session-level metrics that belong together
@@ -233,14 +239,15 @@ The context update notification provides everything needed:
 
 **Recommended client behavior:**
 
-| Percentage | Action |
-|------------|--------|
-| < 75% | Normal operation |
-| 75-90% | Yellow indicator, suggest "Context filling up" |
-| 90-95% | Orange indicator, recommend "Start new session or summarize" |
-| > 95% | Red indicator, warn "Next prompt may fail - handoff recommended" |
+| Percentage | Action                                                           |
+| ---------- | ---------------------------------------------------------------- |
+| < 75%      | Normal operation                                                 |
+| 75-90%     | Yellow indicator, suggest "Context filling up"                   |
+| 90-95%     | Orange indicator, recommend "Start new session or summarize"     |
+| > 95%      | Red indicator, warn "Next prompt may fail - handoff recommended" |
 
 Clients can also:
+
 - Offer "Compact context" or "Summarize conversation" actions
 - Auto-suggest starting a new session
 - Implement automatic handoff when approaching limits

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -4,6 +4,20 @@ description: Updates and announcements about the Agent Client Protocol
 rss: true
 ---
 
+<Update label="January 1, 2026" tags={["RFD"]}>
+## Session Usage RFD moves to Draft stage
+
+The RFD for adding a new `usage_update` variant on the `session/update` notification and `usage` field on prompt responses in the protocol has been moved to Draft stage. Please review the [RFD](./rfds/session-usage) for more information on the current proposal and provide feedback as work on the implementation begins.
+
+</Update>
+
+<Update label="December 31, 2025" tags={["RFD"]}>
+## Proxy Chains RFD moves to Draft stage
+
+The RFD for adding proxy chain functionality in the protocol has been moved to Draft stage. Please review the [RFD](./rfds/proxy-chains) for more information on the current proposal and provide feedback as work on the implementation begins.
+
+</Update>
+
 <Update label="December 11, 2025" tags={["RFD"]}>
 ## Agent Telemetry Export RFD moves to Draft stage
 


### PR DESCRIPTION
Proposes standardized tracking of token usage, cost estimation, and context window status across ACP implementations.

- Token usage reported in PromptResponse (per-turn data)
- Context window and cost reported in session/status (session state)