### PR TITLE
docs: add Factory Droid to Agents page

### DIFF
--- a/docs/get-started/agents.mdx
+++ b/docs/get-started/agents.mdx
@@ -15,6 +15,7 @@ The following agents can be used with an ACP Client:
 - [Code Assistant](https://github.com/stippi/code-assistant?tab=readme-ov-file#configuration)
 - [Docker's cagent](https://github.com/docker/cagent)
 - [fast-agent](https://fast-agent.ai/acp)
+- [Factory Droid](https://factory.ai/)
 - [fount](https://github.com/steve02081504/fount)
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli)
 - [GitHub Copilot](https://github.com/features/copilot) (in [public preview](https://github.blog/changelog/2026-01-28-acp-support-in-copilot-cli-is-now-in-public-preview/))


### PR DESCRIPTION
Adding Droid to the page with a list of supported Agents (https://agentclientprotocol.com/get-started/agents). It is already listed in the ACP Registry page

Thanks!