### PR TITLE
docs: flatten single-item sublists on clients page

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -14,11 +14,9 @@ The following projects implement ACP directly, connect ACP agents to other envir
   - through the [CodeCompanion](https://github.com/olimorris/codecompanion.nvim) plugin
   - through the [carlos-algms/agentic.nvim](https://github.com/carlos-algms/agentic.nvim) plugin
   - through the [yetone/avante.nvim](https://github.com/yetone/avante.nvim) plugin
-- [Obsidian](https://obsidian.md)
-  - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
+- [Obsidian](https://obsidian.md) — through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
 - [Unity Agent Client](https://github.com/nuskey8/UnityAgentClient) (Unity editor)
-- Visual Studio Code
-  - through the [ACP Client](https://github.com/formulahendry/vscode-acp) extension
+- Visual Studio Code — through the [ACP Client](https://github.com/formulahendry/vscode-acp) extension
 - [Zed](https://zed.dev/docs/ai/external-agents)
 
 ## Clients and apps
@@ -30,8 +28,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [aizen](https://aizen.win)
 - [DeepChat](https://github.com/ThinkInAIXYZ/deepchat)
 - [fabriqa.ai](https://fabriqa.ai)
-- [Minion Mind](https://minion-mind.nebulame.com/)
-  - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
+- [Minion Mind](https://minion-mind.nebulame.com/) — through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
 - [Mitto](https://github.com/inercia/mitto)
 - [Nori CLI](https://github.com/tilework-tech/nori-cli)
 - [RayClaw](https://github.com/rayclaw/rayclaw?tab=readme-ov-file#acp-agent-client-protocol)
@@ -43,8 +40,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 ## Notebook and data tools
 
 - [agent-client-kernel](https://github.com/wiki3-ai/agent-client-kernel) (Jupyter notebooks)
-- DuckDB
-  - through the [sidequery/duckdb-acp](https://github.com/sidequery/duckdb-acp) extension
+- DuckDB — through the [sidequery/duckdb-acp](https://github.com/sidequery/duckdb-acp) extension
 - [marimo notebook](https://github.com/marimo-team/marimo)
 
 ## Mobile clients
@@ -57,31 +53,22 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 ## Messaging
 
 - [Juan](https://github.com/DiscreteTom/juan) (Slack)
-- [Telegram ACP Bot](https://github.com/mgaitan/telegram-acp-bot) (Telegram)
-  - through the [`telegram-acp-bot`](https://github.com/mgaitan/telegram-acp-bot) connector
+- [Telegram ACP Bot](https://github.com/mgaitan/telegram-acp-bot) (Telegram) — through the [`telegram-acp-bot`](https://github.com/mgaitan/telegram-acp-bot) connector
 
 ## Frameworks
 
 These frameworks add ACP support through dedicated integrations or adapters:
 
-- [AgentPool](https://phil65.github.io/agentpool/)
-  - with built-in ACP integration for IDEs and external ACP agents
-- [fast-agent](https://fast-agent.ai/acp/)
-  - through [`fast-agent-acp`](https://fast-agent.ai/acp/)
-- [Koog](https://docs.koog.ai/agent-client-protocol/)
-  - through the [`agents-features-acp`](https://github.com/JetBrains/koog/tree/develop/examples/notebooks/acp) integration
-- [LangChain / LangGraph](https://docs.langchain.com/oss/python/deepagents/acp)
-  - through [Deep Agents ACP](https://docs.langchain.com/oss/python/deepagents/acp)
-- [LlamaIndex](https://github.com/AstraBert/workflows-acp)
-  - through the [`workflows-acp`](https://github.com/AstraBert/workflows-acp) adapter for Agent Workflows
-- [LLMling-Agent](https://github.com/phil65/llmling-agent)
-  - with built-in ACP support for running agents through ACP clients
+- [AgentPool](https://phil65.github.io/agentpool/) — with built-in ACP integration for IDEs and external ACP agents
+- [fast-agent](https://fast-agent.ai/acp/) — through [`fast-agent-acp`](https://fast-agent.ai/acp/)
+- [Koog](https://docs.koog.ai/agent-client-protocol/) — through the [`agents-features-acp`](https://github.com/JetBrains/koog/tree/develop/examples/notebooks/acp) integration
+- [LangChain / LangGraph](https://docs.langchain.com/oss/python/deepagents/acp) — through [Deep Agents ACP](https://docs.langchain.com/oss/python/deepagents/acp)
+- [LlamaIndex](https://github.com/AstraBert/workflows-acp) — through the [`workflows-acp`](https://github.com/AstraBert/workflows-acp) adapter for Agent Workflows
+- [LLMling-Agent](https://github.com/phil65/llmling-agent) — with built-in ACP support for running agents through ACP clients
 
 ## Connectors
 
 These connectors bridge ACP into other environments and transport layers:
 
-- [Aptove Bridge](https://github.com/aptove/bridge)
-  - bridges stdio-based ACP agents to the Aptove mobile client over WebSocket
-- [OpenClaw](https://docs.openclaw.ai/cli/acp)
-  - through the [`openclaw acp`](https://docs.openclaw.ai/cli/acp) bridge to an OpenClaw Gateway
+- [Aptove Bridge](https://github.com/aptove/bridge) — bridges stdio-based ACP agents to the Aptove mobile client over WebSocket
+- [OpenClaw](https://docs.openclaw.ai/cli/acp) — through the [`openclaw acp`](https://docs.openclaw.ai/cli/acp) bridge to an OpenClaw Gateway


### PR DESCRIPTION
- flatten single-item nested bullets on the clients page
- keep nested lists only where they add value, like neovim plugin variants
- leave the rest of the ecosystem grouping unchanged