### PR TITLE
docs(rfd): fork options

### DIFF
--- a/docs/rfds/session-fork.mdx
+++ b/docs/rfds/session-fork.mdx
@@ -61,7 +61,7 @@ Then the client would be able to request a fork of the given session:
 }
 ```
 
-The request accepts the same same options as `session/load`, such as `cwd` and `mcpServers`.
+The request expects the same options as `session/load`, such as `cwd` and `mcpServers`.
 
 Similarly, the agent would respond with optional data such as config options, the same as `session/load`.
 


### PR DESCRIPTION
We propose to change the `session/fork` method to accept the same options as `session/load`. This eases the implementation in agents that do not persistently store all the configuration when a session is not active any more.