### PR TITLE
fix: remove duplicate word typos across docs and source

### DIFF
--- a/docs/protocol/draft/schema.mdx
+++ b/docs/protocol/draft/schema.mdx
@@ -1417,7 +1417,7 @@ changed at any point.
 
 Cancels an ongoing request.
 
-This is a notification sent by the the side that sent a request to cancel that request.
+This is a notification sent by the side that sent a request to cancel that request.
 
 Upon receiving this notification, the receiver:
 

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -35,11 +35,11 @@ The RFD for indicating whether a diff resulted in a file deletion has been moved
 <Update label="February 18, 2025" tags={["Governance"]}>
 ## Sergey Ignatov is now a Lead Maintainer
 
-It is with great pleasure that I announce that Sergey Ignatov, from JetBrains, will be joining me as a Lead Maintainer role for ACP. Agus Zubiaga will remain a key part of the the leadership group as a Core Maintainer.
+It is with great pleasure that I announce that Sergey Ignatov, from JetBrains, will be joining me as a Lead Maintainer role for ACP. Agus Zubiaga will remain a key part of the leadership group as a Core Maintainer.
 
 This is in recognition for Sergey's many contributions to the protocol, we would not be where we are today without his efforts. In the past few months, Zed and JetBrains have been able to collaborate closely on the protocol, and it is time to reflect that fact more formally in our governance structure.
 
-I have enjoyed the chance to work with Sergey and the entire JetBrains team. There is still much work to be done, but with all of the agent and client teams working together, I am confident we can continue to make the ACP vision a reality. Allowing you to collaborate with the agent(s) you love wherever you are are already working.
+I have enjoyed the chance to work with Sergey and the entire JetBrains team. There is still much work to be done, but with all of the agent and client teams working together, I am confident we can continue to make the ACP vision a reality. Allowing you to collaborate with the agent(s) you love wherever you are already working.
 
 **Ben Brandt** / Zed Industries / ACP Lead Maintainer
 

--- a/schema/schema.unstable.json
+++ b/schema/schema.unstable.json
@@ -4113,7 +4113,7 @@
               "$ref": "#/$defs/CancelRequestNotification"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or\nchanged at any point.\n\nCancels an ongoing request.\n\nThis is a notification sent by the the side that sent a request to cancel that request.\n\nUpon receiving this notification, the receiver:\n\n1. MUST cancel the corresponding request activity and all nested activities\n2. MAY send any pending notifications.\n3. MUST send one of these responses for the original request:\n  - Valid response with appropriate data (partial results or cancellation marker)\n  - Error response with code `-32800` (Cancelled)\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/cancellation)",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or\nchanged at any point.\n\nCancels an ongoing request.\n\nThis is a notification sent by the side that sent a request to cancel that request.\n\nUpon receiving this notification, the receiver:\n\n1. MUST cancel the corresponding request activity and all nested activities\n2. MAY send any pending notifications.\n3. MUST send one of these responses for the original request:\n  - Valid response with appropriate data (partial results or cancellation marker)\n  - Error response with code `-32800` (Cancelled)\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/cancellation)",
           "title": "CancelRequestNotification"
         }
       ],

--- a/src/maybe_undefined.rs
+++ b/src/maybe_undefined.rs
@@ -57,7 +57,7 @@ impl<T> MaybeUndefined<T> {
         matches!(self, MaybeUndefined::Value(_))
     }
 
-    /// Borrow the value, returns `None` if the the `MaybeUndefined<T>` is
+    /// Borrow the value, returns `None` if the `MaybeUndefined<T>` is
     /// `undefined` or `null`, otherwise returns `Some(T)`.
     #[inline]
     pub const fn value(&self) -> Option<&T> {

--- a/src/protocol_level.rs
+++ b/src/protocol_level.rs
@@ -93,7 +93,7 @@ pub enum ProtocolLevelNotification {
     ///
     /// Cancels an ongoing request.
     ///
-    /// This is a notification sent by the the side that sent a request to cancel that request.
+    /// This is a notification sent by the side that sent a request to cancel that request.
     ///
     /// Upon receiving this notification, the receiver:
     ///


### PR DESCRIPTION
## Summary

- Fix "the the" → "the" in `src/maybe_undefined.rs` doc comment for `MaybeUndefined::value()`
- Fix "the the" → "the" in `src/protocol_level.rs` doc comment for `CancelRequestNotification`
- Fix "the the" → "the" in `docs/updates.mdx` governance announcement
- Fix "are are" → "are" in `docs/updates.mdx` governance announcement
- Regenerated schema files to reflect source changes

## Test plan

- [x] `npm run check` passes (clippy, formatting, spellcheck, tests)
- [x] `npm run generate` produces no additional diff