### PR TITLE
fix mcp right name in docs

### DIFF
--- a/docs/protocol/initialization.mdx
+++ b/docs/protocol/initialization.mdx
@@ -68,7 +68,7 @@ The Agent **MUST** respond with the chosen [protocol version](#protocol-version)
         "audio": true,
         "embeddedContext": true
       },
-      "mcp": {
+      "mcpCapabilities": {
         "http": true,
         "sse": true
       }


### PR DESCRIPTION
## Summary

Fixes incorrect field name `mcp` → `mcpCapabilities` in the initialization documentation example.

## Changes

- **docs/protocol/initialization.mdx**: Changed `"mcp":` to `"mcpCapabilities":` in the `initialize` response example (line 71)

## Problem

The JSON example in the initialization documentation showed an incorrect field name:

```json
"agentCapabilities": {
  "mcp": {        // Incorrect
    "http": true,
    "sse": true
  }
}
```
This was inconsistent with:
- The JSON schema (`schema/schema.json` defines `mcpCapabilities`)
- The Rust implementation (`src/agent.rs` defines `mcp_capabilities` field)
- All other documentation examples (e.g., `docs/protocol/session-setup.mdx`)