### PR TITLE
docs: add fabriqa.ai to clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -16,6 +16,7 @@ The following clients can be used with an ACP Agent:
 - DuckDB
   - through the [sidequery/duckdb-acp](https://github.com/sidequery/duckdb-acp) extension
 - Emacs via [agent-shell.el](https://github.com/xenodium/agent-shell)
+- [fabriqa.ai](https://fabriqa.ai)
 - [JetBrains](https://www.jetbrains.com/help/ai-assistant/acp.html)
 - [Juan](https://github.com/DiscreteTom/juan) (Slack)
 - [marimo notebook](https://github.com/marimo-team/marimo)


### PR DESCRIPTION
## Summary
- Add [fabriqa.ai](https://fabriqa.ai) to the clients list in alphabetical order