### PR TITLE
Add Harnss to Clients and Apps List

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -28,7 +28,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [aizen](https://aizen.win)
 - [DeepChat](https://github.com/ThinkInAIXYZ/deepchat)
 - [fabriqa.ai](https://fabriqa.ai)
-- [Harnss](https://github.com/OpenSource03/harnss) — open-source desktop client for running multiple AI coding agents side by side
+- [Harnss](https://github.com/OpenSource03/harnss)
 - [Minion Mind](https://minion-mind.nebulame.com/) — through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
 - [Mitto](https://github.com/inercia/mitto)
 - [Nori CLI](https://github.com/tilework-tech/nori-cli)


### PR DESCRIPTION

![harnss-banner](https://github.com/user-attachments/assets/6cd3bacb-cae7-4a04-8511-dce110813ef4)


Adds `Harnss` (https://github.com/OpenSource03/harnss) to the list of projects implementing ACP directly in `docs/get-started/clients.mdx`.

---

Harnss is a workspace designed for **agentic coding**, giving coding agents a proper UI instead of scattered terminal sessions. It supports multiple agents like Claude Code, Codex, OpenCode, and Copilot CLI in a single environment. You can run multiple sessions side-by-side, organize projects with Spaces, and monitor what your agents and subagents are doing. With built-in browser context, terminal, and Git management, Harnss provides a centralized environment for working with coding agents.

While it has first-class support for Codex and Claude Code, **there is full ACP support and ACP registry with 1-click install integrated in the project.**

Would appreciate adding it to the list :)