### PR TITLE
fix: avoid redundant JSON validation in extension notification deco…

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -238,7 +238,7 @@ impl Side for ClientSide {
                 if let Some(custom_method) = method.strip_prefix('_') {
                     Ok(AgentNotification::ExtNotification(ExtNotification {
                         method: custom_method.into(),
-                        params: RawValue::from_string(params.get().to_string())?.into(),
+                        params: params.to_owned().into(),
                     }))
                 } else {
                     Err(Error::method_not_found())
@@ -330,7 +330,7 @@ impl Side for AgentSide {
                 if let Some(custom_method) = method.strip_prefix('_') {
                     Ok(ClientNotification::ExtNotification(ExtNotification {
                         method: custom_method.into(),
-                        params: RawValue::from_string(params.get().to_string())?.into(),
+                        params: params.to_owned().into(),
                     }))
                 } else {
                     Err(Error::method_not_found())


### PR DESCRIPTION
The params are already validated RawValue instances from the initial JSON-RPC message parsing, so re-validating them is unnecessary and wasteful.

This change eliminates:
- Unnecessary string allocation
- Redundant JSON parsing