### PR TITLE
RFD: Session Input Options

### DIFF
--- a/docs/rfds/session-input-options.mdx
+++ b/docs/rfds/session-input-options.mdx
@@ -195,13 +195,13 @@ Use the elicitation mechanism from [MCP Elicitation](https://github.com/modelcon
 
 - No new protocol additions - reuses elicitation
 - Consistent with MCP patterns
-- Dynamic - agent can ask different questions per session
+- Dynamic - config options can vary per `session/new` or `session/load` call, not bound to the connection
 
 **Cons:**
 
 - **Client cannot show config UI until session exists** - Creates awkward UX flows where clients must create a session just to discover if there are config options to show.
 - Session exists in "pending config" state - semantically awkward
-- **Agent initialization complexity** - Agent cannot directly use config for session initialization (model selection, system prompt setup, etc.) since the session is already created.
+- **Agent initialization complexity** - Agent cannot directly use config for session initialization (model selection, system prompt setup, etc.) since the session is already created. A workaround is to create a lightweight session that hands off to a configured backend session, but this adds complexity for agent developers and requires the ability to mint session IDs upfront.
 
 **Why not chosen:** This approach works for mid-session information gathering but doesn't solve the initialization use case well.
 


### PR DESCRIPTION
## Summary

Proposal for allowing Agents to declare input options they accept for `session/new` and `session/load` requests, advertised in `InitializeResult` capabilities.

Uses MCP elicitation's JSON Schema format for defining input schemas, providing ecosystem consistency.

## Key Design Decisions

- **Discovery at init time**: Input schemas are advertised in `InitializeResult.capabilities.sessions`, enabling clients to show configuration UI before session creation
- **Elicitation schema format**: Uses the same JSON Schema subset as MCP elicitation for type definitions, encouraging ecosystem alignment
- **Separate schemas**: Distinct schemas for `newSession` vs `loadSession` operations
- **All options optional**: Agents must provide sensible defaults

## Why not pure elicitation?

We considered using MCP elicitation directly (server requests input after `session/new`), but this has UX tradeoffs:
- Session enters "pending" state during elicitation
- Clients can't show configuration UI proactively
- Discovery requires starting a session first

By advertising schemas at init time, clients can build configuration UIs that feel native rather than reactive.

## Related

- Uses schema format from [MCP Elicitation](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/376)
- Complements Session Config Options (runtime configuration during a session)