### PR TITLE
add tests for the Role enum

### DIFF
--- a/src/content.rs
+++ b/src/content.rs
@@ -505,3 +505,43 @@ pub enum Role {
     Assistant,
     User,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_role_assistant_serialize() {
+        let role = Role::Assistant;
+        let json = serde_json::to_value(role).unwrap();
+        assert_eq!(json, serde_json::json!("assistant"));
+    }
+
+    #[test]
+    fn test_role_user_serialize() {
+        let role = Role::User;
+        let json = serde_json::to_value(role).unwrap();
+        assert_eq!(json, serde_json::json!("user"));
+    }
+
+    #[test]
+    fn test_role_assistant_deserialize() {
+        let role: Role = serde_json::from_value(serde_json::json!("assistant")).unwrap();
+        assert_eq!(role, Role::Assistant);
+    }
+
+    #[test]
+    fn test_role_user_deserialize() {
+        let role: Role = serde_json::from_value(serde_json::json!("user")).unwrap();
+        assert_eq!(role, Role::User);
+    }
+
+    #[test]
+    fn test_role_roundtrip() {
+        for role in [Role::Assistant, Role::User] {
+            let json = serde_json::to_value(&role).unwrap();
+            let parsed: Role = serde_json::from_value(json).unwrap();
+            assert_eq!(role, parsed);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add tests for the `Role` enum in `src/content.rs`.

## Changes

- **src/content.rs**: Added `#[cfg(test)] mod tests` with 5 test cases for the `Role` enum

## Test Coverage

| Test | Description |
|------|-------------|
| `test_role_assistant_serialize` | Verifies `Role::Assistant` serializes to `"assistant"` |
| `test_role_user_serialize` | Verifies `Role::User` serializes to `"user"` |
| `test_role_assistant_deserialize` | Verifies `"assistant"` deserializes to `Role::Assistant` |
| `test_role_user_deserialize` | Verifies `"user"` deserializes to `Role::User` |
| `test_role_roundtrip` | Verifies serialize → deserialize yields same value for all variants |

## Motivation

The `Role` enum and the `content.rs` module currently have **zero test coverage**. 
This is the first PR in a series to add comprehensive tests for the content module. I also want to know if you want me to finish  adding tests or not

## Testing

- [x] `cargo test` - all 34 tests pass
- [x] `cargo clippy` - no warnings
