### PR TITLE
Add acp-swift-sdk to community libraries list

### DIFF
--- a/docs/libraries/community.mdx
+++ b/docs/libraries/community.mdx
@@ -23,3 +23,4 @@ description: "Community managed libraries for the Agent Client Protocol"
 
 - [swift-acp](https://github.com/wiedymi/swift-acp)
 - [swift-sdk](https://github.com/aptove/swift-sdk)
+- [acp-swift-sdk](https://github.com/rebornix/acp-swift-sdk)


### PR DESCRIPTION
`acp-swift-sdk` is the core library used in [Agmente](http://agmente.halliharp.com), hope folks can find it useful.