### PR TITLE
Add AutoDev agent link to documentation

### DIFF
--- a/docs/get-started/agents.mdx
+++ b/docs/get-started/agents.mdx
@@ -7,6 +7,7 @@ The following agents can be used with an ACP Client:
 
 - [AgentPool](https://phil65.github.io/agentpool/advanced/acp-integration/)
 - [Augment Code](https://docs.augmentcode.com/cli/acp)
+- [AutoDev](https://github.com/phodal/auto-dev)
 - [Blackbox AI](https://docs.blackbox.ai/features/blackbox-cli/introduction)
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) (via [Zed's SDK adapter](https://github.com/zed-industries/claude-code-acp))
 - [Cline](https://cline.bot/)


### PR DESCRIPTION
Hi,

Recently, we add ACP supports in AutoDev CLI tool `@xiuper/cli`