### PR TITLE
Add swift-acp to community libraries

### DIFF
--- a/docs/libraries/community.mdx
+++ b/docs/libraries/community.mdx
@@ -21,4 +21,5 @@ description: "Community managed libraries for the Agent Client Protocol"
 
 ## Swift
 
+- [swift-acp](https://github.com/wiedymi/swift-acp)
 - [swift-sdk](https://github.com/aptove/swift-sdk)


### PR DESCRIPTION
Hello! I would like to add my swift-acp library to community libraries in the docs. It's used in aizen.win for ACP implementation.

https://github.com/wiedymi/swift-acp