### PR TITLE
Add Mobvibe to mobile clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -52,6 +52,7 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 
 - [Agmente](https://agmente.halliharp.com) ([GitHub](https://github.com/rebornix/Agmente)) (iOS)
 - [Happy](https://happy.engineering/) ([GitHub](https://github.com/slopus/happy)) (iOS, Android, Web)
+- [Mobvibe](https://app.mobvibe.net) ([GitHub](https://github.com/Eric-Song-Nop/mobvibe)) (Android, Web)
 
 ## Messaging
 


### PR DESCRIPTION
## Summary
- add Mobvibe to the ACP clients page under `Mobile clients`
- link both the product site and GitHub repository
- list current platform support as Android and Web only

## Mobvibe
Mobvibe is a mobile-first client for interacting with coding agents remotely, and this adds it to the public ACP client directory alongside similar mobile clients such as Happy.
