### PR TITLE
Add RLM-Code as ACP Client

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -35,6 +35,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Mitto](https://github.com/inercia/mitto)
 - [Nori CLI](https://github.com/tilework-tech/nori-cli)
 - [RayClaw](https://github.com/rayclaw/rayclaw?tab=readme-ov-file#acp-agent-client-protocol)
+- [RLM Code](https://github.com/SuperagenticAI/rlm-code)
 - [Sidequery _(coming soon)_](https://sidequery.dev)
 - [Tidewave](https://tidewave.ai/)
 - [Toad](https://www.batrachian.ai/)


### PR DESCRIPTION
 ## Summary

  Add RLM Code to the ACP clients page.

  ## Why

  RLM Code uses ACP as a client connection mode for external ACP agents via `/connect acp`, and includes ACP agent discovery in its UI. It does not implement an ACP agent/
  server entrypoint itself, so it belongs on the clients page rather than in the ACP agent registry.

  ## Project

  - Repo: https://github.com/SuperagenticAI/rlm-code
  - Docs: https://superagenticai.github.io/rlm-code/