### PR TITLE
Fix typo in publications page

### DIFF
--- a/docs/publications.mdx
+++ b/docs/publications.mdx
@@ -55,6 +55,6 @@ description: ACP publications, talks, presentations, and videos
     href="https://www.youtube.com/watch?v=n11pDnBXPgk"
     horizontal
   >
-    Conversation with Ben North, Sergey Ignatov, and Jan-Niklas Wortmann
+    Conversation with Ben Brandt, Sergey Ignatov, and Jan-Niklas Wortmann
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- fix the speaker name in `docs/publications.mdx`

## Testing
- not run (docs typo fix)