### PR TITLE
docs: add Telegram ACP Bot to clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -31,6 +31,7 @@ The following clients can be used with an ACP Agent:
   - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
 - [OpenClaw](https://docs.openclaw.ai/tools/acp-agents)
 - [Sidequery _(coming soon)_](https://sidequery.dev)
+- [Telegram ACP Bot](https://github.com/mgaitan/telegram-acp-bot) (Telegram)
 - [Tidewave](https://tidewave.ai/)
 - [Toad](https://www.batrachian.ai/)
 - Visual Studio Code


### PR DESCRIPTION
Adds Telegram ACP Bot to the clients list in alphabetical order. 

https://github.com/mgaitan/telegram-acp-bot