### PR TITLE
Add Telegram-ACP to clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -62,6 +62,7 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 - [duckdb-claude-slack](https://github.com/sidequery/duckdb-claude-slack) (Slack)
 - [Juan](https://github.com/DiscreteTom/juan) (Slack)
 - [Telegram ACP Bot](https://github.com/mgaitan/telegram-acp-bot) (Telegram) — through the [`telegram-acp-bot`](https://github.com/mgaitan/telegram-acp-bot) connector
+- [Telegram-ACP](https://github.com/SuperKenVery/Telegram-ACP/) (Telegram) — Supports multi-thread chat and message streaming
 
 ## Frameworks
 


### PR DESCRIPTION
[Telegram-ACP](https://github.com/SuperKenVery/Telegram-ACP/) is my telegram bot that allows multi-threaded chat and message streaming