### PR TITLE
docs(clients): add Ngent to clients and apps list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -34,7 +34,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
   - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
 - [Mitto](https://github.com/inercia/mitto)
 - [Nori CLI](https://github.com/tilework-tech/nori-cli)
-- [Ngent](https://github.com/beyond5959/ngent) (Web UI + HTTP API wrapper for ACP-compatible agents)
+- [Ngent](https://github.com/beyond5959/ngent)
 - [RayClaw](https://github.com/rayclaw/rayclaw?tab=readme-ov-file#acp-agent-client-protocol)
 - [Sidequery _(coming soon)_](https://sidequery.dev)
 - [Tidewave](https://tidewave.ai/)


### PR DESCRIPTION
Add Ngent to docs/get-started/clients.mdx under "Clients and apps" as a Web UI + HTTP API wrapper for ACP-compatible agents.