### PR TITLE
docs: Fix Copilot link in the registry page

### DIFF
--- a/docs/get-started/registry.mdx
+++ b/docs/get-started/registry.mdx
@@ -154,7 +154,7 @@ Visit [the registry repository on GitHub](https://github.com/agentclientprotocol
   </Card>
   <Card
     title="GitHub Copilot"
-    href="https://github.com/github/copilot-language-server-release"
+    href="https://github.com/github/copilot-cli"
     icon={
       <svg
         width="20"


### PR DESCRIPTION
Fix as per report by the Copilot team.