### PR TITLE
Add Pi agent to supported agents documentation

### DIFF
--- a/docs/overview/agents.mdx
+++ b/docs/overview/agents.mdx
@@ -21,7 +21,7 @@ The following agents can be used with an ACP Client:
 - [Mistral Vibe](https://github.com/mistralai/mistral-vibe)
 - [OpenCode](https://github.com/sst/opencode)
 - [OpenHands](https://docs.openhands.dev/openhands/usage/run-openhands/acp)
+- [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) (via [pi-acp adapter](https://github.com/svkozak/pi-acp))
 - [Qwen Code](https://github.com/QwenLM/qwen-code)
 - [Stakpak](https://github.com/stakpak/agent?tab=readme-ov-file#agent-client-protocol-acp)
 - [VT Code](https://github.com/vinhnx/vtcode/blob/main/README.md#zed-ide-integration-agent-client-protocol)
-- [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) (via [pi-acp adapter](https://github.com/svkozak/pi-acp))


### PR DESCRIPTION
Add [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) to supported agents list (via adapter)