### PR TITLE
Add ACP Client VS Code extension to the clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -25,5 +25,7 @@ The following clients can be used with an ACP Agent:
 - [Sidequery _(coming soon)_](https://sidequery.dev)
 - [Tidewave](https://tidewave.ai/)
 - [Toad](https://www.batrachian.ai/)
+- Visual Studio Code
+  - through the [ACP Client](https://github.com/formulahendry/vscode-acp) extension
 - [Web Browser with AI SDK](https://github.com/mcpc-tech/ai-elements-remix-template) (powered by [@mcpc/acp-ai-provider](https://github.com/mcpc-tech/mcpc/tree/main/packages/acp-ai-provider))
 - [Zed](https://zed.dev/docs/ai/external-agents)


### PR DESCRIPTION
This is my personal project at weekend to build an [ACP Client as VS Code extension](https://github.com/formulahendry/vscode-acp).