### PR TITLE
docs: expand clients ecosystem page

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -1,42 +1,87 @@
 ---
 title: "Clients"
-description: "Clients implementing the Agent Client Protocol."
+description: "Clients, frameworks, connectors, and related tools around the Agent Client Protocol."
 ---
 
-The following clients can be used with an ACP Agent:
+The following projects implement ACP directly, connect ACP agents to other environments, or support adjacent coding-agent workflows.
 
-- [ACP UI](https://github.com/formulahendry/acp-ui)
-- [acpx (CLI)](https://github.com/openclaw/acpx)
-- [Agent Studio](https://github.com/sxhxliang/agent-studio)
-- [Agmente](https://agmente.halliharp.com) (iOS)
-- [AionUi](https://github.com/iOfficeAI/AionUi)
-- [aizen](https://aizen.win)
+## Editors and IDEs
+
 - [Chrome ACP](https://github.com/Areo-Joe/chrome-acp) (Chrome extension / PWA)
-- [DeepChat](https://github.com/ThinkInAIXYZ/deepchat)
-- DuckDB
-  - through the [sidequery/duckdb-acp](https://github.com/sidequery/duckdb-acp) extension
 - Emacs via [agent-shell.el](https://github.com/xenodium/agent-shell)
-- [fabriqa.ai](https://fabriqa.ai)
 - [JetBrains](https://www.jetbrains.com/help/ai-assistant/acp.html)
-- [Juan](https://github.com/DiscreteTom/juan) (Slack)
-- [marimo notebook](https://github.com/marimo-team/marimo)
-- [Minion Mind](https://minion-mind.nebulame.com/)
-  - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
-- [Mitto](https://github.com/inercia/mitto)
 - [neovim](https://neovim.io)
   - through the [CodeCompanion](https://github.com/olimorris/codecompanion.nvim) plugin
   - through the [carlos-algms/agentic.nvim](https://github.com/carlos-algms/agentic.nvim) plugin
   - through the [yetone/avante.nvim](https://github.com/yetone/avante.nvim) plugin
-- [Nori CLI](https://github.com/tilework-tech/nori-cli)
 - [Obsidian](https://obsidian.md)
   - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
-- [OpenClaw](https://docs.openclaw.ai/tools/acp-agents)
-- [RayClaw](https://github.com/rayclaw/rayclaw?tab=readme-ov-file#acp-agent-client-protocol)
-- [Sidequery _(coming soon)_](https://sidequery.dev)
-- [Telegram ACP Bot](https://github.com/mgaitan/telegram-acp-bot) (Telegram)
-- [Tidewave](https://tidewave.ai/)
-- [Toad](https://www.batrachian.ai/)
+- [Unity Agent Client](https://github.com/nuskey8/UnityAgentClient) (Unity editor)
 - Visual Studio Code
   - through the [ACP Client](https://github.com/formulahendry/vscode-acp) extension
-- [Web Browser with AI SDK](https://github.com/mcpc-tech/ai-elements-remix-template) (powered by [@mcpc/acp-ai-provider](https://github.com/mcpc-tech/mcpc/tree/main/packages/acp-ai-provider))
 - [Zed](https://zed.dev/docs/ai/external-agents)
+
+## Clients and apps
+
+- [ACP UI](https://github.com/formulahendry/acp-ui)
+- [acpx (CLI)](https://github.com/openclaw/acpx)
+- [Agent Studio](https://github.com/sxhxliang/agent-studio)
+- [AionUi](https://github.com/iOfficeAI/AionUi)
+- [aizen](https://aizen.win)
+- [DeepChat](https://github.com/ThinkInAIXYZ/deepchat)
+- [fabriqa.ai](https://fabriqa.ai)
+- [Minion Mind](https://minion-mind.nebulame.com/)
+  - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
+- [Mitto](https://github.com/inercia/mitto)
+- [Nori CLI](https://github.com/tilework-tech/nori-cli)
+- [RayClaw](https://github.com/rayclaw/rayclaw?tab=readme-ov-file#acp-agent-client-protocol)
+- [Sidequery _(coming soon)_](https://sidequery.dev)
+- [Tidewave](https://tidewave.ai/)
+- [Toad](https://www.batrachian.ai/)
+- [Web Browser with AI SDK](https://github.com/mcpc-tech/ai-elements-remix-template) (powered by [@mcpc/acp-ai-provider](https://github.com/mcpc-tech/mcpc/tree/main/packages/acp-ai-provider))
+
+## Notebook and data tools
+
+- [agent-client-kernel](https://github.com/wiki3-ai/agent-client-kernel) (Jupyter notebooks)
+- DuckDB
+  - through the [sidequery/duckdb-acp](https://github.com/sidequery/duckdb-acp) extension
+- [marimo notebook](https://github.com/marimo-team/marimo)
+
+## Mobile clients
+
+These mobile-first tools bring ACP and related coding-agent workflows to phones and tablets:
+
+- [Agmente](https://agmente.halliharp.com) ([GitHub](https://github.com/rebornix/Agmente)) (iOS)
+- [Happy](https://happy.engineering/) ([GitHub](https://github.com/slopus/happy)) (iOS, Android, Web)
+
+## Messaging
+
+- [Juan](https://github.com/DiscreteTom/juan) (Slack)
+- [Telegram ACP Bot](https://github.com/mgaitan/telegram-acp-bot) (Telegram)
+  - through the [`telegram-acp-bot`](https://github.com/mgaitan/telegram-acp-bot) connector
+
+## Frameworks
+
+These frameworks add ACP support through dedicated integrations or adapters:
+
+- [AgentPool](https://phil65.github.io/agentpool/)
+  - with built-in ACP integration for IDEs and external ACP agents
+- [fast-agent](https://fast-agent.ai/acp/)
+  - through [`fast-agent-acp`](https://fast-agent.ai/acp/)
+- [Koog](https://docs.koog.ai/agent-client-protocol/)
+  - through the [`agents-features-acp`](https://github.com/JetBrains/koog/tree/develop/examples/notebooks/acp) integration
+- [LangChain / LangGraph](https://docs.langchain.com/oss/python/deepagents/acp)
+  - through [Deep Agents ACP](https://docs.langchain.com/oss/python/deepagents/acp)
+- [LlamaIndex](https://github.com/AstraBert/workflows-acp)
+  - through the [`workflows-acp`](https://github.com/AstraBert/workflows-acp) adapter for Agent Workflows
+- [LLMling-Agent](https://github.com/phil65/llmling-agent)
+  - with built-in ACP support for running agents through ACP clients
+
+## Connectors
+
+These connectors bridge ACP into other environments and transport layers:
+
+- [Aptove Bridge](https://github.com/aptove/bridge)
+  - bridges stdio-based ACP agents to the Aptove mobile client over WebSocket
+- [OpenClaw](https://docs.openclaw.ai/cli/acp)
+  - through the [`openclaw acp`](https://docs.openclaw.ai/cli/acp) bridge to an OpenClaw Gateway


### PR DESCRIPTION
- reorganize the clients page into clearer sections
- add missing ACP frameworks, connectors, notebook, and mobile tools
- keep mobile entries linked to both product sites and GitHub repos