### PR TITLE
docs: add Kiro CLI to agents list

### DIFF
--- a/docs/get-started/agents.mdx
+++ b/docs/get-started/agents.mdx
@@ -19,6 +19,7 @@ The following agents can be used with an ACP Client:
 - [Goose](https://block.github.io/goose/docs/guides/acp-clients)
 - [JetBrains Junie _(coming soon)_](https://www.jetbrains.com/junie/)
 - [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)
+- [Kiro CLI](https://kiro.dev/docs/cli/acp/)
 - [Minion Code](https://github.com/femto/minion-code)
 - [Mistral Vibe](https://github.com/mistralai/mistral-vibe)
 - [OpenCode](https://github.com/sst/opencode)


### PR DESCRIPTION
Add Kiro CLI to the list of ACP-compatible agents.

See: https://kiro.dev/docs/cli/acp/