### PR TITLE
ACP Agent renamed to "AgentPool"

### DIFF
--- a/docs/overview/agents.mdx
+++ b/docs/overview/agents.mdx
@@ -5,6 +5,7 @@ description: "Agents implementing the Agent Client Protocol"
 
 The following agents can be used with an ACP Client:
 
+- [AgentPool](https://phil65.github.io/agentpool/advanced/acp-integration/)
 - [Augment Code](https://docs.augmentcode.com/cli/acp)
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) (via [Zed's SDK adapter](https://github.com/zed-industries/claude-code-acp))
 - [Codex CLI](https://developers.openai.com/codex/cli) (via [Zed's adapter](https://github.com/zed-industries/codex-acp))
@@ -15,7 +16,6 @@ The following agents can be used with an ACP Client:
 - [Goose](https://block.github.io/goose/docs/guides/acp-clients)
 - [JetBrains Junie _(coming soon)_](https://www.jetbrains.com/junie/)
 - [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)
-- [LLMling-Agent](https://phil65.github.io/llmling-agent/advanced/acp_integration/)
 - [Mistral Vibe](https://github.com/mistralai/mistral-vibe)
 - [OpenCode](https://github.com/sst/opencode)
 - [OpenHands](https://docs.openhands.dev/openhands/usage/run-openhands/acp)


### PR DESCRIPTION
Renamed my library.
The library evolved into an "Agent hub", and now basically is also a headless ACP client. 
Should I also add it to the Client list? or is that only intended for actual UIs?
This is basically what it does right now:

```mermaid
flowchart LR
    UI["UI"] -->|"ACP / AG-UI"| AP["AgentPool"]
    
    AP -->|"native"| Native["Pydantic-AI Agent"]
    AP -->|"ACP"| ACPAgent["ACP Agent"]
    AP -->|"AG-UI"| AGUIAgent["AG-UI Agent"]
    AP -->|"Claude Code"| CCAgent["Claude Code Agent"]

```

