### PR TITLE
Add swift-acp to community libraries

### DIFF
--- a/docs/libraries/community.mdx
+++ b/docs/libraries/community.mdx
@@ -21,4 +21,5 @@ description: "Community managed libraries for the Agent Client Protocol"
 
 ## Swift
 
+- [swift-acp](https://github.com/wiedymi/swift-acp)
 - [swift-sdk](https://github.com/aptove/swift-sdk)


### PR DESCRIPTION
Hi there again! You did not even read my PR, its not same lib as you already have in community seciton in docs for swift, it's different one, not even fork...