### PR TITLE
docs: add video for "Agent Client Protocol in GitHub Copilot"

### DIFF
--- a/docs/publications.mdx
+++ b/docs/publications.mdx
@@ -83,4 +83,12 @@ description: ACP publications, talks, presentations, and videos
   >
     Conversation with Ben Brandt, Sergey Ignatov, and Jan-Niklas Wortmann
   </Card>
+
+  <Card
+    title="Agent Client Protocol in GitHub Copilot"
+    href="https://www.bilibili.com/video/BV1bDQ4B9Eri/"
+    horizontal
+  >
+    Jun Han
+  </Card>
 </CardGroup>


### PR DESCRIPTION
It is the video of this ACP talk: https://github.com/agentclientprotocol/agent-client-protocol/pull/944