### PR TITLE
docs: add Minion Mind to agents list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -18,6 +18,8 @@ The following clients can be used with an ACP Agent:
 - Emacs via [agent-shell.el](https://github.com/xenodium/agent-shell)
 - [JetBrains](https://www.jetbrains.com/help/ai-assistant/acp.html)
 - [marimo notebook](https://github.com/marimo-team/marimo)
+- [Minion Mind](https://minion-mind.nebulame.com/)
+  - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
 - [Mitto](https://github.com/inercia/mitto)
 - [neovim](https://neovim.io)
   - through the [CodeCompanion](https://github.com/olimorris/codecompanion.nvim) plugin


### PR DESCRIPTION
## Summary
- Adds [Minion Mind](https://minion-mind.nebulame.com/) to the list of ACP-compatible agents
- Minion Mind supports ACP through the [Obsidian Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin

## Test plan
- [x] Verify the link to Minion Mind works
- [x] Verify alphabetical ordering is maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)