### PR TITLE
feat(unstable): Rename unstable session/stop method to session/close

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ unstable = [
     "unstable_session_list",
     "unstable_session_model",
     "unstable_session_resume",
-    "unstable_session_stop",
+    "unstable_session_close",
     "unstable_session_usage",
     "unstable_message_id",
     "unstable_boolean_config",
@@ -34,7 +34,7 @@ unstable_session_info_update = []
 unstable_session_list = []
 unstable_session_model = []
 unstable_session_resume = []
-unstable_session_stop = []
+unstable_session_close = []
 unstable_session_usage = []
 unstable_message_id = []
 unstable_boolean_config = []

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -123,7 +123,7 @@
               "rfds/diff-delete",
               "rfds/boolean-config-option",
               "rfds/elicitation",
-              "rfds/session-stop"
+              "rfds/session-close"
             ]
           },
           {
@@ -206,6 +206,11 @@
       "source": "/registry",
       "destination": "/get-started/registry",
       "permanent": false
+    },
+    {
+      "source": "/rfds/session-stop",
+      "destination": "/rfds/session-close",
+      "permanent": true
     }
   ]
 }

--- a/docs/protocol/draft/schema.mdx
+++ b/docs/protocol/draft/schema.mdx
@@ -196,6 +196,71 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
   The ID of the session to cancel operations for.
 </ResponseField>
 
+<a id="session-close"></a>
+### <span class="font-mono">session/close</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Closes an active session and frees up any resources associated with it.
+
+This method is only available if the agent advertises the `session.close` capability.
+
+The agent must cancel any ongoing work (as if `session/cancel` was called)
+and then free up any resources associated with the session.
+
+#### <span class="font-mono">CloseSessionRequest</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Request parameters for closing an active session.
+
+If supported, the agent **must** cancel any ongoing work related to the session
+(treat it as if `session/cancel` was called) and then free up any resources
+associated with the session.
+
+Only available if the Agent supports the `session.close` capability.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+
+</ResponseField>
+<ResponseField name="sessionId" type={<a href="#sessionid">SessionId</a>} required>
+  The ID of the session to close.
+</ResponseField>
+
+#### <span class="font-mono">CloseSessionResponse</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Response from closing a session.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+
+</ResponseField>
+
 <a id="session-fork"></a>
 ### <span class="font-mono">session/fork</span>
 
@@ -883,71 +948,6 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
 Response to `session/set_model` method.
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField name="_meta" type={"object | null"} >
-  The _meta property is reserved by ACP to allow clients and agents to attach additional
-metadata to their interactions. Implementations MUST NOT make assumptions about values at
-these keys.
-
-See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-
-</ResponseField>
-
-<a id="session-stop"></a>
-### <span class="font-mono">session/stop</span>
-
-**UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-Stops an active session and frees up any resources associated with it.
-
-This method is only available if the agent advertises the `session.stop` capability.
-
-The agent must cancel any ongoing work (as if `session/cancel` was called)
-and then free up any resources associated with the session.
-
-#### <span class="font-mono">StopSessionRequest</span>
-
-**UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-Request parameters for stopping an active session.
-
-If supported, the agent **must** cancel any ongoing work related to the session
-(treat it as if `session/cancel` was called) and then free up any resources
-associated with the session.
-
-Only available if the Agent supports the `session.stop` capability.
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField name="_meta" type={"object | null"} >
-  The _meta property is reserved by ACP to allow clients and agents to attach additional
-metadata to their interactions. Implementations MUST NOT make assumptions about values at
-these keys.
-
-See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-
-</ResponseField>
-<ResponseField name="sessionId" type={<a href="#sessionid">SessionId</a>} required>
-  The ID of the session to stop.
-</ResponseField>
-
-#### <span class="font-mono">StopSessionResponse</span>
-
-**UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-Response from stopping a session.
 
 **Type:** Object
 
@@ -3387,12 +3387,35 @@ This capability is not part of the spec yet, and may be removed or changed at an
 Whether the agent supports `session/resume`.
 
 </ResponseField>
-<ResponseField name="stop" type={<><span><a href="#sessionstopcapabilities">SessionStopCapabilities</a></span><span> | null</span></>} >
+<ResponseField name="stop" type={<><span><a href="#sessionclosecapabilities">SessionCloseCapabilities</a></span><span> | null</span></>} >
   **UNSTABLE**
 
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
-Whether the agent supports `session/stop`.
+Whether the agent supports `session/close`.
+
+</ResponseField>
+
+## <span class="font-mono">SessionCloseCapabilities</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Capabilities for the `session/close` method.
+
+By supplying `\{\}` it means that the agent supports closing of sessions.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
 
 </ResponseField>
 
@@ -3804,29 +3827,6 @@ This capability is not part of the spec yet, and may be removed or changed at an
 Capabilities for the `session/resume` method.
 
 By supplying `\{\}` it means that the agent supports resuming of sessions.
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField name="_meta" type={"object | null"} >
-  The _meta property is reserved by ACP to allow clients and agents to attach additional
-metadata to their interactions. Implementations MUST NOT make assumptions about values at
-these keys.
-
-See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-
-</ResponseField>
-
-## <span class="font-mono">SessionStopCapabilities</span>
-
-**UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-Capabilities for the `session/stop` method.
-
-By supplying `\{\}` it means that the agent supports stopping of sessions.
 
 **Type:** Object
 

--- a/docs/rfds/session-close.mdx
+++ b/docs/rfds/session-close.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Stopping active sessions"
+title: "Closing active sessions"
 ---
 
 Author(s): [@SteffenDE](https://github.com/SteffenDE)
@@ -8,7 +8,7 @@ Author(s): [@SteffenDE](https://github.com/SteffenDE)
 
 > What are you proposing to change?
 
-We propose adding the ability to stop active sessions. This allows the agent to free up any memory
+We propose adding the ability to close active sessions. This allows the agent to free up any memory
 and threads/subprocesses associated with that session.
 
 ## Status quo
@@ -29,7 +29,7 @@ lead to a bad user experience.
 
 > What are you proposing to improve the situation?
 
-Add a new `session/stop` method. If supported, the agent **must** cancel any ongoing work
+Add a new `session/close` method. If supported, the agent **must** cancel any ongoing work
 related to the session (treat it as if `session/cancel` was called) and then free up any resources
 associated with the session.
 
@@ -37,23 +37,23 @@ associated with the session.
 
 > How will things will play out once this feature exists?
 
-Clients can track what sessions are actively used by a user and automatically stop old sessions.
+Clients can track what sessions are actively used by a user and automatically close old sessions.
 
 ## Implementation details and plan
 
 > Tell me more about your implementation. What is your detailed implementation plan?
 
-We propose to add a new `"session/stop"` method. Agents must declare this option is
-available by returning `session: { stop : {} }` in their capabilities. The object is reserved
+We propose to add a new `"session/close"` method. Agents must declare this option is
+available by returning `session: { close : {} }` in their capabilities. The object is reserved
 to declare future capabilities.
 
-Then the client would be able to stop a specific session with:
+Then the client would be able to close a specific session with:
 
 ```json
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "method": "session/stop",
+  "method": "session/close",
   "params": {
     "sessionId": "sess_789xyz"
   }
@@ -76,4 +76,5 @@ seems like a good idea.
 
 ## Revision history
 
+2026-03-09: Rename from session/stop to session/close
 2026-02-24: Initial draft

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -5,9 +5,9 @@ rss: true
 ---
 
 <Update label="February 24, 2026" tags={["RFD"]}>
-## session/stop RFD moves to Draft stage
+## session/close RFD moves to Draft stage
 
-The RFD for allowing agents to close or stop a given session has been moved to Draft stage. Please review the [RFD](./rfds/session-stop) for more information on the current proposal and provide feedback as work on the implementation begins.
+The RFD for allowing agents to close a given session has been moved to Draft stage. Please review the [RFD](./rfds/session-close) for more information on the current proposal and provide feedback as work on the implementation begins.
 
 </Update>
 

--- a/schema/meta.unstable.json
+++ b/schema/meta.unstable.json
@@ -3,6 +3,7 @@
     "authenticate": "authenticate",
     "initialize": "initialize",
     "session_cancel": "session/cancel",
+    "session_close": "session/close",
     "session_fork": "session/fork",
     "session_list": "session/list",
     "session_load": "session/load",
@@ -11,8 +12,7 @@
     "session_resume": "session/resume",
     "session_set_config_option": "session/set_config_option",
     "session_set_mode": "session/set_mode",
-    "session_set_model": "session/set_model",
-    "session_stop": "session/stop"
+    "session_set_model": "session/set_model"
   },
   "clientMethods": {
     "fs_read_text_file": "fs/read_text_file",

--- a/schema/schema.unstable.json
+++ b/schema/schema.unstable.json
@@ -263,10 +263,10 @@
                 {
                   "allOf": [
                     {
-                      "$ref": "#/$defs/StopSessionResponse"
+                      "$ref": "#/$defs/CloseSessionResponse"
                     }
                   ],
-                  "title": "StopSessionResponse"
+                  "title": "CloseSessionResponse"
                 },
                 {
                   "allOf": [
@@ -890,11 +890,11 @@
                 {
                   "allOf": [
                     {
-                      "$ref": "#/$defs/StopSessionRequest"
+                      "$ref": "#/$defs/CloseSessionRequest"
                     }
                   ],
-                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nStops an active session and frees up any resources associated with it.\n\nThis method is only available if the agent advertises the `session.stop` capability.\n\nThe agent must cancel any ongoing work (as if `session/cancel` was called)\nand then free up any resources associated with the session.",
-                  "title": "StopSessionRequest"
+                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCloses an active session and frees up any resources associated with it.\n\nThis method is only available if the agent advertises the `session.close` capability.\n\nThe agent must cancel any ongoing work (as if `session/cancel` was called)\nand then free up any resources associated with the session.",
+                  "title": "CloseSessionRequest"
                 },
                 {
                   "allOf": [
@@ -1058,6 +1058,41 @@
         }
       ],
       "x-docs-ignore": true
+    },
+    "CloseSessionRequest": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest parameters for closing an active session.\n\nIf supported, the agent **must** cancel any ongoing work related to the session\n(treat it as if `session/cancel` was called) and then free up any resources\nassociated with the session.\n\nOnly available if the Agent supports the `session.close` capability.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        },
+        "sessionId": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ],
+          "description": "The ID of the session to close."
+        }
+      },
+      "required": ["sessionId"],
+      "type": "object",
+      "x-method": "session/close",
+      "x-side": "agent"
+    },
+    "CloseSessionResponse": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nResponse from closing a session.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        }
+      },
+      "type": "object",
+      "x-method": "session/close",
+      "x-side": "agent"
     },
     "ConfigOptionUpdate": {
       "description": "Session configuration options have been updated.",
@@ -2871,13 +2906,24 @@
         "stop": {
           "anyOf": [
             {
-              "$ref": "#/$defs/SessionStopCapabilities"
+              "$ref": "#/$defs/SessionCloseCapabilities"
             },
             {
               "type": "null"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/stop`."
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/close`."
+        }
+      },
+      "type": "object"
+    },
+    "SessionCloseCapabilities": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for the `session/close` method.\n\nBy supplying `{}` it means that the agent supports closing of sessions.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
         }
       },
       "type": "object"
@@ -3306,17 +3352,6 @@
       },
       "type": "object"
     },
-    "SessionStopCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for the `session/stop` method.\n\nBy supplying `{}` it means that the agent supports stopping of sessions.",
-      "properties": {
-        "_meta": {
-          "additionalProperties": true,
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-          "type": ["object", "null"]
-        }
-      },
-      "type": "object"
-    },
     "SessionUpdate": {
       "description": "Different types of updates that can be sent during session processing.\n\nThese updates provide real-time feedback about the agent's progress.\n\nSee protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protocol/prompt-turn#3-agent-reports-output)",
       "discriminator": {
@@ -3700,41 +3735,6 @@
           "type": "string"
         }
       ]
-    },
-    "StopSessionRequest": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest parameters for stopping an active session.\n\nIf supported, the agent **must** cancel any ongoing work related to the session\n(treat it as if `session/cancel` was called) and then free up any resources\nassociated with the session.\n\nOnly available if the Agent supports the `session.stop` capability.",
-      "properties": {
-        "_meta": {
-          "additionalProperties": true,
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-          "type": ["object", "null"]
-        },
-        "sessionId": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/SessionId"
-            }
-          ],
-          "description": "The ID of the session to stop."
-        }
-      },
-      "required": ["sessionId"],
-      "type": "object",
-      "x-method": "session/stop",
-      "x-side": "agent"
-    },
-    "StopSessionResponse": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nResponse from stopping a session.",
-      "properties": {
-        "_meta": {
-          "additionalProperties": true,
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-          "type": ["object", "null"]
-        }
-      },
-      "type": "object",
-      "x-method": "session/stop",
-      "x-side": "agent"
     },
     "Terminal": {
       "description": "Embed a terminal created with `terminal/create` by its id.\n\nThe terminal must be added before calling `terminal/release`.\n\nSee protocol docs: [Terminal](https://agentclientprotocol.com/protocol/terminals)",

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1287,26 +1287,26 @@ impl ResumeSessionResponse {
     }
 }
 
-// Stop session
+// Close session
 
 /// **UNSTABLE**
 ///
 /// This capability is not part of the spec yet, and may be removed or changed at any point.
 ///
-/// Request parameters for stopping an active session.
+/// Request parameters for closing an active session.
 ///
 /// If supported, the agent **must** cancel any ongoing work related to the session
 /// (treat it as if `session/cancel` was called) and then free up any resources
 /// associated with the session.
 ///
-/// Only available if the Agent supports the `session.stop` capability.
-#[cfg(feature = "unstable_session_stop")]
+/// Only available if the Agent supports the `session.close` capability.
+#[cfg(feature = "unstable_session_close")]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[schemars(extend("x-side" = "agent", "x-method" = SESSION_STOP_METHOD_NAME))]
+#[schemars(extend("x-side" = "agent", "x-method" = SESSION_CLOSE_METHOD_NAME))]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct StopSessionRequest {
-    /// The ID of the session to stop.
+pub struct CloseSessionRequest {
+    /// The ID of the session to close.
     pub session_id: SessionId,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
     /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
@@ -1317,8 +1317,8 @@ pub struct StopSessionRequest {
     pub meta: Option<Meta>,
 }
 
-#[cfg(feature = "unstable_session_stop")]
-impl StopSessionRequest {
+#[cfg(feature = "unstable_session_close")]
+impl CloseSessionRequest {
     #[must_use]
     pub fn new(session_id: impl Into<SessionId>) -> Self {
         Self {
@@ -1343,13 +1343,13 @@ impl StopSessionRequest {
 ///
 /// This capability is not part of the spec yet, and may be removed or changed at any point.
 ///
-/// Response from stopping a session.
-#[cfg(feature = "unstable_session_stop")]
+/// Response from closing a session.
+#[cfg(feature = "unstable_session_close")]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[schemars(extend("x-side" = "agent", "x-method" = SESSION_STOP_METHOD_NAME))]
+#[schemars(extend("x-side" = "agent", "x-method" = SESSION_CLOSE_METHOD_NAME))]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct StopSessionResponse {
+pub struct CloseSessionResponse {
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
     /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
     /// these keys.
@@ -1359,8 +1359,8 @@ pub struct StopSessionResponse {
     pub meta: Option<Meta>,
 }
 
-#[cfg(feature = "unstable_session_stop")]
-impl StopSessionResponse {
+#[cfg(feature = "unstable_session_close")]
+impl CloseSessionResponse {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -3161,10 +3161,10 @@ pub struct SessionCapabilities {
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
-    /// Whether the agent supports `session/stop`.
-    #[cfg(feature = "unstable_session_stop")]
+    /// Whether the agent supports `session/close`.
+    #[cfg(feature = "unstable_session_close")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub stop: Option<SessionStopCapabilities>,
+    pub stop: Option<SessionCloseCapabilities>,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
     /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
     /// these keys.
@@ -3204,10 +3204,10 @@ impl SessionCapabilities {
         self
     }
 
-    #[cfg(feature = "unstable_session_stop")]
-    /// Whether the agent supports `session/stop`.
+    #[cfg(feature = "unstable_session_close")]
+    /// Whether the agent supports `session/close`.
     #[must_use]
-    pub fn stop(mut self, stop: impl IntoOption<SessionStopCapabilities>) -> Self {
+    pub fn stop(mut self, stop: impl IntoOption<SessionCloseCapabilities>) -> Self {
         self.stop = stop.into_option();
         self
     }
@@ -3342,13 +3342,13 @@ impl SessionResumeCapabilities {
 ///
 /// This capability is not part of the spec yet, and may be removed or changed at any point.
 ///
-/// Capabilities for the `session/stop` method.
+/// Capabilities for the `session/close` method.
 ///
-/// By supplying `{}` it means that the agent supports stopping of sessions.
-#[cfg(feature = "unstable_session_stop")]
+/// By supplying `{}` it means that the agent supports closing of sessions.
+#[cfg(feature = "unstable_session_close")]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[non_exhaustive]
-pub struct SessionStopCapabilities {
+pub struct SessionCloseCapabilities {
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
     /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
     /// these keys.
@@ -3358,8 +3358,8 @@ pub struct SessionStopCapabilities {
     pub meta: Option<Meta>,
 }
 
-#[cfg(feature = "unstable_session_stop")]
-impl SessionStopCapabilities {
+#[cfg(feature = "unstable_session_close")]
+impl SessionCloseCapabilities {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -3544,9 +3544,9 @@ pub struct AgentMethodNames {
     /// Method for resuming an existing session.
     #[cfg(feature = "unstable_session_resume")]
     pub session_resume: &'static str,
-    /// Method for stopping an active session.
-    #[cfg(feature = "unstable_session_stop")]
-    pub session_stop: &'static str,
+    /// Method for closing an active session.
+    #[cfg(feature = "unstable_session_close")]
+    pub session_close: &'static str,
 }
 
 /// Constant containing all agent method names.
@@ -3567,8 +3567,8 @@ pub const AGENT_METHOD_NAMES: AgentMethodNames = AgentMethodNames {
     session_fork: SESSION_FORK_METHOD_NAME,
     #[cfg(feature = "unstable_session_resume")]
     session_resume: SESSION_RESUME_METHOD_NAME,
-    #[cfg(feature = "unstable_session_stop")]
-    session_stop: SESSION_STOP_METHOD_NAME,
+    #[cfg(feature = "unstable_session_close")]
+    session_close: SESSION_CLOSE_METHOD_NAME,
 };
 
 /// Method name for the initialize request.
@@ -3599,9 +3599,9 @@ pub(crate) const SESSION_FORK_METHOD_NAME: &str = "session/fork";
 /// Method name for resuming an existing session.
 #[cfg(feature = "unstable_session_resume")]
 pub(crate) const SESSION_RESUME_METHOD_NAME: &str = "session/resume";
-/// Method name for stopping an active session.
-#[cfg(feature = "unstable_session_stop")]
-pub(crate) const SESSION_STOP_METHOD_NAME: &str = "session/stop";
+/// Method name for closing an active session.
+#[cfg(feature = "unstable_session_close")]
+pub(crate) const SESSION_CLOSE_METHOD_NAME: &str = "session/close";
 
 /// All possible requests that a client can send to an agent.
 ///
@@ -3695,18 +3695,18 @@ pub enum ClientRequest {
     /// The agent should resume the session context, allowing the conversation to continue
     /// without replaying the message history (unlike `session/load`).
     ResumeSessionRequest(ResumeSessionRequest),
-    #[cfg(feature = "unstable_session_stop")]
+    #[cfg(feature = "unstable_session_close")]
     /// **UNSTABLE**
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
-    /// Stops an active session and frees up any resources associated with it.
+    /// Closes an active session and frees up any resources associated with it.
     ///
-    /// This method is only available if the agent advertises the `session.stop` capability.
+    /// This method is only available if the agent advertises the `session.close` capability.
     ///
     /// The agent must cancel any ongoing work (as if `session/cancel` was called)
     /// and then free up any resources associated with the session.
-    StopSessionRequest(StopSessionRequest),
+    CloseSessionRequest(CloseSessionRequest),
     /// Sets the current mode for a session.
     ///
     /// Allows switching between different agent modes (e.g., "ask", "architect", "code")
@@ -3766,8 +3766,8 @@ impl ClientRequest {
             Self::ForkSessionRequest(_) => AGENT_METHOD_NAMES.session_fork,
             #[cfg(feature = "unstable_session_resume")]
             Self::ResumeSessionRequest(_) => AGENT_METHOD_NAMES.session_resume,
-            #[cfg(feature = "unstable_session_stop")]
-            Self::StopSessionRequest(_) => AGENT_METHOD_NAMES.session_stop,
+            #[cfg(feature = "unstable_session_close")]
+            Self::CloseSessionRequest(_) => AGENT_METHOD_NAMES.session_close,
             Self::SetSessionModeRequest(_) => AGENT_METHOD_NAMES.session_set_mode,
             Self::SetSessionConfigOptionRequest(_) => AGENT_METHOD_NAMES.session_set_config_option,
             Self::PromptRequest(_) => AGENT_METHOD_NAMES.session_prompt,
@@ -3800,8 +3800,8 @@ pub enum AgentResponse {
     ForkSessionResponse(ForkSessionResponse),
     #[cfg(feature = "unstable_session_resume")]
     ResumeSessionResponse(#[serde(default)] ResumeSessionResponse),
-    #[cfg(feature = "unstable_session_stop")]
-    StopSessionResponse(#[serde(default)] StopSessionResponse),
+    #[cfg(feature = "unstable_session_close")]
+    CloseSessionResponse(#[serde(default)] CloseSessionResponse),
     SetSessionModeResponse(#[serde(default)] SetSessionModeResponse),
     SetSessionConfigOptionResponse(SetSessionConfigOptionResponse),
     PromptResponse(PromptResponse),

--- a/src/bin/generate.rs
+++ b/src/bin/generate.rs
@@ -943,7 +943,7 @@ starting with '$/' it is free to ignore the notification."
                 "session/prompt" => self.agent.get("PromptRequest").unwrap(),
                 "session/cancel" => self.agent.get("CancelNotification").unwrap(),
                 "session/set_model" => self.agent.get("SetSessionModelRequest").unwrap(),
-                "session/stop" => self.agent.get("StopSessionRequest").unwrap(),
+                "session/close" => self.agent.get("CloseSessionRequest").unwrap(),
                 _ => panic!("Introduced a method? Add it here :)"),
             }
         }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -292,9 +292,9 @@ impl Side for AgentSide {
             m if m == AGENT_METHOD_NAMES.session_resume => serde_json::from_str(params.get())
                 .map(ClientRequest::ResumeSessionRequest)
                 .map_err(Into::into),
-            #[cfg(feature = "unstable_session_stop")]
-            m if m == AGENT_METHOD_NAMES.session_stop => serde_json::from_str(params.get())
-                .map(ClientRequest::StopSessionRequest)
+            #[cfg(feature = "unstable_session_close")]
+            m if m == AGENT_METHOD_NAMES.session_close => serde_json::from_str(params.get())
+                .map(ClientRequest::CloseSessionRequest)
                 .map_err(Into::into),
             m if m == AGENT_METHOD_NAMES.session_set_mode => serde_json::from_str(params.get())
                 .map(ClientRequest::SetSessionModeRequest)


### PR DESCRIPTION
This better encapsulates the usage and differentiates it more from
session/cancel
