### PR TITLE
docs: add carlos-algms/agentic.nvim as neovim plugin

### DIFF
--- a/docs/overview/clients.mdx
+++ b/docs/overview/clients.mdx
@@ -16,6 +16,7 @@ The following clients can be used with an ACP Agent:
 - [marimo notebook](https://github.com/marimo-team/marimo)
 - [neovim](https://neovim.io)
   - through the [CodeCompanion](https://github.com/olimorris/codecompanion.nvim) plugin
+  - through the [carlos-algms/agentic.nvim](https://github.com/carlos-algms/agentic.nvim) plugin
   - through the [yetone/avante.nvim](https://github.com/yetone/avante.nvim) plugin
 - [Obsidian](https://obsidian.md)
   - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin


### PR DESCRIPTION
[carlos-algms/agentic.nvim](https://github.com/carlos-algms/agentic.nvim) is an ACP focused plugin for Neovim that implements the major providers:

- opencode
- claude
- gemini
- codex
- cursor