### PR TITLE
docs: fix incomplete sentence in KillTerminalCommandRequest doc comment

### DIFF
--- a/docs/protocol/draft/schema.mdx
+++ b/docs/protocol/draft/schema.mdx
@@ -1181,7 +1181,7 @@ This method can be helpful when implementing command timeouts which terminate
 the command as soon as elapsed, and then get the final output so it can be sent
 to the model.
 
-Note: `terminal/release` when `TerminalId` is no longer needed.
+Note: Call `terminal/release` when `TerminalId` is no longer needed.
 
 See protocol docs: [Terminals](https://agentclientprotocol.com/protocol/terminals)
 

--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -852,7 +852,7 @@ This method can be helpful when implementing command timeouts which terminate
 the command as soon as elapsed, and then get the final output so it can be sent
 to the model.
 
-Note: `terminal/release` when `TerminalId` is no longer needed.
+Note: Call `terminal/release` when `TerminalId` is no longer needed.
 
 See protocol docs: [Terminals](https://agentclientprotocol.com/protocol/terminals)
 

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -170,7 +170,7 @@
                       "$ref": "#/$defs/KillTerminalCommandRequest"
                     }
                   ],
-                  "description": "Kills the terminal command without releasing the terminal\n\nWhile `terminal/release` will also kill the command, this method will keep\nthe `TerminalId` valid so it can be used with other methods.\n\nThis method can be helpful when implementing command timeouts which terminate\nthe command as soon as elapsed, and then get the final output so it can be sent\nto the model.\n\nNote: `terminal/release` when `TerminalId` is no longer needed.\n\nSee protocol docs: [Terminals](https://agentclientprotocol.com/protocol/terminals)",
+                  "description": "Kills the terminal command without releasing the terminal\n\nWhile `terminal/release` will also kill the command, this method will keep\nthe `TerminalId` valid so it can be used with other methods.\n\nThis method can be helpful when implementing command timeouts which terminate\nthe command as soon as elapsed, and then get the final output so it can be sent\nto the model.\n\nNote: Call `terminal/release` when `TerminalId` is no longer needed.\n\nSee protocol docs: [Terminals](https://agentclientprotocol.com/protocol/terminals)",
                   "title": "KillTerminalCommandRequest"
                 },
                 {

--- a/schema/schema.unstable.json
+++ b/schema/schema.unstable.json
@@ -170,7 +170,7 @@
                       "$ref": "#/$defs/KillTerminalCommandRequest"
                     }
                   ],
-                  "description": "Kills the terminal command without releasing the terminal\n\nWhile `terminal/release` will also kill the command, this method will keep\nthe `TerminalId` valid so it can be used with other methods.\n\nThis method can be helpful when implementing command timeouts which terminate\nthe command as soon as elapsed, and then get the final output so it can be sent\nto the model.\n\nNote: `terminal/release` when `TerminalId` is no longer needed.\n\nSee protocol docs: [Terminals](https://agentclientprotocol.com/protocol/terminals)",
+                  "description": "Kills the terminal command without releasing the terminal\n\nWhile `terminal/release` will also kill the command, this method will keep\nthe `TerminalId` valid so it can be used with other methods.\n\nThis method can be helpful when implementing command timeouts which terminate\nthe command as soon as elapsed, and then get the final output so it can be sent\nto the model.\n\nNote: Call `terminal/release` when `TerminalId` is no longer needed.\n\nSee protocol docs: [Terminals](https://agentclientprotocol.com/protocol/terminals)",
                   "title": "KillTerminalCommandRequest"
                 },
                 {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1681,7 +1681,7 @@ pub enum AgentRequest {
     /// the command as soon as elapsed, and then get the final output so it can be sent
     /// to the model.
     ///
-    /// Note: `terminal/release` when `TerminalId` is no longer needed.
+    /// Note: Call `terminal/release` when `TerminalId` is no longer needed.
     ///
     /// See protocol docs: [Terminals](https://agentclientprotocol.com/protocol/terminals)
     KillTerminalCommandRequest(KillTerminalCommandRequest),


### PR DESCRIPTION
## Summary

- Fix sentence fragment in `KillTerminalCommandRequest` doc comment in `src/client.rs`
- Changed "Note: `terminal/release` when..." → "Note: Call `terminal/release` when..."
- The original was missing the verb "Call", matching the style already used in the same doc block ("allowing the Agent to call `terminal/output`")
- Regenerated schema files to reflect the change

## Test plan

- [x] `npm run check` passes (clippy, formatting, spellcheck, tests)
- [x] `npm run generate` produces no additional diff