### PR TITLE
Update ecosystem docs for new clients and libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Learn more at [agentclientprotocol.com](https://agentclientprotocol.com/).
 - [Clients](https://agentclientprotocol.com/overview/clients)
 - Official Libraries
   - **Kotlin**: [`acp-kotlin`](https://github.com/agentclientprotocol/kotlin-sdk) - Supports JVM, other targets are in progress, see [samples](https://github.com/agentclientprotocol/kotlin-sdk/tree/master/samples/kotlin-acp-client-sample/src/main/kotlin/com/agentclientprotocol/samples)
+  - **Java**: [`java-sdk`](https://github.com/agentclientprotocol/java-sdk) - See [examples](https://github.com/agentclientprotocol/java-sdk/tree/main/examples)
   - **Python**: [`python-sdk`](https://github.com/agentclientprotocol/python-sdk) - See [examples](https://github.com/agentclientprotocol/python-sdk/tree/main/examples)
   - **Rust**: [`agent-client-protocol`](https://crates.io/crates/agent-client-protocol) - See [examples/agent.rs](https://github.com/agentclientprotocol/rust-sdk/blob/main/examples/agent.rs) and [examples/client.rs](https://github.com/agentclientprotocol/rust-sdk/blob/main/examples/client.rs)
   - **TypeScript**: [`@agentclientprotocol/sdk`](https://www.npmjs.com/package/@agentclientprotocol/sdk) - See [examples/](https://github.com/agentclientprotocol/typescript-sdk/tree/main/src/examples)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -92,6 +92,7 @@
             "group": "Libraries",
             "pages": [
               "libraries/kotlin",
+              "libraries/java",
               "libraries/python",
               "libraries/rust",
               "libraries/typescript",

--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -23,6 +23,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 
 - [ACP UI](https://github.com/formulahendry/acp-ui)
 - [acpx (CLI)](https://github.com/openclaw/acpx)
+- [gemini-cli-desktop](https://github.com/Piebald-AI/gemini-cli-desktop)
 - [Agent Studio](https://github.com/sxhxliang/agent-studio)
 - [AionUi](https://github.com/iOfficeAI/AionUi)
 - [aizen](https://aizen.win)
@@ -52,9 +53,12 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 
 - [Agmente](https://agmente.halliharp.com) ([GitHub](https://github.com/rebornix/Agmente)) (iOS)
 - [Happy](https://happy.engineering/) ([GitHub](https://github.com/slopus/happy)) (iOS, Android, Web)
+- [Mobvibe](https://github.com/Eric-Song-Nop/mobvibe) (iOS, Android, Web)
 
 ## Messaging
 
+- [ACP Discord](https://github.com/broven/acp-discord) (Discord)
+- [duckdb-claude-slack](https://github.com/sidequery/duckdb-claude-slack) (Slack)
 - [Juan](https://github.com/DiscreteTom/juan) (Slack)
 - [Telegram ACP Bot](https://github.com/mgaitan/telegram-acp-bot) (Telegram) — through the [`telegram-acp-bot`](https://github.com/mgaitan/telegram-acp-bot) connector
 

--- a/docs/libraries/community.mdx
+++ b/docs/libraries/community.mdx
@@ -7,6 +7,10 @@ description: "Community managed libraries for the Agent Client Protocol"
 
 - [acp_dart](https://github.com/SkrOYC/acp-dart)
 
+## .NET
+
+- [acpdotnet](https://github.com/microsoft/acpdotnet)
+
 ## Emacs
 
 - [acp.el](https://github.com/xenodium/acp.el)
@@ -14,10 +18,15 @@ description: "Community managed libraries for the Agent Client Protocol"
 ## Go
 
 - [acp-go-sdk](https://github.com/coder/acp-go-sdk)
+- [acp-go](https://github.com/ironpark/acp-go)
 
 ## React
 
 - [use-acp](https://github.com/marimo-team/use-acp)
+
+## TypeScript
+
+- [acp-ts-sdk](https://github.com/langwatch/acp-ts-sdk)
 
 ## Swift
 

--- a/docs/libraries/java.mdx
+++ b/docs/libraries/java.mdx
@@ -1,0 +1,10 @@
+---
+title: "Java"
+description: "Java library for the Agent Client Protocol"
+---
+
+The [java-sdk](https://github.com/agentclientprotocol/java-sdk) provides Java models, JSON-RPC plumbing, and side-specific connection helpers for building ACP-compatible agents and clients.
+
+The repository includes runnable examples for client and agent implementations, plus Spring AI integrations, under [`examples/`](https://github.com/agentclientprotocol/java-sdk/tree/main/examples).
+
+For dependency setup and API details, see the repository README and published Javadocs from the project.


### PR DESCRIPTION
## Summary
- add the official Java SDK to the docs and navigation
- expand the community libraries page with additional ACP libraries
- expand the clients page with newly found ACP apps and messaging clients

## Testing
- npx prettier --check README.md docs/docs.json docs/get-started/clients.mdx docs/libraries/community.mdx docs/libraries/java.mdx