### PR TITLE
docs: Fix typo in config_option_update - should be singular

### DIFF
--- a/docs/protocol/session-config-options.mdx
+++ b/docs/protocol/session-config-options.mdx
@@ -227,7 +227,7 @@ The Agent **MUST** respond with the complete list of all configuration options a
 
 ### From the Agent
 
-The Agent can also change configuration options and notify the Client by sending a `config_options_update` session notification:
+The Agent can also change configuration options and notify the Client by sending a `config_option_update` session notification:
 
 ```json
 {
@@ -236,7 +236,7 @@ The Agent can also change configuration options and notify the Client by sending
   "params": {
     "sessionId": "sess_abc123def456",
     "update": {
-      "sessionUpdate": "config_options_update",
+      "sessionUpdate": "config_option_update",
       "configOptions": [
         {
           "id": "mode",


### PR DESCRIPTION
## Summary

The `session-config-options.mdx` page uses `"config_options_update"` (plural) as the `sessionUpdate` discriminator value, but the schema (`schema.md`) defines it as `"config_option_update"` (singular)

## References

- Schema definition uses `ConfigOptionUpdate` → `"config_option_update"`
- Both Claude and Codex ACP send `"config_option_update"` (singular):
  - [claude-agent-acp](https://github.com/zed-industries/claude-agent-acp) (`src/acp-agent.ts`)
  - [codex-acp](https://github.com/zed-industries/codex-acp) (`src/thread.rs` via `SessionUpdate::ConfigOptionUpdate`)