### PR TITLE
docs: update RFD dates to 2026

### DIFF
--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -4,35 +4,35 @@ description: Updates and announcements about the Agent Client Protocol
 rss: true
 ---
 
-<Update label="February 24, 2025" tags={["RFD"]}>
+<Update label="February 24, 2026" tags={["RFD"]}>
 ## session/stop RFD moves to Draft stage
 
 The RFD for allowing agents to close or stop a given session has been moved to Draft stage. Please review the [RFD](./rfds/session-stop) for more information on the current proposal and provide feedback as work on the implementation begins.
 
 </Update>
 
-<Update label="February 24, 2025" tags={["RFD"]}>
+<Update label="February 24, 2026" tags={["RFD"]}>
 ## Elicitation RFD moves to Draft stage
 
 The RFD for allowing agents to elicit user input has been moved to Draft stage. Please review the [RFD](./rfds/elicitation) for more information on the current proposal and provide feedback as work on the implementation begins.
 
 </Update>
 
-<Update label="February 24, 2025" tags={["RFD"]}>
+<Update label="February 24, 2026" tags={["RFD"]}>
 ## Boolean Config Option RFD moves to Draft stage
 
 The RFD for adding boolean config options to the protocol has been moved to Draft stage. Please review the [RFD](./rfds/boolean-config-option) for more information on the current proposal and provide feedback as work on the implementation begins.
 
 </Update>
 
-<Update label="February 20, 2025" tags={["RFD"]}>
+<Update label="February 20, 2026" tags={["RFD"]}>
 ## Delete in Diff RFD moves to Draft stage
 
 The RFD for indicating whether a diff resulted in a file deletion has been moved to Draft stage. Please review the [RFD](./rfds/diff-delete) for more information on the current proposal and provide feedback as work on the implementation begins.
 
 </Update>
 
-<Update label="February 18, 2025" tags={["Governance"]}>
+<Update label="February 18, 2026" tags={["Governance"]}>
 ## Sergey Ignatov is now a Lead Maintainer
 
 It is with great pleasure that I announce that Sergey Ignatov, from JetBrains, will be joining me as a Lead Maintainer role for ACP. Agus Zubiaga will remain a key part of the leadership group as a Core Maintainer.
@@ -45,35 +45,35 @@ I have enjoyed the chance to work with Sergey and the entire JetBrains team. The
 
 </Update>
 
-<Update label="February 18, 2025" tags={["RFD"]}>
+<Update label="February 18, 2026" tags={["RFD"]}>
 ## Message ID RFD moves to Draft stage
 
 The RFD for adding message ids to the protocol has been moved to Draft stage. Please review the [RFD](./rfds/message-id) for more information on the current proposal and provide feedback as work on the implementation begins.
 
 </Update>
 
-<Update label="February 18, 2025" tags={["RFD"]}>
+<Update label="February 18, 2026" tags={["RFD"]}>
 ## session/list RFD moves to Preview stage
 
 The RFD for the session/list method has been moved to Preview stage. Please review the [RFD](./rfds/session-list) for more information on the current proposal and provide feedback before the feature is stabilized.
 
 </Update>
 
-<Update label="February 18, 2025" tags={["RFD"]}>
+<Update label="February 18, 2026" tags={["RFD"]}>
 ## session_info_update RFD moves to Preview stage
 
 The RFD for the session_info_update notification has been moved to Preview stage. Please review the [RFD](./rfds/session-info-update) for more information on the current proposal and provide feedback before the feature is stabilized.
 
 </Update>
 
-<Update label="February 10, 2025" tags={["RFD"]}>
+<Update label="February 10, 2026" tags={["RFD"]}>
 ## ACP Registry RFD moves to Preview stage
 
 The RFD for the ACP Registry has been moved to Preview stage. Please review the [RFD](./rfds/acp-agent-registry) for more information on the current proposal and provide feedback before the feature is stabilized.
 
 </Update>
 
-<Update label="February 4, 2025" tags={["RFD"]}>
+<Update label="February 4, 2026" tags={["RFD"]}>
 ## Session Config Options RFD moves to Completed
 
 The RFD for adding more generic Session Config Options to the protocol has been stabilized and is now a part of the protocol. Please review the [documentation](./protocol/session-config-options) for more information.
@@ -101,7 +101,7 @@ The RFD for basing the Rust SDK on SACP has been moved to Draft stage. Please re
 
 </Update>
 
-<Update label="January 15, 2025" tags={["RFD"]}>
+<Update label="January 15, 2026" tags={["RFD"]}>
 ## Session Config Options RFD moves to Preview stage
 
 The RFD for adding more generic Session Config Options to the protocol has been moved to Preview stage. Please review the [RFD](./rfds/session-config-options) for more information on the current proposal and provide feedback before the feature is stabilized.


### PR DESCRIPTION
This PR fix incorrect years in the `updates` documentation.

Some update entries in `docs/updates.mdx` still used the year **2025** even though they correspond to updates from **2026**.  
This PR corrects those labels to keep the update timeline accurate.