### PR TITLE
docs: add Chrome ACP to clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -10,6 +10,7 @@ The following clients can be used with an ACP Agent:
 - [Agmente](https://agmente.halliharp.com) (iOS)
 - [AionUi](https://github.com/iOfficeAI/AionUi)
 - [aizen](https://aizen.win)
+- [Chrome ACP](https://github.com/Areo-Joe/chrome-acp) (Chrome extension / PWA)
 - [DeepChat](https://github.com/ThinkInAIXYZ/deepchat)
 - DuckDB
   - through the [sidequery/duckdb-acp](https://github.com/sidequery/duckdb-acp) extension


### PR DESCRIPTION
I have created an ACP client called [Chrome ACP](https://github.com/Areo-Joe/chrome-acp).

It can make use of any ACP compatible agent, providing UI by Chrome extension or web app or PWA.

I want to have this project listed on the ACP's official docs.