### PR TITLE
Add acpx CLI client to documentation

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -6,6 +6,7 @@ description: "Clients implementing the Agent Client Protocol."
 The following clients can be used with an ACP Agent:
 
 - [ACP UI](https://github.com/formulahendry/acp-ui)
+- [acpx (CLI)](https://github.com/openclaw/acpx)
 - [Agent Studio](https://github.com/sxhxliang/agent-studio)
 - [Agmente](https://agmente.halliharp.com) (iOS)
 - [AionUi](https://github.com/iOfficeAI/AionUi)


### PR DESCRIPTION
Adding acpx to the list

acpx is an ACP client, not for humans, but for agents. ACP methods are mapped to CLI subcommands

It implements stable ACP methods, and on top of it other opinionated conveniences like message queueing, persisted sessions, and so on

I am currently working to integrate it into openclaw, so that you can use acp compatible harnesses directly in e.g. discord threads, without the main openclaw agent in the middle

README should give some idea: https://github.com/openclaw/acpx

Let me know if you need more clarification