### PR TITLE
Add Agmente to the clients list

### DIFF
--- a/docs/overview/clients.mdx
+++ b/docs/overview/clients.mdx
@@ -5,6 +5,7 @@ description: "Clients implementing the Agent Client Protocol"
 
 The following clients can be used with an ACP Agent:
 
+- [Agmente](https://agmente.halliharp.com) (iOS)
 - [AionUi](https://github.com/iOfficeAI/AionUi)
 - [aizen](https://aizen.win)
 - [DeepChat](https://github.com/ThinkInAIXYZ/deepchat)


### PR DESCRIPTION
As someone who loves self hosting and building apps for them, I enjoyed running CLIs on my servers, which led me to build an [iOS client](https://agmente.halliharp.com) to manage them via ACP (requires converting stdio to WebSocket using `stdio-to-ws` or similar libraries).

