### PR TITLE
fix(rpc): preserve '_' prefix for extension methods and reject empty ext

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -23,6 +23,9 @@ pub type Meta = serde_json::Map<String, serde_json::Value>;
 #[serde(transparent)]
 #[non_exhaustive]
 pub struct ExtRequest {
+    /// Wire method name for this extension request.
+    ///
+    /// Extension method names must start with `_`, and the name is preserved exactly.
     #[serde(skip)] // this is used for routing, but when serializing we only want the params
     pub method: Arc<str>,
     #[schemars(with = "serde_json::Value")]
@@ -65,6 +68,9 @@ impl ExtResponse {
 #[serde(transparent)]
 #[non_exhaustive]
 pub struct ExtNotification {
+    /// Wire method name for this extension notification.
+    ///
+    /// Extension method names must start with `_`, and the name is preserved exactly.
     #[serde(skip)] // this is used for routing, but when serializing we only want the params
     pub method: Arc<str>,
     #[schemars(with = "serde_json::Value")]

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -25,7 +25,7 @@ pub type Meta = serde_json::Map<String, serde_json::Value>;
 pub struct ExtRequest {
     /// Wire method name for this extension request.
     ///
-    /// Extension method names must start with `_`, and the name is preserved exactly.
+    /// Extension method names must start with `_`.
     #[serde(skip)] // this is used for routing, but when serializing we only want the params
     pub method: Arc<str>,
     #[schemars(with = "serde_json::Value")]
@@ -70,7 +70,7 @@ impl ExtResponse {
 pub struct ExtNotification {
     /// Wire method name for this extension notification.
     ///
-    /// Extension method names must start with `_`, and the name is preserved exactly.
+    /// Extension method names must start with `_`.
     #[serde(skip)] // this is used for routing, but when serializing we only want the params
     pub method: Arc<str>,
     #[schemars(with = "serde_json::Value")]

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -220,9 +220,9 @@ impl Side for ClientSide {
                 .map(AgentRequest::ElicitationRequest)
                 .map_err(Into::into),
             _ => {
-                if let Some(custom_method) = method.strip_prefix('_') {
+                if is_valid_ext_method(method) {
                     Ok(AgentRequest::ExtMethodRequest(ExtRequest {
-                        method: custom_method.into(),
+                        method: method.into(),
                         params: params.to_owned().into(),
                     }))
                 } else {
@@ -246,9 +246,9 @@ impl Side for ClientSide {
                     .map_err(Into::into)
             }
             _ => {
-                if let Some(custom_method) = method.strip_prefix('_') {
+                if is_valid_ext_method(method) {
                     Ok(AgentNotification::ExtNotification(ExtNotification {
-                        method: custom_method.into(),
+                        method: method.into(),
                         params: params.to_owned().into(),
                     }))
                 } else {
@@ -337,9 +337,9 @@ impl Side for AgentSide {
                 .map(ClientRequest::CloseNesRequest)
                 .map_err(Into::into),
             _ => {
-                if let Some(custom_method) = method.strip_prefix('_') {
+                if is_valid_ext_method(method) {
                     Ok(ClientRequest::ExtMethodRequest(ExtRequest {
-                        method: custom_method.into(),
+                        method: method.into(),
                         params: params.to_owned().into(),
                     }))
                 } else {
@@ -385,9 +385,9 @@ impl Side for AgentSide {
                 .map(ClientNotification::RejectNesNotification)
                 .map_err(Into::into),
             _ => {
-                if let Some(custom_method) = method.strip_prefix('_') {
+                if is_valid_ext_method(method) {
                     Ok(ClientNotification::ExtNotification(ExtNotification {
-                        method: custom_method.into(),
+                        method: method.into(),
                         params: params.to_owned().into(),
                     }))
                 } else {
@@ -398,11 +398,16 @@ impl Side for AgentSide {
     }
 }
 
+fn is_valid_ext_method(method: &str) -> bool {
+    method.starts_with('_') && method.len() > 1
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use serde_json::{Number, Value};
+    use crate::ErrorCode;
+    use serde_json::{Number, Value, json};
 
     #[test]
     fn id_deserialization() {
@@ -449,6 +454,43 @@ mod tests {
 
         let id = RequestId::Str("id".to_owned());
         assert_eq!(id.to_string(), "id");
+    }
+
+    #[test]
+    fn decode_ext_request_preserves_prefix_on_client_side() {
+        let raw = serde_json::value::RawValue::from_string(r#"{"x":1}"#.to_string()).unwrap();
+        let request = ClientSide::decode_request("_vendor/custom_request", Some(&raw)).unwrap();
+        assert_eq!(request.method(), "_vendor/custom_request");
+    }
+
+    #[test]
+    fn decode_ext_request_preserves_prefix_on_agent_side() {
+        let raw = serde_json::value::RawValue::from_string(r#"{"x":1}"#.to_string()).unwrap();
+        let request = AgentSide::decode_request("_vendor/custom_request", Some(&raw)).unwrap();
+        assert_eq!(request.method(), "_vendor/custom_request");
+    }
+
+    #[test]
+    fn decode_ext_notification_preserves_prefix_on_client_side() {
+        let raw = serde_json::value::RawValue::from_string(r#"{"x":1}"#.to_string()).unwrap();
+        let notification =
+            ClientSide::decode_notification("_vendor/custom_notification", Some(&raw)).unwrap();
+        assert_eq!(notification.method(), "_vendor/custom_notification");
+    }
+
+    #[test]
+    fn decode_ext_notification_preserves_prefix_on_agent_side() {
+        let raw = serde_json::value::RawValue::from_string(r#"{"x":1}"#.to_string()).unwrap();
+        let notification =
+            AgentSide::decode_notification("_vendor/custom_notification", Some(&raw)).unwrap();
+        assert_eq!(notification.method(), "_vendor/custom_notification");
+    }
+
+    #[test]
+    fn decode_rejects_empty_ext_method_name() {
+        let raw = serde_json::value::RawValue::from_string(json!({}).to_string()).unwrap();
+        let err = ClientSide::decode_request("_", Some(&raw)).unwrap_err();
+        assert_eq!(err.code, ErrorCode::MethodNotFound);
     }
 }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -221,10 +221,10 @@ impl Side for ClientSide {
                 .map_err(Into::into),
             _ => {
                 if is_valid_ext_method(method) {
-                    Ok(AgentRequest::ExtMethodRequest(ExtRequest {
-                        method: method.into(),
-                        params: params.to_owned().into(),
-                    }))
+                    Ok(AgentRequest::ExtMethodRequest(ExtRequest::new(
+                        method,
+                        params.to_owned().into(),
+                    )))
                 } else {
                     Err(Error::method_not_found())
                 }
@@ -247,10 +247,10 @@ impl Side for ClientSide {
             }
             _ => {
                 if is_valid_ext_method(method) {
-                    Ok(AgentNotification::ExtNotification(ExtNotification {
-                        method: method.into(),
-                        params: params.to_owned().into(),
-                    }))
+                    Ok(AgentNotification::ExtNotification(ExtNotification::new(
+                        method,
+                        params.to_owned().into(),
+                    )))
                 } else {
                     Err(Error::method_not_found())
                 }
@@ -338,10 +338,10 @@ impl Side for AgentSide {
                 .map_err(Into::into),
             _ => {
                 if is_valid_ext_method(method) {
-                    Ok(ClientRequest::ExtMethodRequest(ExtRequest {
-                        method: method.into(),
-                        params: params.to_owned().into(),
-                    }))
+                    Ok(ClientRequest::ExtMethodRequest(ExtRequest::new(
+                        method,
+                        params.to_owned().into(),
+                    )))
                 } else {
                     Err(Error::method_not_found())
                 }
@@ -386,10 +386,10 @@ impl Side for AgentSide {
                 .map_err(Into::into),
             _ => {
                 if is_valid_ext_method(method) {
-                    Ok(ClientNotification::ExtNotification(ExtNotification {
-                        method: method.into(),
-                        params: params.to_owned().into(),
-                    }))
+                    Ok(ClientNotification::ExtNotification(ExtNotification::new(
+                        method,
+                        params.to_owned().into(),
+                    )))
                 } else {
                     Err(Error::method_not_found())
                 }
@@ -407,7 +407,7 @@ mod tests {
     use super::*;
 
     use crate::ErrorCode;
-    use serde_json::{Number, Value, json};
+    use serde_json::{Number, Value};
 
     #[test]
     fn id_deserialization() {
@@ -488,8 +488,18 @@ mod tests {
 
     #[test]
     fn decode_rejects_empty_ext_method_name() {
-        let raw = serde_json::value::RawValue::from_string(json!({}).to_string()).unwrap();
+        let raw = serde_json::value::RawValue::from_string(r#"{}"#.to_string()).unwrap();
+
         let err = ClientSide::decode_request("_", Some(&raw)).unwrap_err();
+        assert_eq!(err.code, ErrorCode::MethodNotFound);
+
+        let err = ClientSide::decode_notification("_", Some(&raw)).unwrap_err();
+        assert_eq!(err.code, ErrorCode::MethodNotFound);
+
+        let err = AgentSide::decode_request("_", Some(&raw)).unwrap_err();
+        assert_eq!(err.code, ErrorCode::MethodNotFound);
+
+        let err = AgentSide::decode_notification("_", Some(&raw)).unwrap_err();
         assert_eq!(err.code, ErrorCode::MethodNotFound);
     }
 }


### PR DESCRIPTION
## Summary

Fixes extension method handling so custom JSON-RPC methods keep their required `_` prefix across decode/routing/serialization.

## Problem

Extension methods are documented as underscore-prefixed (`_...`), but decode logic stripped `_` and stored the method without it.  
That could cause round-trip drift:

`"_vendor/foo"` -> `"vendor/foo"` (re-emitted)

This breaks extension namespace expectations and risks future method-name collisions.

## Changes

- Preserve extension method names exactly as received on the wire (including `_`) in all decode paths.
- Reject invalid empty extension method name (`"_"`).
- Add regression tests for:
  - request decode prefix preservation (both sides)
  - notification decode prefix preservation (both sides)
  - empty extension method rejection
- Add doc comments clarifying `ExtRequest.method` and `ExtNotification.method` semantics.