### PR TITLE
Use raw publication links

### DIFF
--- a/docs/publications.mdx
+++ b/docs/publications.mdx
@@ -5,10 +5,12 @@ description: ACP publications, talks, presentations, and videos
 
 ## Talks
 
+{/* Mintlify files note for future updates: https://www.mintlify.com/docs/create/files#files — Supported file types for Enterprise plans: Documents: .pdf, .txt; Data: .xml, .csv; Archives: .zip. */}
+
 <CardGroup cols={1}>
   <Card
     title="AI Builders Berlin: Agents in the IDE"
-    href="/assets/publications/ACP Talk Berlin, 2025.11.26.pdf"
+    href="https://raw.githubusercontent.com/agentclientprotocol/agent-client-protocol/main/docs/assets/publications/ACP%20Talk%20Berlin%2C%202025.11.26.pdf"
     horizontal
   >
     November 26, 2025 · Ben Brandt
@@ -16,7 +18,7 @@ description: ACP publications, talks, presentations, and videos
 
 <Card
   title="OpenAI | Codex Meetup Berlin: Integrating Codex Into IntelliJ"
-  href="/assets/publications/ACP AppServer, Berlin, 28.01.26.pdf"
+  href="https://raw.githubusercontent.com/agentclientprotocol/agent-client-protocol/main/docs/assets/publications/ACP%20AppServer%2C%20Berlin%2C%2028.01.26.pdf"
   horizontal
 >
   January 28, 2026 · Anna Zhdan
@@ -24,7 +26,7 @@ description: ACP publications, talks, presentations, and videos
 
 <Card
   title="AI Builders Amsterdam: AI Agents and IDEs"
-  href="/assets/publications/ACP talk Amsterdam, 29.01.26.pdf"
+  href="https://raw.githubusercontent.com/agentclientprotocol/agent-client-protocol/main/docs/assets/publications/ACP%20talk%20Amsterdam%2C%2029.01.26.pdf"
   horizontal
 >
   January 29, 2026 · Sergey Ignatov
@@ -32,7 +34,7 @@ description: ACP publications, talks, presentations, and videos
 
 <Card
   title="JUG Bern: Your AI Agent In Any Editor"
-  href="/assets/publications/ACP Schweiz, 17.02.26.pdf"
+  href="https://raw.githubusercontent.com/agentclientprotocol/agent-client-protocol/main/docs/assets/publications/ACP%20Schweiz%2C%2017.02.26.pdf"
   horizontal
 >
   February 11, 2026 · Anna Zhdan
@@ -40,7 +42,7 @@ description: ACP publications, talks, presentations, and videos
 
 <Card
   title="Munich AI Tech Meetup @ JetBrains: Your AI Agent In Any Editor"
-  href="/assets/publications/ACP München, 25.02.26.pdf"
+  href="https://raw.githubusercontent.com/agentclientprotocol/agent-client-protocol/main/docs/assets/publications/ACP%20M%C3%BCnchen%2C%2025.02.26.pdf"
   horizontal
 >
   February 25, 2026 · Anna Zhdan
@@ -48,7 +50,7 @@ description: ACP publications, talks, presentations, and videos
 
   <Card
     title="London Agentic AI Meetup"
-    href="/assets/publications/ACP talk London, 11.03.26.pdf"
+    href="https://raw.githubusercontent.com/agentclientprotocol/agent-client-protocol/main/docs/assets/publications/ACP%20talk%20London%2C%2011.03.26.pdf"
     horizontal
   >
     March 11, 2026 · Ben Brandt, Sergey Ignatov


### PR DESCRIPTION
## Summary
- switch publication cards to raw GitHub PDF URLs
- add a Mintlify files note for future publication updates

## Verification
- tested the links in local Mint preview
- ran `npm run format:check`