### PR TITLE
docs: add OpenClaw to agents list

### DIFF
--- a/docs/get-started/agents.mdx
+++ b/docs/get-started/agents.mdx
@@ -25,6 +25,7 @@ The following agents can be used with an ACP Client:
 - [Kiro CLI](https://kiro.dev/docs/cli/acp/)
 - [Minion Code](https://github.com/femto/minion-code)
 - [Mistral Vibe](https://github.com/mistralai/mistral-vibe)
+- [OpenClaw](https://docs.openclaw.ai/cli/acp)
 - [OpenCode](https://github.com/sst/opencode)
 - [OpenHands](https://docs.openhands.dev/openhands/usage/run-openhands/acp)
 - [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) (via [pi-acp adapter](https://github.com/svkozak/pi-acp))


### PR DESCRIPTION
In addition to be ACP Client, the OpenClaw could also act as ACP Agent: https://docs.openclaw.ai/cli/acp
ACP Client could talk to OpenClaw Gateway via ACP.

Samples:

1. Zed editor setup: https://docs.openclaw.ai/cli/acp#zed-editor-setup
2. Run OpenClaw in VS Code through ACP: https://dev.to/formulahendry/run-openclaw-in-vs-code-through-acp-agent-client-protocol-4amo