### PR TITLE
RFD: Agent-to-Client Logging

### DIFF
--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -8,9 +8,9 @@ Author(s): [@chazcb](https://github.com/chazcb)
 
 > What are you proposing to change?
 
-Add a `log` notification that allows agents to send diagnostic messages to clients without terminating operations. This enables real-time visibility into agent health, warnings, and errors.
+Add a `log` notification that allows agents to send diagnostic messages to clients without terminating operations.
 
-**Key insight**: JSON-RPC error responses terminate the request. But many situations (MCP server disconnected, approaching rate limit, using fallback model) warrant notifying the client *without* stopping the run.
+JSON-RPC error responses terminate the request—the run is over. But many situations (approaching rate limit, using fallback model, retrying a failed request) warrant notifying the client *without* stopping the run. This proposal adds that capability.
 
 ## Status quo
 
@@ -27,9 +27,9 @@ ACP has no mechanism for agents to proactively notify clients about diagnostic i
 4. **No standard severity levels**: No way to distinguish errors from warnings from informational messages.
 
 **Real-world examples:**
-- MCP server disconnects, but other tools still work → client should know, but run continues
-- Approaching rate limit → warn the user, don't abort
-- Using fallback model → informational, definitely don't abort
+- Backing model rate limited → warn the user, retry in progress
+- Backing service disconnected → informational, reconnecting
+- Using fallback model → informational, run continues
 - Server shutting down in 5 minutes → warn all sessions
 
 ## What we propose to do about it
@@ -44,12 +44,12 @@ Add a `log` notification (agent → client) that requires capability negotiation
   "method": "log",
   "params": {
     "level": "warning",
-    "message": "MCP server 'database-tools' disconnected, retrying...",
+    "message": "Backing model rate limited, retrying in 5 seconds...",
     "sessionId": "abc-123",
-    "logger": "mcp",
+    "logger": "model",
     "code": -32001,
     "timestamp": "2025-01-21T10:30:00Z",
-    "data": { "server": "database-tools", "retryIn": 5 }
+    "data": { "model": "claude-3", "retryIn": 5 }
   }
 }
 ```
@@ -128,7 +128,7 @@ The key question is: **should the run stop?**
 - JSON-RPC error responses terminate the request—the run is over
 - `log` notifications are independent—the run continues
 
-Many situations (MCP server disconnected but others work, approaching rate limit, using fallback model) warrant notifying the client without aborting.
+Many situations (backing model rate limited, approaching context limit, using fallback model) warrant notifying the client without aborting.
 
 Also: not all agents use `prompt()`. Some use extension methods like `_enqueue` (a notification). Notifications have no response, so there's nowhere to return an error.
 

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -20,7 +20,7 @@ ACP has no mechanism for agents to proactively notify clients about diagnostic i
 
 1. **JSON-RPC errors terminate requests**: If an agent returns an error, the run stops. There's no way to report non-fatal issues.
 
-2. **`session/update` requires a session**: Connection-wide errors (MCP server failures, server shutting down) can't be communicated because there's no session to attach them to.
+2. **`session/update` requires a session**: Connection-wide issues (server shutting down, configuration problems) can't be communicated because there's no session to attach them to.
 
 3. **Errors during long runs are invisible**: A prompt turn can run for minutes. If something goes wrong mid-run but the agent can recover, the client has no visibility.
 
@@ -107,7 +107,7 @@ Several reasons:
 
 3. **Opt-in presentation**: Not all clients care about logs. A separate channel lets clients ignore them entirely without polluting the conversation stream.
 
-4. **Connection-wide messages**: Errors can occur before any session exists (e.g., MCP server failing to connect after `initialize` but before `session/new`). `session/update` requires a `sessionId`, so it simply can't be used in these cases.
+4. **Connection-wide messages**: Errors can occur before any session exists (e.g., after `initialize` but before `session/new`). `session/update` requires a `sessionId`, so it simply can't be used in these cases.
 
 ### Why not use a separate channel (stderr, separate SSE endpoint, etc.)?
 

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -8,314 +8,179 @@ Author(s): [@chazcb](https://github.com/chazcb)
 
 > What are you proposing to change?
 
-Add a `log` notification that allows agents to send diagnostic messages (errors, warnings, info, etc.) to clients. This notification supports both connection-wide and session-specific messages via an optional `sessionId` field.
+Add a `log` notification that allows agents to send diagnostic messages to clients without terminating operations. This enables real-time visibility into agent health, warnings, and errors.
 
-Currently, servers have no way to proactively notify clients about errors, warnings, or other diagnostic information outside of request-response cycles. This RFD proposes a simple, flexible logging mechanism that:
-
-- Supports both connection-wide and session-specific messages via optional `sessionId`
-- Uses 8 severity levels (RFC 5424/MCP-compatible)
-- Requires capability negotiation for clean opt-in (no breaking changes)
-- Includes optional structured data and error codes
-- Follows ACP's existing naming conventions
+**Key insight**: JSON-RPC error responses terminate the request. But many situations (MCP server disconnected, approaching rate limit, using fallback model) warrant notifying the client *without* stopping the run.
 
 ## Status quo
 
-> How do things work today and what problems does this cause? Why would we change things?
+> How do things work today and what problems does this cause?
 
-Today, ACP has several limitations around server-to-client diagnostic messaging:
+ACP has no mechanism for agents to proactively notify clients about diagnostic information:
 
-1. **JSON-RPC errors are response-only**: The JSON-RPC 2.0 specification only allows errors in response to method calls. Servers cannot proactively send error notifications.
+1. **JSON-RPC errors terminate requests**: If an agent returns an error, the run stops. There's no way to report non-fatal issues.
 
-2. **SessionNotification requires a session**: The existing `session/update` notification requires a `sessionId`. This means servers cannot communicate errors that occur:
-   - Before any session is created
-   - During connection setup or MCP server initialization
-   - At the connection level (affecting all sessions)
+2. **`session/update` requires a session**: Connection-wide errors (MCP server failures, server shutting down) can't be communicated because there's no session to attach them to.
 
-3. **No severity levels**: There's no standard way to indicate whether a message is an error, warning, informational, or debug-level.
+3. **Errors during long runs are invisible**: A prompt turn can run for minutes. If something goes wrong mid-run but the agent can recover, the client has no visibility.
 
-4. **Transport-agnostic gap**: ACP supports multiple transports (stdio, WebSocket, HTTP). While the stdio transport allows informal stderr logging, other transports have no equivalent. A protocol-level logging mechanism ensures consistent behavior across all transports.
+4. **No standard severity levels**: No way to distinguish errors from warnings from informational messages.
 
-### Real-world problems this causes
-
-- **MCP server connection failures**: When an agent fails to connect to an MCP server, there's no way to inform the client. The user just sees tools not working.
-- **Rate limiting**: When a provider rate-limits requests, the server can only fail the current request. It cannot proactively warn about approaching limits or advise the client to wait.
-- **Transient errors**: Connection timeouts, retries, and other transient issues are invisible to clients.
-- **Debugging**: Developers have no visibility into agent behavior without external logging infrastructure.
+**Real-world examples:**
+- MCP server disconnects, but other tools still work → client should know, but run continues
+- Approaching rate limit → warn the user, don't abort
+- Using fallback model → informational, definitely don't abort
+- Server shutting down in 5 minutes → warn all sessions
 
 ## What we propose to do about it
 
 > What are you proposing to improve the situation?
 
-Add a new `log` notification method (agent → client) with the following structure:
+Add a `log` notification (agent → client) that requires capability negotiation:
 
 ```json
 {
   "jsonrpc": "2.0",
   "method": "log",
   "params": {
-    "level": "error",
+    "level": "warning",
+    "message": "MCP server 'database-tools' disconnected, retrying...",
     "sessionId": "abc-123",
-    "logger": "mcp.database",
-    "message": "Connection to MCP server 'database-tools' failed",
+    "logger": "mcp",
     "code": -32001,
     "timestamp": "2025-01-21T10:30:00Z",
-    "data": {
-      "server": "database-tools",
-      "error": "ECONNREFUSED",
-      "retryIn": 5
-    },
-    "_meta": {}
+    "data": { "server": "database-tools", "retryIn": 5 }
   }
 }
 ```
+
+### Capability Declaration
+
+Clients opt-in by declaring `logging` capability during `initialize`:
+
+```json
+{
+  "method": "initialize",
+  "params": {
+    "clientCapabilities": { "logging": {} }
+  }
+}
+```
+
+Agents MUST NOT send `log` notifications to clients that didn't declare this capability. This ensures backward compatibility—older clients simply don't receive notifications they can't handle.
 
 ### Fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `level` | `LogLevel` | Yes | Severity level of the message |
-| `message` | `string` | Yes | Human-readable log message |
-| `sessionId` | `SessionId` | No | Session this message pertains to. Omit for connection-wide messages. |
-| `logger` | `string` | No | Name of the logger/component emitting this message (e.g., "mcp.database", "auth") |
-| `code` | `ErrorCode` | No | Structured error code (uses same space as JSON-RPC errors) |
-| `timestamp` | `string` | No | ISO 8601 timestamp when the event occurred |
+| `level` | `LogLevel` | Yes | RFC 5424 severity: `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency` |
+| `message` | `string` | Yes | Human-readable message |
+| `sessionId` | `SessionId` | No | Omit for connection-wide messages |
+| `logger` | `string` | No | Component name (e.g., "mcp", "auth") |
+| `code` | `ErrorCode` | No | Structured error code |
+| `timestamp` | `string` | No | ISO 8601 timestamp |
 | `data` | `object` | No | Additional structured data |
 | `_meta` | `object` | No | Extensibility metadata |
 
-### Capability Declaration
+### Method Naming
 
-Clients that want to receive `log` notifications MUST declare the `logging` capability during `initialize`:
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "initialize",
-  "params": {
-    "protocolVersion": "0.1",
-    "clientCapabilities": {
-      "logging": {}
-    }
-  }
-}
-```
-
-Agents MUST NOT send `log` notifications to clients that did not declare this capability.
-
-### Log Levels (RFC 5424)
-
-The `LogLevel` enum follows RFC 5424 syslog severity levels, which are also used by MCP:
-
-| Level | Description |
-|-------|-------------|
-| `debug` | Detailed debugging information |
-| `info` | General informational messages |
-| `notice` | Normal but significant events |
-| `warning` | Warning conditions |
-| `error` | Error conditions |
-| `critical` | Critical conditions |
-| `alert` | Action must be taken immediately |
-| `emergency` | System is unusable |
-
-### Why `log` (no namespace)?
-
-The method name follows ACP's convention for connection-level operations:
-
-| Pattern | Examples |
-|---------|----------|
-| No namespace (connection-level) | `initialize`, `authenticate`, **`log`** |
-| Resource namespace | `session/*`, `fs/*`, `terminal/*` |
-| Protocol-level | `$/cancel_request` |
-
-We chose `log` over alternatives:
-- `log/message` - Creates a namespace with only one method
-- `notifications/message` - ACP doesn't use the `notifications/` pattern
-- `SessionUpdate::Log` - Can't handle connection-wide messages
+The method name `log` follows ACP's convention for connection-level operations (like `initialize`, `authenticate`) rather than using a namespace like `log/message`.
 
 ## Shiny future
 
-> How will things will play out once this feature exists?
+> How will things play out once this feature exists?
 
-Once this feature exists:
-
-1. **Better error visibility**: Clients can display connection errors, rate limit warnings, and other diagnostic information to users. IDEs could show a status indicator or notification panel for agent health.
-
-2. **Proactive warnings**: Servers can warn about approaching limits (token budget, rate limits) before they become errors, allowing clients to adapt.
-
-3. **Debugging support**: Developers can see what's happening inside agents without external logging infrastructure. The `logger` field allows filtering by component.
-
-4. **Session-scoped context**: Errors related to specific sessions can be attributed correctly, while connection-wide issues (like MCP server failures) are clearly distinguished.
-
-5. **Structured error handling**: The optional `code` field allows clients to programmatically handle specific error types (retry on rate limit, prompt for auth on auth errors, etc.).
+1. **Real-time health visibility**: Clients can show agent status—errors in a panel, warnings in a status bar
+2. **Non-fatal error reporting**: Agents can report issues without aborting runs
+3. **Proactive warnings**: "Approaching rate limit" before it becomes an error
+4. **Debugging**: Developers see what's happening without external infrastructure
 
 ## Frequently asked questions
 
-> What questions have arisen over the course of authoring this document or during subsequent discussions?
+### Why not use `session/update`?
 
-### How does this relate to the [Agent Telemetry Export RFD](./agent-telemetry-export)?
+Several reasons:
 
-They are **complementary**, serving different purposes:
+1. **Separation of concerns**: `SessionUpdate` represents conversation state (messages, tool calls, mode changes). Logs are diagnostic metadata, not conversation content. Mixing them forces clients to filter out logs they don't want in the conversation UI.
 
-| Aspect | `log` notification (this RFD) | OTEL Telemetry Export |
-|--------|------------------------------|----------------------|
-| **Channel** | In-band (ACP protocol messages) | Out-of-band (HTTP to OTLP collector) |
-| **Purpose** | Real-time user-facing notifications | Observability/debugging infrastructure |
-| **Audience** | End users via client UI | Developers, ops teams, observability backends |
-| **Transport** | Works on all ACP transports | Requires HTTP (stdio subprocess focus) |
-| **Volume** | Low (errors, warnings, key events) | High (traces, spans, metrics, debug logs) |
+2. **Breaking change**: Adding a log variant to `SessionUpdate` would send logs to existing clients that don't expect them. A separate capability-gated notification is opt-in and non-breaking.
 
-**When to use which:**
+3. **Opt-in presentation**: Not all clients care about logs. A separate channel lets clients ignore them entirely without polluting the conversation stream.
 
-- **`log` notification**: User-relevant events that should appear in the client UI
-  - "Rate limit exceeded - waiting 60s" → User sees toast/status bar
-  - "MCP server disconnected" → User knows why tools stopped working
+4. **Connection-wide messages**: Errors can occur before any session exists (e.g., MCP server failing to connect after `initialize` but before `session/new`). `session/update` requires a `sessionId`, so it simply can't be used in these cases.
 
-- **OTEL telemetry**: Developer/ops diagnostics for debugging and monitoring
-  - Detailed span traces with timing
-  - Token usage metrics
-  - High-volume debug logs
-  - Integration with Datadog, Grafana, etc.
+### Why not use a separate channel (stderr, separate SSE endpoint, etc.)?
 
-Agents may emit both: a `log` notification for user-visible errors AND detailed OTEL telemetry for debugging the same issue.
+1. **Transport-agnostic**: ACP works over stdio, WebSocket, HTTP, etc. A side channel like stderr only exists for stdio. A protocol-level solution works across all transports.
 
-### Why not add a variant to `SessionUpdate`?
+2. **Already connected**: Clients already have an ACP connection. Why require a separate channel just for logs?
 
-There are several reasons to keep logging separate from `session/update`:
+3. **Session context**: The `sessionId` field ties logs to specific sessions. A separate channel would need to reinvent this.
 
-1. **Connection-level messages are essential**: Errors can occur before any session exists (during initialization, MCP server connection, authentication). A session-scoped mechanism simply cannot handle these cases.
+4. **Capability negotiation**: ACP already has capability negotiation. A separate channel would need its own opt-in mechanism.
 
-2. **Separation of concerns**: Log messages are conceptually different from conversation state. `SessionUpdate` represents the actual conversation flow (user messages, agent responses, tool calls, mode changes). Mixing diagnostic notifications into that stream forces clients to filter out messages they may not want to display in the conversation UI. A separate channel lets clients handle logs independently—show them in a status bar, a separate panel, or ignore them entirely.
+5. **OTEL handles heavy telemetry**: The [Agent Telemetry Export RFD](./agent-telemetry-export) covers high-volume, developer-focused observability. `log` is for low-volume, user-facing messages—different use case, belongs in-band.
 
-3. **Opt-in presentation**: Not all clients care about every log message. By keeping logs separate, clients can choose their level of engagement without polluting the conversation thread.
-
-### Should logging require capability negotiation?
-
-**Yes.** Agents MUST only send `log` notifications to clients that declare support via a `logging` capability in `ClientCapabilities` during `initialize`.
-
-This works because:
-
-1. **Initialize handles startup errors**: The `initialize` method is a request/response—if something is broken during startup, the agent responds with a JSON-RPC error. There's no "pre-initialize" gap where we need unsolicited notifications.
-
-2. **Clean opt-in**: Clients explicitly declare they want log notifications. Older clients that don't support `log` simply don't receive them—no SDK changes needed, no breaking changes.
-
-3. **Follows MCP pattern**: MCP requires a `logging` capability for the same reasons.
-
-**Flow:**
-1. Transport connects
-2. Client calls `initialize()` with `clientCapabilities: { logging: {} }`
-3. If startup fails → Agent responds with JSON-RPC error
-4. If startup succeeds → Agent knows client supports `log`, can send notifications
-
-Clients that don't declare `logging` capability won't receive `log` notifications, but can still receive JSON-RPC errors in response to their method calls.
-
-### Why not just return errors on `prompt()` responses?
+### Why not return errors on `prompt()`?
 
 The key question is: **should the run stop?**
 
-A JSON-RPC error response terminates the request—the run is over. But many situations warrant notifying the client *without* aborting:
+- JSON-RPC error responses terminate the request—the run is over
+- `log` notifications are independent—the run continues
 
-1. **Non-fatal issues during long runs**: A prompt turn can run for minutes. If one MCP server disconnects but others are fine, the agent might continue with degraded functionality. The client should know about the issue, but the run shouldn't stop.
+Many situations (MCP server disconnected but others work, approaching rate limit, using fallback model) warrant notifying the client without aborting.
 
-2. **Warnings and informational messages**: "Approaching rate limit" or "Using fallback model" are useful to surface, but definitely shouldn't abort the run.
+Also: not all agents use `prompt()`. Some use extension methods like `_enqueue` (a notification). Notifications have no response, so there's nowhere to return an error.
 
-3. **Connection-wide issues**: Some errors affect all sessions (server shutting down soon). There's no single prompt to attach these to.
+### How does this relate to the [Agent Telemetry Export RFD](./agent-telemetry-export)?
 
-4. **Out-of-band timing**: Errors can occur between prompt turns, when no request is pending.
+They're complementary:
 
-5. **Alternative interaction patterns**: Not all ACP implementations use `prompt()`. Some agents use custom extension methods like `_enqueue` (a notification for steering during a run). Since notifications don't have responses, there's no place to return a JSON-RPC error.
+| | `log` notification | OTEL Telemetry |
+|-|-------------------|----------------|
+| **Channel** | In-band (ACP) | Out-of-band (HTTP) |
+| **Audience** | End users | Developers/ops |
+| **Volume** | Low (key events) | High (traces, metrics) |
 
-The `log` notification provides an independent channel for diagnostic messages that don't terminate the current operation.
-
-### When should agents use `log` vs JSON-RPC error responses?
-
-**JSON-RPC errors should still be used when possible.** The `log` notification is specifically for out-of-band situations where there's no request to respond to:
-
-| Situation | Use |
-|-----------|-----|
-| Request fails (invalid params, auth required, etc.) | JSON-RPC error response |
-| Connection to upstream service lost | `log` notification |
-| Rate limit hit during request processing | JSON-RPC error response |
-| Approaching rate limit (proactive warning) | `log` notification |
-| MCP server disconnected | `log` notification |
-| Server shutting down soon | `log` notification |
-
-The rule of thumb: if there's a pending request that caused the error, respond with a JSON-RPC error. If the error/warning is unsolicited (no request triggered it), use `log`.
+Use `log` for user-facing messages. Use OTEL for observability infrastructure.
 
 ### Is this a breaking change?
 
-**No.** Because logging requires capability negotiation:
+**No.** Capability negotiation makes it opt-in:
+- Older clients don't declare capability → don't receive notifications
+- Older agents don't send notifications → nothing changes
 
-- **Older clients** don't declare `logging` capability → agents don't send `log` notifications → no change in behavior
-- **Older agents** don't send `log` notifications → updated clients just don't receive any → no change in behavior
-- **Updated clients + updated agents** → client declares `logging` capability → agent sends `log` notifications → new feature works
+### When should agents use `log` vs JSON-RPC errors?
 
-No SDK changes are required for backward compatibility. Clients opt-in by declaring the capability.
+| Situation | Use |
+|-----------|-----|
+| Request fails | JSON-RPC error (terminates request) |
+| Non-fatal issue during run | `log` notification (run continues) |
+| Proactive warning | `log` notification |
+| Connection-wide issue | `log` notification |
 
-### Why use RFC 5424 log levels instead of simpler error/warning/info?
+Rule: If there's a pending request that should fail, use JSON-RPC error. Otherwise, use `log`.
 
-RFC 5424 levels are a well-established standard used by syslog, many logging libraries, and MCP. Using the same levels:
+### Why RFC 5424 log levels instead of just error/warning/info?
 
-- Provides familiar semantics for developers
-- Enables compatibility with MCP logging
+RFC 5424 (syslog) levels are used by MCP, most logging libraries, and observability tools. Using the same 8 levels:
+- Provides familiar semantics
+- Enables MCP compatibility
 - Supports future use cases (debug logging, critical alerts)
 
-Clients can always map these to simpler categories in their UI.
-
-### How should clients handle log messages?
-
-Clients have flexibility in how they present log messages:
-
-- **IDE status bar**: Show counts of errors/warnings with hover details
-- **Notification toasts**: Pop up for critical/alert/emergency levels
-- **Log panel**: Dedicated panel showing filterable log history
-- **Ignore**: For levels below a configured threshold
-
-The `logger` field can help clients filter/categorize messages.
-
-### Can agents flood clients with log messages?
-
-Yes, like any notification. Clients should:
-
-- Rate-limit UI updates
-- Drop old messages if buffer is full
-- Consider filtering by level
-
-Agents should be reasonable about log frequency.
-
-### What alternative approaches did you consider, and why did you settle on this one?
-
-1. **Tunneling over `SessionUpdate`**: Rejected because it can't handle connection-wide messages and mixes concerns.
-
-2. **JSON-RPC error responses**: Not possible - JSON-RPC only allows errors in response to requests.
-
-3. **Out-of-band telemetry (like agent-telemetry-export RFD)**: Good for observability backends but doesn't solve in-band client notification needs.
-
-4. **Transport-specific logging (e.g., stderr)**: Only works for stdio transport. ACP is transport-agnostic, so we need a protocol-level solution that works over WebSocket, HTTP, and any future transports.
-
-5. **New capability negotiation**: Considered requiring a capability, but logging is basic infrastructure that all clients should handle (even if just ignoring it).
-
-The proposed `log` notification is the simplest solution that:
-- Works at all lifecycle stages
-- Supports both session-scoped and connection-wide messages
-- Uses standard log levels
-- Fits ACP's existing patterns
-- Works identically across all transports
+Clients can always map to simpler categories in their UI.
 
 ### How does this compare to other protocols?
 
-| Protocol | Method | Levels | Scoping | Notes |
-|----------|--------|--------|---------|-------|
-| **ACP (proposed)** | `log` | RFC 5424 (8 levels) | Optional `sessionId` | Connection-wide or session-scoped |
-| **[MCP](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging)** | `notifications/message` | RFC 5424 (8 levels) | None (server-wide) | Requires `logging` capability; has `logging/setLevel` request |
-| **[LSP](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_logMessage)** | `window/logMessage` | 5 levels (Error→Debug) | None | Separate `window/showMessage` for UI display |
-| **[A2A](https://a2a-protocol.org/latest/specification/)** | None (via `TaskStatus.message`) | None | Task-scoped | Errors via binding-specific mechanisms (JSON-RPC, gRPC, HTTP Problem Details) |
-| **[AG-UI](https://docs.ag-ui.com/concepts/events)** | `RunError` event | None | Run-scoped | Event-driven; uses `StepStarted`/`StepFinished` for progress |
+| Protocol | Method | Levels | Scoping |
+|----------|--------|--------|---------|
+| **ACP (proposed)** | `log` | RFC 5424 (8) | Optional `sessionId` |
+| **[MCP](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging)** | `notifications/message` | RFC 5424 (8) | Server-wide only |
+| **[LSP](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_logMessage)** | `window/logMessage` | 5 levels | None |
+| **[A2A](https://a2a-protocol.org/latest/specification/)** | None | None | Task-scoped |
+| **[AG-UI](https://docs.ag-ui.com/concepts/events)** | `RunError` event | None | Run-scoped |
 
-**Key design choices:**
-
-- **RFC 5424 levels**: Aligns with MCP for ecosystem consistency. More expressive than LSP's 5 levels.
-- **Optional `sessionId`**: Unlike MCP (server-wide only) or A2A/AG-UI (task/run-scoped only), ACP supports both connection-wide AND session-scoped messages.
-- **Single method**: Unlike LSP which separates `logMessage` (background) from `showMessage` (UI), ACP uses one method with levels. Clients decide presentation.
+ACP's optional `sessionId` is unique—supports both connection-wide AND session-scoped messages.
 
 ## Revision history
 

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -196,10 +196,10 @@ The proposed `log` notification is the simplest solution that:
 | Protocol | Method | Levels | Scoping | Notes |
 |----------|--------|--------|---------|-------|
 | **ACP (proposed)** | `log` | RFC 5424 (8 levels) | Optional `sessionId` | Connection-wide or session-scoped |
-| **MCP** | `notifications/message` | RFC 5424 (8 levels) | None (server-wide) | Requires `logging` capability; has `logging/setLevel` request |
-| **LSP** | `window/logMessage` | 5 levels (Error→Debug) | None | Separate `window/showMessage` for UI display |
-| **A2A** | None (via `TaskStatus.message`) | None | Task-scoped | Errors via binding-specific mechanisms (JSON-RPC, gRPC, HTTP Problem Details) |
-| **AG-UI** | `RunError` event | None | Run-scoped | Event-driven; uses `StepStarted`/`StepFinished` for progress |
+| **[MCP](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging)** | `notifications/message` | RFC 5424 (8 levels) | None (server-wide) | Requires `logging` capability; has `logging/setLevel` request |
+| **[LSP](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_logMessage)** | `window/logMessage` | 5 levels (Error→Debug) | None | Separate `window/showMessage` for UI display |
+| **[A2A](https://a2a-protocol.org/latest/specification/)** | None (via `TaskStatus.message`) | None | Task-scoped | Errors via binding-specific mechanisms (JSON-RPC, gRPC, HTTP Problem Details) |
+| **[AG-UI](https://docs.ag-ui.com/concepts/events)** | `RunError` event | None | Run-scoped | Event-driven; uses `StepStarted`/`StepFinished` for progress |
 
 **Key design choices:**
 

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -8,9 +8,7 @@ Author(s): [@chazcb](https://github.com/chazcb)
 
 > What are you proposing to change?
 
-Add a `log` notification that allows agents to send purely informational diagnostic messages to clients without terminating operations.
-
-JSON-RPC error responses terminate the request—the run is over. But many situations (approaching rate limit, using fallback model, retrying a failed request) warrant informing the client *without* stopping the run. This proposal adds that capability.
+Add a `log` notification that allows agents to send diagnostic messages to clients.
 
 ## Status quo
 

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -159,13 +159,38 @@ Agents may emit both: a `log` notification for user-visible errors AND detailed 
 
 ### Why not add a variant to `SessionUpdate`?
 
-`SessionUpdate` variants are delivered via `session/update`, which requires a `sessionId`. This means:
+There are several reasons to keep logging separate from `session/update`:
 
-1. You cannot send messages before any session exists
-2. You cannot send connection-wide messages that affect all sessions
-3. Semantically, log messages are different from session state updates (chunks, tool calls, mode changes)
+1. **Connection-level messages are essential**: Errors can occur before any session exists (during initialization, MCP server connection, authentication). A session-scoped mechanism simply cannot handle these cases.
 
-A separate `log` notification cleanly handles all scoping scenarios.
+2. **Separation of concerns**: Log messages are conceptually different from conversation state. `SessionUpdate` represents the actual conversation flow (user messages, agent responses, tool calls, mode changes). Mixing diagnostic notifications into that stream forces clients to filter out messages they may not want to display in the conversation UI. A separate channel lets clients handle logs independently—show them in a status bar, a separate panel, or ignore them entirely.
+
+3. **Opt-in presentation**: Not all clients care about every log message. By keeping logs separate, clients can choose their level of engagement without polluting the conversation thread.
+
+### Why not require capability negotiation for logging?
+
+We considered requiring a `logging` capability (like MCP does), but rejected it because:
+
+1. **Pre-initialize errors**: Connection-level errors can occur *before* `initialize` completes. If the agent can't send logs until capabilities are negotiated, critical startup errors would be lost.
+
+2. **Basic infrastructure**: Logging is fundamental enough that all clients should be able to receive it (even if they choose to ignore it). Making it capability-gated adds friction without clear benefit.
+
+Clients that don't want to display logs can simply ignore `log` notifications.
+
+### When should agents use `log` vs JSON-RPC error responses?
+
+**JSON-RPC errors should still be used when possible.** The `log` notification is specifically for out-of-band situations where there's no request to respond to:
+
+| Situation | Use |
+|-----------|-----|
+| Request fails (invalid params, auth required, etc.) | JSON-RPC error response |
+| Connection to upstream service lost | `log` notification |
+| Rate limit hit during request processing | JSON-RPC error response |
+| Approaching rate limit (proactive warning) | `log` notification |
+| MCP server disconnected | `log` notification |
+| Server shutting down soon | `log` notification |
+
+The rule of thumb: if there's a pending request that caused the error, respond with a JSON-RPC error. If the error/warning is unsolicited (no request triggered it), use `log`.
 
 ### Why use RFC 5424 log levels instead of simpler error/warning/info?
 

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -23,7 +23,7 @@ But neither option works when:
 
 - There's no active JSON RPC request to attach an error response to
 - We don't want to fail the request (e.g., retries, rate limiting, fallback selection)
-- There's no session yet (diagnostics after `initialize` but before `session/start`)
+- There's no session yet (diagnostics after `initialize` but before `session/new`)
 - We don't want to put diagnostics in chat history, or to force clients to filter non-chat content, or to fake chat content just to send diagnostic logs, etc.
 
 Without a way to surface these situations, users can be left confused when their ACP connection or session seem to stall or behave unexpectedly.
@@ -89,7 +89,31 @@ If `level` is omitted, agents should default to `info`. Agents MUST NOT send log
 
 ### Method naming
 
-`log` follows ACP’s convention for connection-level operations (e.g., `initialize`, `authenticate`) rather than introducing a new namespace.
+`log` follows ACP's convention for connection-level operations (e.g., `initialize`, `authenticate`) rather than introducing a new namespace.
+
+## Alternatives considered
+
+### Add a notification type to `session/update`
+
+Extend `session/update` with a new notification type for diagnostics. This keeps diagnostics within the existing session machinery but has drawbacks: it requires a session (can't send connection-wide diagnostics), risks polluting chat history unless clients explicitly filter, and overloads `session/update` with non-conversation concerns. Additionally, ACP specifies that session history is replayed on `session/load`, but diagnostic logs are transient and shouldn't be replayed—they're not part of the conversation.
+
+### Structured `status` notification
+
+Instead of general-purpose logging, define a more structured `status` notification explicitly for lightweight status info—similar to Claude Code's interim status messages ("Thinking...", "Searching files..."). This would be scoped to either the current session or the agent/connection level.
+
+**Tradeoffs**: More constrained semantics could be clearer for clients, but less flexible. Logging with severity levels is a well-understood pattern; inventing a new "status" abstraction may not add value over `log` with `level: info`.
+
+### Explicit progress or heartbeat notification
+
+Define a `progress` or `heartbeat` notification specifically for long-running operations, with structured fields like `percentComplete`, `estimatedTimeRemaining`, etc.
+
+**Tradeoffs**: Progress is better suited to `session/update` since it's about task state. Heartbeats could be useful but solve a different problem (connection liveness) than diagnostics. A `log` notification can express "retrying in 5s" without requiring structured progress semantics.
+
+### Transport-level mechanisms
+
+Use HTTP headers, WebSocket ping payloads, or other transport-level channels for status.
+
+**Tradeoffs**: ACP is transport-agnostic. Relying on transport-specific mechanisms would fragment implementations and lose capability negotiation.
 
 ## Shiny future
 

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -1,0 +1,195 @@
+---
+title: "Server-to-Client Logging"
+---
+
+Author(s): [@chazcb](https://github.com/chazcb)
+
+## Elevator pitch
+
+> What are you proposing to change?
+
+Add a `log` notification that allows agents to send diagnostic messages (errors, warnings, info, etc.) to clients. This notification supports both connection-wide and session-specific messages via an optional `sessionId` field.
+
+Currently, servers have no way to proactively notify clients about errors, warnings, or other diagnostic information outside of request-response cycles. This RFD proposes a simple, flexible logging mechanism that:
+
+- Works before, during, and after sessions exist
+- Supports 8 severity levels (RFC 5424/MCP-compatible)
+- Includes optional structured data and error codes
+- Follows ACP's existing naming conventions
+
+## Status quo
+
+> How do things work today and what problems does this cause? Why would we change things?
+
+Today, ACP has several limitations around server-to-client diagnostic messaging:
+
+1. **JSON-RPC errors are response-only**: The JSON-RPC 2.0 specification only allows errors in response to method calls. Servers cannot proactively send error notifications.
+
+2. **SessionNotification requires a session**: The existing `session/update` notification requires a `sessionId`. This means servers cannot communicate errors that occur:
+   - Before any session is created
+   - During connection setup or MCP server initialization
+   - At the connection level (affecting all sessions)
+
+3. **No severity levels**: There's no standard way to indicate whether a message is an error, warning, informational, or debug-level.
+
+4. **stderr is informal**: The transport spec mentions agents MAY write to stderr for logging, but this is unstructured and clients may ignore it.
+
+### Real-world problems this causes
+
+- **MCP server connection failures**: When an agent fails to connect to an MCP server, there's no way to inform the client. The user just sees tools not working.
+- **Rate limiting**: When a provider rate-limits requests, the server can only fail the current request. It cannot proactively warn about approaching limits or advise the client to wait.
+- **Transient errors**: Connection timeouts, retries, and other transient issues are invisible to clients.
+- **Debugging**: Developers have no visibility into agent behavior without external logging infrastructure.
+
+## What we propose to do about it
+
+> What are you proposing to improve the situation?
+
+Add a new `log` notification method (agent → client) with the following structure:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "log",
+  "params": {
+    "level": "error",
+    "sessionId": "abc-123",
+    "logger": "mcp.database",
+    "message": "Connection to MCP server 'database-tools' failed",
+    "code": -32001,
+    "timestamp": "2025-01-21T10:30:00Z",
+    "data": {
+      "server": "database-tools",
+      "error": "ECONNREFUSED",
+      "retryIn": 5
+    },
+    "_meta": {}
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `level` | `LogLevel` | Yes | Severity level of the message |
+| `message` | `string` | Yes | Human-readable log message |
+| `sessionId` | `SessionId` | No | Session this message pertains to. Omit for connection-wide messages. |
+| `logger` | `string` | No | Name of the logger/component emitting this message (e.g., "mcp.database", "auth") |
+| `code` | `ErrorCode` | No | Structured error code (uses same space as JSON-RPC errors) |
+| `timestamp` | `string` | No | ISO 8601 timestamp when the event occurred |
+| `data` | `object` | No | Additional structured data |
+| `_meta` | `object` | No | Extensibility metadata |
+
+### Log Levels (RFC 5424)
+
+The `LogLevel` enum follows RFC 5424 syslog severity levels, which are also used by MCP:
+
+| Level | Description |
+|-------|-------------|
+| `debug` | Detailed debugging information |
+| `info` | General informational messages |
+| `notice` | Normal but significant events |
+| `warning` | Warning conditions |
+| `error` | Error conditions |
+| `critical` | Critical conditions |
+| `alert` | Action must be taken immediately |
+| `emergency` | System is unusable |
+
+### Why `log` (no namespace)?
+
+The method name follows ACP's convention for connection-level operations:
+
+| Pattern | Examples |
+|---------|----------|
+| No namespace (connection-level) | `initialize`, `authenticate`, **`log`** |
+| Resource namespace | `session/*`, `fs/*`, `terminal/*` |
+| Protocol-level | `$/cancel_request` |
+
+We chose `log` over alternatives:
+- `log/message` - Creates a namespace with only one method
+- `notifications/message` - ACP doesn't use the `notifications/` pattern
+- `SessionUpdate::Log` - Can't handle connection-wide messages
+
+## Shiny future
+
+> How will things will play out once this feature exists?
+
+Once this feature exists:
+
+1. **Better error visibility**: Clients can display connection errors, rate limit warnings, and other diagnostic information to users. IDEs could show a status indicator or notification panel for agent health.
+
+2. **Proactive warnings**: Servers can warn about approaching limits (token budget, rate limits) before they become errors, allowing clients to adapt.
+
+3. **Debugging support**: Developers can see what's happening inside agents without external logging infrastructure. The `logger` field allows filtering by component.
+
+4. **Session-scoped context**: Errors related to specific sessions can be attributed correctly, while connection-wide issues (like MCP server failures) are clearly distinguished.
+
+5. **Structured error handling**: The optional `code` field allows clients to programmatically handle specific error types (retry on rate limit, prompt for auth on auth errors, etc.).
+
+## Frequently asked questions
+
+> What questions have arisen over the course of authoring this document or during subsequent discussions?
+
+### Why not add a variant to `SessionUpdate`?
+
+`SessionUpdate` variants are delivered via `session/update`, which requires a `sessionId`. This means:
+
+1. You cannot send messages before any session exists
+2. You cannot send connection-wide messages that affect all sessions
+3. Semantically, log messages are different from session state updates (chunks, tool calls, mode changes)
+
+A separate `log` notification cleanly handles all scoping scenarios.
+
+### Why use RFC 5424 log levels instead of simpler error/warning/info?
+
+RFC 5424 levels are a well-established standard used by syslog, many logging libraries, and MCP. Using the same levels:
+
+- Provides familiar semantics for developers
+- Enables compatibility with MCP logging
+- Supports future use cases (debug logging, critical alerts)
+
+Clients can always map these to simpler categories in their UI.
+
+### How should clients handle log messages?
+
+Clients have flexibility in how they present log messages:
+
+- **IDE status bar**: Show counts of errors/warnings with hover details
+- **Notification toasts**: Pop up for critical/alert/emergency levels
+- **Log panel**: Dedicated panel showing filterable log history
+- **Ignore**: For levels below a configured threshold
+
+The `logger` field can help clients filter/categorize messages.
+
+### Can agents flood clients with log messages?
+
+Yes, like any notification. Clients should:
+
+- Rate-limit UI updates
+- Drop old messages if buffer is full
+- Consider filtering by level
+
+Agents should be reasonable about log frequency.
+
+### What alternative approaches did you consider, and why did you settle on this one?
+
+1. **Tunneling over `SessionUpdate`**: Rejected because it can't handle connection-wide messages and mixes concerns.
+
+2. **JSON-RPC error responses**: Not possible - JSON-RPC only allows errors in response to requests.
+
+3. **Out-of-band telemetry (like agent-telemetry-export RFD)**: Good for observability backends but doesn't solve in-band client notification needs.
+
+4. **stderr logging**: Already exists informally but is unstructured, has no levels, and clients may ignore it.
+
+5. **New capability negotiation**: Considered requiring a capability, but logging is basic infrastructure that all clients should handle (even if just ignoring it).
+
+The proposed `log` notification is the simplest solution that:
+- Works at all lifecycle stages
+- Supports both session-scoped and connection-wide messages
+- Uses standard log levels
+- Fits ACP's existing patterns
+
+## Revision history
+
+- **2025-01-21**: Initial draft

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -109,6 +109,18 @@ Several reasons:
 
 4. **Connection-wide messages**: Errors can occur before any session exists (e.g., after `initialize` but before `session/new`). `session/update` requires a `sessionId`, so it simply can't be used in these cases.
 
+### Why not send diagnostics as agent text messages?
+
+Sending diagnostic info as `agent_message_chunk` would conflate conversation content with status messages:
+
+1. **Wrong semantics**: Agent messages are conversation history. Diagnostics are ephemeral status. "Rate limit warning from 2 hours ago" shouldn't appear when you reload a session.
+
+2. **No severity levels**: Text chunks can't express error vs warning vs info.
+
+3. **Filtering burden**: Clients would need to parse messages to separate "real" responses from diagnostics. How? Magic prefix? `_meta` field? Both are hacky.
+
+4. **Still requires sessionId**: Doesn't solve connection-wide messages.
+
 ### Why not use a separate channel (stderr, separate SSE endpoint, etc.)?
 
 1. **Transport-agnostic**: ACP works over stdio, WebSocket, HTTP, etc. A side channel like stderr only exists for stdio. A protocol-level solution works across all transports.

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -192,6 +192,17 @@ Clients that don't want to display logs can simply ignore `log` notifications.
 
 The rule of thumb: if there's a pending request that caused the error, respond with a JSON-RPC error. If the error/warning is unsolicited (no request triggered it), use `log`.
 
+### Is this a breaking change?
+
+**No.** Per JSON-RPC 2.0, notifications are fire-and-forget—the sender does not expect a response. If a client receives a notification for a method it doesn't recognize, it simply ignores it. This is standard JSON-RPC behavior.
+
+This means:
+- Existing clients will safely ignore `log` notifications from updated agents
+- Updated clients will work with older agents that don't send `log` notifications
+- No version negotiation or capability exchange is required
+
+The proposal is fully backward-compatible.
+
 ### Why use RFC 5424 log levels instead of simpler error/warning/info?
 
 RFC 5424 levels are a well-established standard used by syslog, many logging libraries, and MCP. Using the same levels:

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -131,6 +131,32 @@ Once this feature exists:
 
 > What questions have arisen over the course of authoring this document or during subsequent discussions?
 
+### How does this relate to the [Agent Telemetry Export RFD](./agent-telemetry-export)?
+
+They are **complementary**, serving different purposes:
+
+| Aspect | `log` notification (this RFD) | OTEL Telemetry Export |
+|--------|------------------------------|----------------------|
+| **Channel** | In-band (ACP protocol messages) | Out-of-band (HTTP to OTLP collector) |
+| **Purpose** | Real-time user-facing notifications | Observability/debugging infrastructure |
+| **Audience** | End users via client UI | Developers, ops teams, observability backends |
+| **Transport** | Works on all ACP transports | Requires HTTP (stdio subprocess focus) |
+| **Volume** | Low (errors, warnings, key events) | High (traces, spans, metrics, debug logs) |
+
+**When to use which:**
+
+- **`log` notification**: User-relevant events that should appear in the client UI
+  - "Rate limit exceeded - waiting 60s" → User sees toast/status bar
+  - "MCP server disconnected" → User knows why tools stopped working
+
+- **OTEL telemetry**: Developer/ops diagnostics for debugging and monitoring
+  - Detailed span traces with timing
+  - Token usage metrics
+  - High-volume debug logs
+  - Integration with Datadog, Grafana, etc.
+
+Agents may emit both: a `log` notification for user-visible errors AND detailed OTEL telemetry for debugging the same issue.
+
 ### Why not add a variant to `SessionUpdate`?
 
 `SessionUpdate` variants are delivered via `session/update`, which requires a `sessionId`. This means:

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -8,13 +8,13 @@ Author(s): [@chazcb](https://github.com/chazcb)
 
 > What are you proposing to change?
 
-Introduce a capability-gated `log` notification (agent → client) so agents can share diagnostic messages without polluting conversation history.
+Introduce a capability-gated `log` notification (agent → client) so agents can share diagnostic messages with clients for debugging and visibility into agent internals, without polluting conversation history.
 
 ## Status quo
 
 > How do things work today and what problems does this cause? Why would we change things?
 
-Today, agents have limited ways to inform clients about status that might impact their experience. The two options are:
+Today, agents have limited ways to send diagnostic information to clients. The two options are:
 
 1. **JSON-RPC errors**: Terminate the request immediately with an informative error message the client can display to the user
 2. **`session/update`**: Update conversation history with diagnostic information in the `agent_message_chunk` or other chat history notification
@@ -26,28 +26,26 @@ But neither option works when:
 - There's no session yet (diagnostics after `initialize` but before `session/new`)
 - We don't want to put diagnostics in chat history, or to force clients to filter non-chat content, or to fake chat content just to send diagnostic logs, etc.
 
-Without a way to surface these situations, users can be left confused when their ACP connection or session seem to stall or behave unexpectedly.
+Without a way to surface these situations, clients have no visibility into what's happening inside the agent—making debugging difficult and leaving developers blind to retries, fallbacks, and other internal behavior.
 
 ## What we propose to do about it
 
 > What are you proposing to improve the situation?
 
-Add a `log` JSON-RPC notification that is explicitly capability-gated. Clients opt in via `clientCapabilities.logging`; agents only send logs to clients that declare the capability. Clients can optionally specify a minimum log level.
+Add a `log` JSON-RPC notification that is explicitly capability-gated. Clients opt in via `clientCapabilities.logging`; agents only send logs to clients that declare the capability.
 
 ```json
 {
   "method": "initialize",
   "params": {
     "clientCapabilities": {
-      "logging": {
-        "level": "warning"
-      }
+      "logging": {}
     }
   }
 }
 ```
 
-If `level` is omitted, agents should default to `info`. Agents MUST NOT send logs below the client's requested level.
+When a client declares the `logging` capability, agents MAY send logs at any level. Clients are responsible for filtering or displaying logs as appropriate for their UI (e.g., showing only errors in a status bar, or all levels in a debug pane).
 
 ### Method
 
@@ -80,12 +78,12 @@ If `level` is omitted, agents should default to `info`. Agents MUST NOT send log
 
 ### Semantics
 
-- **Capability-gated**: Agents MUST NOT send `log` notification to clients that did not declare `clientCapabilities.logging`.
-- **Level filtering**: Agents MUST NOT send logs below the client's requested level (default: `info`).
+- **Capability-gated**: Agents MUST NOT send `log` notifications to clients that did not declare `clientCapabilities.logging`.
+- **Client-side filtering**: Clients are responsible for filtering logs by level as appropriate for their UI.
 - **Informational only**: Clients MAY display logs but MUST NOT treat them as protocol-affecting or control flow signals.
 - **Best-effort delivery**: Logs are not reliable transport and are not replayed on reconnect.
 - **Session optional**: `sessionId` is optional; omitted logs are connection-wide.
-- **Manageable volume**: Implementations should keep volume low and user-relevant.
+- **Reasonable volume**: Agents should avoid flooding clients with excessive logs, but volume management is implementation-specific.
 
 ### Method naming
 
@@ -99,9 +97,9 @@ Extend `session/update` with a new notification type for diagnostics. This keeps
 
 ### Structured `status` notification
 
-Instead of general-purpose logging, define a more structured `status` notification explicitly for lightweight status info—similar to Claude Code's interim status messages ("Thinking...", "Searching files..."). This would be scoped to either the current session or the agent/connection level.
+Instead of general-purpose logging, define a more structured `status` notification explicitly for user-facing status info—similar to Claude Code's interim status messages ("Thinking...", "Searching files..."). This would be scoped to either the current session or the agent/connection level.
 
-**Tradeoffs**: More constrained semantics could be clearer for clients, but less flexible. Logging with severity levels is a well-understood pattern; inventing a new "status" abstraction may not add value over `log` with `level: info`.
+**Why not chosen**: This proposal focuses on debug/diagnostic logging for developer visibility, not user-facing status updates. A structured status notification could be valuable for UI feedback, but it solves a different problem and could be addressed in a separate RFD. Logs are intentionally unstructured and may be noisy; status updates would need stricter semantics for reliable UI display.
 
 ### Explicit progress or heartbeat notification
 
@@ -119,9 +117,9 @@ Use HTTP headers, WebSocket ping payloads, or other transport-level channels for
 
 > How will things play out once this feature exists?
 
-- **Clear connection feedback**: Clients can surface warnings (rate limits, retries, fallbacks) so users understand what's happening.
-- **No more mysterious stalls**: Users see why things are slow (retries, rate limits) rather than assuming a hang.
-- **Better developer experience**: Diagnostics are visible without requiring OTEL or external logging.
+- **Debug visibility**: Clients can offer a "show logs" pane for developers and power users to see what's happening inside the agent (retries, rate limits, fallbacks, errors).
+- **Remote debugging**: For remote agents where stderr isn't accessible, clients can still surface agent diagnostics.
+- **Better developer experience**: Diagnostics are visible without requiring OTEL or external logging infrastructure.
 - **No compatibility risk**: Capability gating means legacy clients are unaffected.
 
 ## Implementation details and plan
@@ -129,13 +127,17 @@ Use HTTP headers, WebSocket ping payloads, or other transport-level channels for
 > Tell me more about your implementation. What is your detailed implementation plan?
 
 1. **Schema**: Add a `LogLevel` enum and a `LogNotification` params schema with the fields above.
-2. **Capabilities**: Add `clientCapabilities.logging` with optional `level` field for minimum severity filtering.
+2. **Capabilities**: Add `clientCapabilities.logging` as a capability clients can declare.
 3. **Protocol**: Add `log` to method tables and route it through notification handling.
 4. **Docs**: Update protocol docs and examples to show capability negotiation and sample logs.
 
 ## Frequently asked questions
 
 > What questions have arisen over the course of authoring this document or during subsequent discussions?
+
+### Is this for user-facing status updates?
+
+No. This proposal is for debug/diagnostic logging—giving developers and power users visibility into agent internals. Logs may be verbose, unstructured, and not suitable for primary UI display. User-facing status (like "Thinking..." or "Searching files...") would benefit from a more structured approach; see the "Structured `status` notification" alternative.
 
 ### Why not use `session/update`?
 
@@ -163,11 +165,15 @@ No. Logs are not part of session state and are not replayed.
 
 ### How does this relate to Agent Telemetry Export?
 
-They are complementary: `log` is low-volume, user-facing diagnostics in-band; OTEL, as currently proposed, is for high-volume, developer/ops telemetry out-of-band. See `/docs/rfds/agent-telemetry-export`.
+They are complementary: `log` is low-volume, in-band diagnostics for client-side visibility; OTEL, as currently proposed, is for high-volume, developer/ops telemetry out-of-band. See `/docs/rfds/agent-telemetry-export`.
 
 ### Is this a breaking change?
 
 No. It is opt-in via capability negotiation; older clients won't receive notifications they don't understand.
+
+### Can clients change the log level at runtime?
+
+Not in this proposal. Clients declare the capability at initialization and are responsible for filtering logs client-side. A future extension could add a `logging/setLevel` method if runtime control proves necessary, but for simplicity we start with client-side filtering.
 
 ### Why RFC 5424 log levels instead of error/warning/info?
 
@@ -175,4 +181,5 @@ RFC 5424 is widely used and aligns with MCP and common logging libraries. Client
 
 ## Revision history
 
+- **2025-02-04**: Clarified focus on debug/diagnostic logging vs user-facing status; simplified capability (client-side filtering); addressed PR feedback
 - **2025-01-21**: Initial draft

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -8,9 +8,9 @@ Author(s): [@chazcb](https://github.com/chazcb)
 
 > What are you proposing to change?
 
-Add a `log` notification that allows agents to send diagnostic messages to clients without terminating operations.
+Add a `log` notification that allows agents to send purely informational diagnostic messages to clients without terminating operations.
 
-JSON-RPC error responses terminate the request—the run is over. But many situations (approaching rate limit, using fallback model, retrying a failed request) warrant notifying the client *without* stopping the run. This proposal adds that capability.
+JSON-RPC error responses terminate the request—the run is over. But many situations (approaching rate limit, using fallback model, retrying a failed request) warrant informing the client *without* stopping the run. This proposal adds that capability.
 
 ## Status quo
 
@@ -47,7 +47,6 @@ Add a `log` notification (agent → client) that requires capability negotiation
     "message": "Backing model rate limited, retrying in 5 seconds...",
     "sessionId": "abc-123",
     "logger": "model",
-    "code": -32001,
     "timestamp": "2025-01-21T10:30:00Z",
     "data": { "model": "claude-3", "retryIn": 5 }
   }
@@ -69,6 +68,8 @@ Clients opt-in by declaring `logging` capability during `initialize`:
 
 Agents MUST NOT send `log` notifications to clients that didn't declare this capability. This ensures backward compatibility—older clients simply don't receive notifications they can't handle.
 
+Log notifications are purely informational. Clients MAY display them to users but MUST NOT take automated action based on their contents.
+
 ### Fields
 
 | Field | Type | Required | Description |
@@ -76,10 +77,9 @@ Agents MUST NOT send `log` notifications to clients that didn't declare this cap
 | `level` | `LogLevel` | Yes | RFC 5424 severity: `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency` |
 | `message` | `string` | Yes | Human-readable message |
 | `sessionId` | `SessionId` | No | Omit for connection-wide messages |
-| `logger` | `string` | No | Component name (e.g., "mcp", "auth") |
-| `code` | `ErrorCode` | No | Structured error code |
+| `logger` | `string` | No | Component name (e.g., "model", "auth") |
 | `timestamp` | `string` | No | ISO 8601 timestamp |
-| `data` | `object` | No | Additional structured data |
+| `data` | `object` | No | Additional context for display/debugging (opaque to clients) |
 | `_meta` | `object` | No | Extensibility metadata |
 
 ### Method Naming

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -32,7 +32,7 @@ Today, ACP has several limitations around server-to-client diagnostic messaging:
 
 3. **No severity levels**: There's no standard way to indicate whether a message is an error, warning, informational, or debug-level.
 
-4. **stderr is informal**: The transport spec mentions agents MAY write to stderr for logging, but this is unstructured and clients may ignore it.
+4. **Transport-agnostic gap**: ACP supports multiple transports (stdio, WebSocket, HTTP). While the stdio transport allows informal stderr logging, other transports have no equivalent. A protocol-level logging mechanism ensures consistent behavior across all transports.
 
 ### Real-world problems this causes
 
@@ -180,7 +180,7 @@ Agents should be reasonable about log frequency.
 
 3. **Out-of-band telemetry (like agent-telemetry-export RFD)**: Good for observability backends but doesn't solve in-band client notification needs.
 
-4. **stderr logging**: Already exists informally but is unstructured, has no levels, and clients may ignore it.
+4. **Transport-specific logging (e.g., stderr)**: Only works for stdio transport. ACP is transport-agnostic, so we need a protocol-level solution that works over WebSocket, HTTP, and any future transports.
 
 5. **New capability negotiation**: Considered requiring a capability, but logging is basic infrastructure that all clients should handle (even if just ignoring it).
 
@@ -189,6 +189,23 @@ The proposed `log` notification is the simplest solution that:
 - Supports both session-scoped and connection-wide messages
 - Uses standard log levels
 - Fits ACP's existing patterns
+- Works identically across all transports
+
+### How does this compare to other protocols?
+
+| Protocol | Method | Levels | Scoping | Notes |
+|----------|--------|--------|---------|-------|
+| **ACP (proposed)** | `log` | RFC 5424 (8 levels) | Optional `sessionId` | Connection-wide or session-scoped |
+| **MCP** | `notifications/message` | RFC 5424 (8 levels) | None (server-wide) | Requires `logging` capability; has `logging/setLevel` request |
+| **LSP** | `window/logMessage` | 5 levels (Error→Debug) | None | Separate `window/showMessage` for UI display |
+| **A2A** | None (via `TaskStatus.message`) | None | Task-scoped | Errors via binding-specific mechanisms (JSON-RPC, gRPC, HTTP Problem Details) |
+| **AG-UI** | `RunError` event | None | Run-scoped | Event-driven; uses `StepStarted`/`StepFinished` for progress |
+
+**Key design choices:**
+
+- **RFC 5424 levels**: Aligns with MCP for ecosystem consistency. More expressive than LSP's 5 levels.
+- **Optional `sessionId`**: Unlike MCP (server-wide only) or A2A/AG-UI (task/run-scoped only), ACP supports both connection-wide AND session-scoped messages.
+- **Single method**: Unlike LSP which separates `logMessage` (background) from `showMessage` (UI), ACP uses one method with levels. Clients decide presentation.
 
 ## Revision history
 

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Server-to-Client Logging"
+title: "Agent-to-Client Logging"
 ---
 
 Author(s): [@chazcb](https://github.com/chazcb)
@@ -8,33 +8,48 @@ Author(s): [@chazcb](https://github.com/chazcb)
 
 > What are you proposing to change?
 
-Add a `log` notification that allows agents to send diagnostic messages to clients.
+Introduce a capability-gated `log` notification (agent → client) so agents can share diagnostic messages without polluting conversation history.
 
 ## Status quo
 
-> How do things work today and what problems does this cause?
+> How do things work today and what problems does this cause? Why would we change things?
 
-ACP has no mechanism for agents to proactively notify clients about diagnostic information:
+Today, agents have limited ways to inform clients about status that might impact their experience. The two options are:
 
-1. **JSON-RPC errors terminate requests**: If an agent returns an error, the run stops. There's no way to report non-fatal issues.
+1. **JSON-RPC errors**: Terminate the request immediately with an informative error message the client can display to the user
+2. **`session/update`**: Update conversation history with diagnostic information in the `agent_message_chunk` or other chat history notification
 
-2. **`session/update` requires a session**: Connection-wide issues (server shutting down, configuration problems) can't be communicated because there's no session to attach them to.
+But neither option works when:
 
-3. **Errors during long runs are invisible**: A prompt turn can run for minutes. If something goes wrong mid-run but the agent can recover, the client has no visibility.
+- There's no active JSON RPC request to attach an error response to
+- We don't want to fail the request (e.g., retries, rate limiting, fallback selection)
+- There's no session yet (diagnostics after `initialize` but before `session/start`)
+- We don't want to put diagnostics in chat history, or to force clients to filter non-chat content, or to fake chat content just to send diagnostic logs, etc.
 
-4. **No standard severity levels**: No way to distinguish errors from warnings from informational messages.
-
-**Real-world examples:**
-- Backing model rate limited → warn the user, retry in progress
-- Backing service disconnected → informational, reconnecting
-- Using fallback model → informational, run continues
-- Server shutting down in 5 minutes → warn all sessions
+Without a way to surface these situations, users can be left confused when their ACP connection or session seem to stall or behave unexpectedly.
 
 ## What we propose to do about it
 
 > What are you proposing to improve the situation?
 
-Add a `log` notification (agent → client) that requires capability negotiation:
+Add a `log` JSON-RPC notification that is explicitly capability-gated. Clients opt in via `clientCapabilities.logging`; agents only send logs to clients that declare the capability. Clients can optionally specify a minimum log level.
+
+```json
+{
+  "method": "initialize",
+  "params": {
+    "clientCapabilities": {
+      "logging": {
+        "level": "warning"
+      }
+    }
+  }
+}
+```
+
+If `level` is omitted, agents should default to `info`. Agents MUST NOT send logs below the client's requested level.
+
+### Method
 
 ```json
 {
@@ -51,146 +66,88 @@ Add a `log` notification (agent → client) that requires capability negotiation
 }
 ```
 
-### Capability Declaration
-
-Clients opt-in by declaring `logging` capability during `initialize`:
-
-```json
-{
-  "method": "initialize",
-  "params": {
-    "clientCapabilities": { "logging": {} }
-  }
-}
-```
-
-Agents MUST NOT send `log` notifications to clients that didn't declare this capability. This ensures backward compatibility—older clients simply don't receive notifications they can't handle.
-
-Log notifications are purely informational. Clients MAY display them to users but MUST NOT take automated action based on their contents.
-
 ### Fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `level` | `LogLevel` | Yes | RFC 5424 severity: `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency` |
-| `message` | `string` | Yes | Human-readable message |
+| `message` | `string` | Yes | Human-readable summary safe for display |
 | `sessionId` | `SessionId` | No | Omit for connection-wide messages |
 | `logger` | `string` | No | Component name (e.g., "model", "auth") |
-| `timestamp` | `string` | No | ISO 8601 timestamp |
-| `data` | `object` | No | Additional context for display/debugging (opaque to clients) |
+| `timestamp` | `string` | No | ISO 8601 timestamp if provided |
+| `data` | `object` | No | Opaque context (clients must not depend on structure) |
 | `_meta` | `object` | No | Extensibility metadata |
 
-### Method Naming
+### Semantics
 
-The method name `log` follows ACP's convention for connection-level operations (like `initialize`, `authenticate`) rather than using a namespace like `log/message`.
+- **Capability-gated**: Agents MUST NOT send `log` notification to clients that did not declare `clientCapabilities.logging`.
+- **Level filtering**: Agents MUST NOT send logs below the client's requested level (default: `info`).
+- **Informational only**: Clients MAY display logs but MUST NOT treat them as protocol-affecting or control flow signals.
+- **Best-effort delivery**: Logs are not reliable transport and are not replayed on reconnect.
+- **Session optional**: `sessionId` is optional; omitted logs are connection-wide.
+- **Manageable volume**: Implementations should keep volume low and user-relevant.
+
+### Method naming
+
+`log` follows ACP’s convention for connection-level operations (e.g., `initialize`, `authenticate`) rather than introducing a new namespace.
 
 ## Shiny future
 
 > How will things play out once this feature exists?
 
-1. **Real-time health visibility**: Clients can show agent status—errors in a panel, warnings in a status bar
-2. **Non-fatal error reporting**: Agents can report issues without aborting runs
-3. **Proactive warnings**: "Approaching rate limit" before it becomes an error
-4. **Debugging**: Developers see what's happening without external infrastructure
+- **Clear connection feedback**: Clients can surface warnings (rate limits, retries, fallbacks) so users understand what's happening.
+- **No more mysterious stalls**: Users see why things are slow (retries, rate limits) rather than assuming a hang.
+- **Better developer experience**: Diagnostics are visible without requiring OTEL or external logging.
+- **No compatibility risk**: Capability gating means legacy clients are unaffected.
+
+## Implementation details and plan
+
+> Tell me more about your implementation. What is your detailed implementation plan?
+
+1. **Schema**: Add a `LogLevel` enum and a `LogNotification` params schema with the fields above.
+2. **Capabilities**: Add `clientCapabilities.logging` with optional `level` field for minimum severity filtering.
+3. **Protocol**: Add `log` to method tables and route it through notification handling.
+4. **Docs**: Update protocol docs and examples to show capability negotiation and sample logs.
 
 ## Frequently asked questions
 
+> What questions have arisen over the course of authoring this document or during subsequent discussions?
+
 ### Why not use `session/update`?
 
-Several reasons:
-
-1. **Separation of concerns**: `SessionUpdate` represents conversation state (messages, tool calls, mode changes). Logs are diagnostic metadata, not conversation content. Mixing them forces clients to filter out logs they don't want in the conversation UI.
-
-2. **Breaking change**: Adding a log variant to `SessionUpdate` would send logs to existing clients that don't expect them. A separate capability-gated notification is opt-in and non-breaking.
-
-3. **Opt-in presentation**: Not all clients care about logs. A separate channel lets clients ignore them entirely without polluting the conversation stream.
-
-4. **Connection-wide messages**: Errors can occur before any session exists (e.g., after `initialize` but before `session/new`). `session/update` requires a `sessionId`, so it simply can't be used in these cases.
+`session/update` represents conversation state. Logs are diagnostic metadata and should not appear in chat history or require clients to filter out non-conversation content. `session/update` also can't represent connection-wide issues because it requires `sessionId`.
 
 ### Why not send diagnostics as agent text messages?
 
-Sending diagnostic info as `agent_message_chunk` would conflate conversation content with status messages:
+Agent messages are persistent conversation content. Logs are ephemeral status and should not be reloaded or forked with the session. Agent text also lacks severity levels and would require ad-hoc parsing to separate real answers from diagnostics.
 
-1. **Wrong semantics**: Agent messages are conversation history. Diagnostics are ephemeral status. "Rate limit warning from 2 hours ago" shouldn't appear when you reload a session.
+### Why not use a separate channel (stderr, SSE side channel, etc.)?
 
-2. **No severity levels**: Text chunks can't express error vs warning vs info.
-
-3. **Filtering burden**: Clients would need to parse messages to separate "real" responses from diagnostics. How? Magic prefix? `_meta` field? Both are hacky.
-
-4. **Still requires sessionId**: Doesn't solve connection-wide messages.
-
-### Why not use a separate channel (stderr, separate SSE endpoint, etc.)?
-
-1. **Transport-agnostic**: ACP works over stdio, WebSocket, HTTP, etc. A side channel like stderr only exists for stdio. A protocol-level solution works across all transports.
-
-2. **Already connected**: Clients already have an ACP connection. Why require a separate channel just for logs?
-
-3. **Session context**: The `sessionId` field ties logs to specific sessions. A separate channel would need to reinvent this.
-
-4. **Capability negotiation**: ACP already has capability negotiation. A separate channel would need its own opt-in mechanism.
-
-5. **OTEL handles heavy telemetry**: The [Agent Telemetry Export RFD](./agent-telemetry-export) covers high-volume, developer-focused observability. `log` is for low-volume, user-facing messages—different use case, belongs in-band.
+ACP is transport-agnostic. A protocol-level log works uniformly across stdio, WebSocket, and HTTP, reuses capability negotiation, and allows optional session scoping without inventing a parallel channel.
 
 ### Why not return errors on `prompt()`?
 
-The key question is: **should the run stop?**
+JSON-RPC errors terminate the request. Many conditions (rate limiting, retries, fallback selection) are non-fatal and should not end the run. Logs allow notification without aborting.
 
-- JSON-RPC error responses terminate the request—the run is over
-- `log` notifications are independent—the run continues
+### Are logs ordered relative to other notifications?
 
-Many situations (backing model rate limited, approaching context limit, using fallback model) warrant notifying the client without aborting.
+No strict guarantees. Implementations may keep logs ordered with other notifications for readability, but clients must treat them as best-effort informational messages.
 
-Also: not all agents use `prompt()`. Some use extension methods like `_enqueue` (a notification). Notifications have no response, so there's nowhere to return an error.
+### Are logs replayed after reconnect?
 
-### How does this relate to the [Agent Telemetry Export RFD](./agent-telemetry-export)?
+No. Logs are not part of session state and are not replayed.
 
-They're complementary:
+### How does this relate to Agent Telemetry Export?
 
-| | `log` notification | OTEL Telemetry |
-|-|-------------------|----------------|
-| **Channel** | In-band (ACP) | Out-of-band (HTTP) |
-| **Audience** | End users | Developers/ops |
-| **Volume** | Low (key events) | High (traces, metrics) |
-
-Use `log` for user-facing messages. Use OTEL for observability infrastructure.
+They are complementary: `log` is low-volume, user-facing diagnostics in-band; OTEL, as currently proposed, is for high-volume, developer/ops telemetry out-of-band. See `/docs/rfds/agent-telemetry-export`.
 
 ### Is this a breaking change?
 
-**No.** Capability negotiation makes it opt-in:
-- Older clients don't declare capability → don't receive notifications
-- Older agents don't send notifications → nothing changes
+No. It is opt-in via capability negotiation; older clients won't receive notifications they don't understand.
 
-### When should agents use `log` vs JSON-RPC errors?
+### Why RFC 5424 log levels instead of error/warning/info?
 
-| Situation | Use |
-|-----------|-----|
-| Request fails | JSON-RPC error (terminates request) |
-| Non-fatal issue during run | `log` notification (run continues) |
-| Proactive warning | `log` notification |
-| Connection-wide issue | `log` notification |
-
-Rule: If there's a pending request that should fail, use JSON-RPC error. Otherwise, use `log`.
-
-### Why RFC 5424 log levels instead of just error/warning/info?
-
-RFC 5424 (syslog) levels are used by MCP, most logging libraries, and observability tools. Using the same 8 levels:
-- Provides familiar semantics
-- Enables MCP compatibility
-- Supports future use cases (debug logging, critical alerts)
-
-Clients can always map to simpler categories in their UI.
-
-### How does this compare to other protocols?
-
-| Protocol | Method | Levels | Scoping |
-|----------|--------|--------|---------|
-| **ACP (proposed)** | `log` | RFC 5424 (8) | Optional `sessionId` |
-| **[MCP](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging)** | `notifications/message` | RFC 5424 (8) | Server-wide only |
-| **[LSP](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_logMessage)** | `window/logMessage` | 5 levels | None |
-| **[A2A](https://a2a-protocol.org/latest/specification/)** | None | None | Task-scoped |
-| **[AG-UI](https://docs.ag-ui.com/concepts/events)** | `RunError` event | None | Run-scoped |
-
-ACP's optional `sessionId` is unique—supports both connection-wide AND session-scoped messages.
+RFC 5424 is widely used and aligns with MCP and common logging libraries. Clients can map to simpler categories in their UI.
 
 ## Revision history
 

--- a/docs/rfds/server-logging.mdx
+++ b/docs/rfds/server-logging.mdx
@@ -12,8 +12,9 @@ Add a `log` notification that allows agents to send diagnostic messages (errors,
 
 Currently, servers have no way to proactively notify clients about errors, warnings, or other diagnostic information outside of request-response cycles. This RFD proposes a simple, flexible logging mechanism that:
 
-- Works before, during, and after sessions exist
-- Supports 8 severity levels (RFC 5424/MCP-compatible)
+- Supports both connection-wide and session-specific messages via optional `sessionId`
+- Uses 8 severity levels (RFC 5424/MCP-compatible)
+- Requires capability negotiation for clean opt-in (no breaking changes)
 - Includes optional structured data and error codes
 - Follows ACP's existing naming conventions
 
@@ -80,6 +81,26 @@ Add a new `log` notification method (agent → client) with the following struct
 | `timestamp` | `string` | No | ISO 8601 timestamp when the event occurred |
 | `data` | `object` | No | Additional structured data |
 | `_meta` | `object` | No | Extensibility metadata |
+
+### Capability Declaration
+
+Clients that want to receive `log` notifications MUST declare the `logging` capability during `initialize`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "0.1",
+    "clientCapabilities": {
+      "logging": {}
+    }
+  }
+}
+```
+
+Agents MUST NOT send `log` notifications to clients that did not declare this capability.
 
 ### Log Levels (RFC 5424)
 
@@ -167,15 +188,43 @@ There are several reasons to keep logging separate from `session/update`:
 
 3. **Opt-in presentation**: Not all clients care about every log message. By keeping logs separate, clients can choose their level of engagement without polluting the conversation thread.
 
-### Why not require capability negotiation for logging?
+### Should logging require capability negotiation?
 
-We considered requiring a `logging` capability (like MCP does), but rejected it because:
+**Yes.** Agents MUST only send `log` notifications to clients that declare support via a `logging` capability in `ClientCapabilities` during `initialize`.
 
-1. **Pre-initialize errors**: Connection-level errors can occur *before* `initialize` completes. If the agent can't send logs until capabilities are negotiated, critical startup errors would be lost.
+This works because:
 
-2. **Basic infrastructure**: Logging is fundamental enough that all clients should be able to receive it (even if they choose to ignore it). Making it capability-gated adds friction without clear benefit.
+1. **Initialize handles startup errors**: The `initialize` method is a request/response—if something is broken during startup, the agent responds with a JSON-RPC error. There's no "pre-initialize" gap where we need unsolicited notifications.
 
-Clients that don't want to display logs can simply ignore `log` notifications.
+2. **Clean opt-in**: Clients explicitly declare they want log notifications. Older clients that don't support `log` simply don't receive them—no SDK changes needed, no breaking changes.
+
+3. **Follows MCP pattern**: MCP requires a `logging` capability for the same reasons.
+
+**Flow:**
+1. Transport connects
+2. Client calls `initialize()` with `clientCapabilities: { logging: {} }`
+3. If startup fails → Agent responds with JSON-RPC error
+4. If startup succeeds → Agent knows client supports `log`, can send notifications
+
+Clients that don't declare `logging` capability won't receive `log` notifications, but can still receive JSON-RPC errors in response to their method calls.
+
+### Why not just return errors on `prompt()` responses?
+
+The key question is: **should the run stop?**
+
+A JSON-RPC error response terminates the request—the run is over. But many situations warrant notifying the client *without* aborting:
+
+1. **Non-fatal issues during long runs**: A prompt turn can run for minutes. If one MCP server disconnects but others are fine, the agent might continue with degraded functionality. The client should know about the issue, but the run shouldn't stop.
+
+2. **Warnings and informational messages**: "Approaching rate limit" or "Using fallback model" are useful to surface, but definitely shouldn't abort the run.
+
+3. **Connection-wide issues**: Some errors affect all sessions (server shutting down soon). There's no single prompt to attach these to.
+
+4. **Out-of-band timing**: Errors can occur between prompt turns, when no request is pending.
+
+5. **Alternative interaction patterns**: Not all ACP implementations use `prompt()`. Some agents use custom extension methods like `_enqueue` (a notification for steering during a run). Since notifications don't have responses, there's no place to return a JSON-RPC error.
+
+The `log` notification provides an independent channel for diagnostic messages that don't terminate the current operation.
 
 ### When should agents use `log` vs JSON-RPC error responses?
 
@@ -194,14 +243,13 @@ The rule of thumb: if there's a pending request that caused the error, respond w
 
 ### Is this a breaking change?
 
-**No.** Per JSON-RPC 2.0, notifications are fire-and-forget—the sender does not expect a response. If a client receives a notification for a method it doesn't recognize, it simply ignores it. This is standard JSON-RPC behavior.
+**No.** Because logging requires capability negotiation:
 
-This means:
-- Existing clients will safely ignore `log` notifications from updated agents
-- Updated clients will work with older agents that don't send `log` notifications
-- No version negotiation or capability exchange is required
+- **Older clients** don't declare `logging` capability → agents don't send `log` notifications → no change in behavior
+- **Older agents** don't send `log` notifications → updated clients just don't receive any → no change in behavior
+- **Updated clients + updated agents** → client declares `logging` capability → agent sends `log` notifications → new feature works
 
-The proposal is fully backward-compatible.
+No SDK changes are required for backward compatibility. Clients opt-in by declaring the capability.
 
 ### Why use RFC 5424 log levels instead of simpler error/warning/info?
 


### PR DESCRIPTION
## Summary

This RFD proposes a capability-gated `log` notification (agent → client) so agents can share diagnostic messages without polluting conversation history.

### Key features
- **Capability-gated**: Clients opt in via `clientCapabilities.logging`; agents only send logs to clients that declare the capability
- **Level filtering**: Clients can specify minimum log level (default: `info`)
- **Optional `sessionId`**: Connection-wide if absent, session-specific if present
- **RFC 5424 severity levels**: debug, info, notice, warning, error, critical, alert, emergency
- **Optional fields**: logger name, timestamp, structured data

### Problem

Today, agents have limited ways to inform clients about status that might impact their experience:
- **JSON-RPC errors**: Terminate the request immediately (can't use for non-fatal conditions)
- **`session/update`**: Puts diagnostics in chat history (not appropriate for transient status)

Neither works when:
- There's no active JSON RPC request to attach an error response to
- We don't want to fail the request (e.g., retries, rate limiting, fallback selection)
- There's no session yet (diagnostics after `initialize` but before `session/new`)
- We don't want to put diagnostics in chat history

### Example

```json
{
  "jsonrpc": "2.0",
  "method": "log",
  "params": {
    "level": "warning",
    "message": "Backing model rate limited, retrying in 5 seconds...",
    "sessionId": "abc-123",
    "logger": "model",
    "timestamp": "2025-01-21T10:30:00Z",
    "data": { "model": "claude-3", "retryIn": 5 }
  }
}
```

### Capability negotiation

```json
{
  "method": "initialize",
  "params": {
    "clientCapabilities": {
      "logging": {
        "level": "warning"
      }
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)