### PR TITLE
docs/rfds: Add support for Agent Skill discovery

### DIFF
--- a/docs/rfds/skills.mdx
+++ b/docs/rfds/skills.mdx
@@ -13,6 +13,7 @@ Define first-class **Skills** discovery in ACP so agents and clients can enumera
 Skills exist today as **tool-specific filesystem conventions** that are not directly exposed via ACP at all:
 
 - Users have to know what skills are available by heart rather than using the standard `$`/`/skills` discovery mechanisms.
+  - This is also an unnecessary 'surprise' for users coming from direct codex/claude usage who are used to this affordance.
 - Each client defines its own discovery paths and activation heuristics.
 - ACP only mentions skills indirectly in the proxy-chains RFD; there is no protocol-level contract for listing or fetching skills.
 - Proxies can inject instructions, but there is no standardized metadata, no cross-client interoperability, and no way for an agent to ask, “what skills are available?”


### PR DESCRIPTION
Whoops. I had not seen https://github.com/agentclientprotocol/agent-client-protocol/pull/370 when I made this. I thought I'd searched but I guess I didn't search hard enough. I'll close this because I don't think it makes sense to have two open Skill RFDs but please feel free to reopen if you think it has value. I think this is less ambitious/simpler overall than https://github.com/agentclientprotocol/agent-client-protocol/pull/370 which may make it more palatable.

-----

Draft RFD proposing a minimal ACP skills discovery contract. It defines `skills/list`, recommends `/skills` and `$`,`/` UX hooks, clarifies that skills are agent-owned and discovery-only, and captures non-goals.

## Note

This is my first RFD here—please be patient if I’m not following protocol perfectly. 😅

Co-authored-by: Codex <codex@openai.com>