### PR TITLE
Add WeChat ACP to the clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -63,6 +63,7 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 - [Juan](https://github.com/DiscreteTom/juan) (Slack)
 - [Telegram ACP Bot](https://github.com/mgaitan/telegram-acp-bot) (Telegram) — through the [`telegram-acp-bot`](https://github.com/mgaitan/telegram-acp-bot) connector
 - [Telegram-ACP](https://github.com/SuperKenVery/Telegram-ACP/) (Telegram) — Supports multi-thread chat and message streaming
+- [WeChat ACP](https://github.com/formulahendry/wechat-acp) (WeChat)
 
 ## Frameworks
 


### PR DESCRIPTION
Bridge WeChat direct messages to any ACP-compatible AI agent.

![wechat-acp](https://github.com/user-attachments/assets/4157e45b-4ecb-466a-ac49-0a023b7d4be1)

