### PR TITLE
fix(unstable): Move elicitation scope into mode variants

### DIFF
--- a/docs/protocol/draft/schema.mdx
+++ b/docs/protocol/draft/schema.mdx
@@ -1574,56 +1574,6 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 
 **Variants:**
 
-<ResponseField name="Session" type="object">
-Tied to a session, optionally to a specific tool call within that session.
-
-When `tool_call_id` is set, the elicitation is tied to a specific tool call.
-This is useful when an agent receives an elicitation from an MCP server
-during a tool call and needs to redirect it to the user.
-
-<Expandable title="Properties">
-
-<ResponseField
-  name="sessionId"
-  type={<a href="#sessionid">SessionId</a>}
-  required
->
-  The session this elicitation is tied to.
-</ResponseField>
-<ResponseField
-  name="toolCallId"
-  type={
-    <>
-      <span>
-        <a href="#toolcallid">ToolCallId</a>
-      </span>
-      <span> | null</span>
-    </>
-  }
->
-  Optional tool call within the session.
-</ResponseField>
-
-</Expandable>
-</ResponseField>
-
-<ResponseField name="Request" type="object">
-Tied to a specific JSON-RPC request outside of a session
-(e.g., during auth/configuration phases before any session is started).
-
-<Expandable title="Properties">
-
-<ResponseField
-  name="requestId"
-  type={<a href="#requestid">RequestId</a>}
-  required
->
-  The request this elicitation is tied to.
-</ResponseField>
-
-</Expandable>
-</ResponseField>
-
 <ResponseField name="form" type="object">
 Form-based elicitation where the client renders a form from the provided schema.
 
@@ -3379,9 +3329,9 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 Form-based elicitation mode where the client renders a form from the provided schema.
 
-**Type:** Object
+**Type:** Union
 
-**Properties:**
+**Shared properties:**
 
 <ResponseField
   name="requestedSchema"
@@ -3389,6 +3339,58 @@ Form-based elicitation mode where the client renders a form from the provided sc
   required
 >
   A JSON Schema describing the form fields to present to the user.
+</ResponseField>
+
+**Variants:**
+
+<ResponseField name="Session" type="object">
+Tied to a session, optionally to a specific tool call within that session.
+
+When `tool_call_id` is set, the elicitation is tied to a specific tool call.
+This is useful when an agent receives an elicitation from an MCP server
+during a tool call and needs to redirect it to the user.
+
+<Expandable title="Properties">
+
+<ResponseField
+  name="sessionId"
+  type={<a href="#sessionid">SessionId</a>}
+  required
+>
+  The session this elicitation is tied to.
+</ResponseField>
+<ResponseField
+  name="toolCallId"
+  type={
+    <>
+      <span>
+        <a href="#toolcallid">ToolCallId</a>
+      </span>
+      <span> | null</span>
+    </>
+  }
+>
+  Optional tool call within the session.
+</ResponseField>
+
+</Expandable>
+</ResponseField>
+
+<ResponseField name="Request" type="object">
+Tied to a specific JSON-RPC request outside of a session
+(e.g., during auth/configuration phases before any session is started).
+
+<Expandable title="Properties">
+
+<ResponseField
+  name="requestId"
+  type={<a href="#requestid">RequestId</a>}
+  required
+>
+  The request this elicitation is tied to.
+</ResponseField>
+
+</Expandable>
 </ResponseField>
 
 ## <span class="font-mono">ElicitationId</span>
@@ -3649,9 +3651,9 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 URL-based elicitation mode where the client directs the user to a URL.
 
-**Type:** Object
+**Type:** Union
 
-**Properties:**
+**Shared properties:**
 
 <ResponseField
   name="elicitationId"
@@ -3662,6 +3664,58 @@ URL-based elicitation mode where the client directs the user to a URL.
 </ResponseField>
 <ResponseField name="url" type={"string"} required>
   The URL to direct the user to.
+</ResponseField>
+
+**Variants:**
+
+<ResponseField name="Session" type="object">
+Tied to a session, optionally to a specific tool call within that session.
+
+When `tool_call_id` is set, the elicitation is tied to a specific tool call.
+This is useful when an agent receives an elicitation from an MCP server
+during a tool call and needs to redirect it to the user.
+
+<Expandable title="Properties">
+
+<ResponseField
+  name="sessionId"
+  type={<a href="#sessionid">SessionId</a>}
+  required
+>
+  The session this elicitation is tied to.
+</ResponseField>
+<ResponseField
+  name="toolCallId"
+  type={
+    <>
+      <span>
+        <a href="#toolcallid">ToolCallId</a>
+      </span>
+      <span> | null</span>
+    </>
+  }
+>
+  Optional tool call within the session.
+</ResponseField>
+
+</Expandable>
+</ResponseField>
+
+<ResponseField name="Request" type="object">
+Tied to a specific JSON-RPC request outside of a session
+(e.g., during auth/configuration phases before any session is started).
+
+<Expandable title="Properties">
+
+<ResponseField
+  name="requestId"
+  type={<a href="#requestid">RequestId</a>}
+  required
+>
+  The request this elicitation is tied to.
+</ResponseField>
+
+</Expandable>
 </ResponseField>
 
 ## <span class="font-mono">EmbeddedResource</span>

--- a/docs/protocol/draft/schema.mdx
+++ b/docs/protocol/draft/schema.mdx
@@ -3343,12 +3343,8 @@ Form-based elicitation mode where the client renders a form from the provided sc
 
 **Variants:**
 
-<ResponseField name="Session" type="object">
+<ResponseField name="Session">
 Tied to a session, optionally to a specific tool call within that session.
-
-When `tool_call_id` is set, the elicitation is tied to a specific tool call.
-This is useful when an agent receives an elicitation from an MCP server
-during a tool call and needs to redirect it to the user.
 
 <Expandable title="Properties">
 
@@ -3376,7 +3372,7 @@ during a tool call and needs to redirect it to the user.
 </Expandable>
 </ResponseField>
 
-<ResponseField name="Request" type="object">
+<ResponseField name="Request">
 Tied to a specific JSON-RPC request outside of a session
 (e.g., during auth/configuration phases before any session is started).
 
@@ -3569,6 +3565,27 @@ Multi-select array property.
 </Expandable>
 </ResponseField>
 
+## <span class="font-mono">ElicitationRequestScope</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Request-scoped elicitation, tied to a specific JSON-RPC request outside of a session
+(e.g., during auth/configuration phases before any session is started).
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField
+  name="requestId"
+  type={<a href="#requestid">RequestId</a>}
+  required
+>
+  The request this elicitation is tied to.
+</ResponseField>
+
 ## <span class="font-mono">ElicitationSchema</span>
 
 Type-safe elicitation schema for requesting structured user input.
@@ -3610,6 +3627,43 @@ Type discriminator for elicitation schemas.
 
 <ResponseField name="object" type="string">
   Object schema type.
+</ResponseField>
+
+## <span class="font-mono">ElicitationSessionScope</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Session-scoped elicitation, optionally tied to a specific tool call.
+
+When `tool_call_id` is set, the elicitation is tied to a specific tool call.
+This is useful when an agent receives an elicitation from an MCP server
+during a tool call and needs to redirect it to the user.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField
+  name="sessionId"
+  type={<a href="#sessionid">SessionId</a>}
+  required
+>
+  The session this elicitation is tied to.
+</ResponseField>
+<ResponseField
+  name="toolCallId"
+  type={
+    <>
+      <span>
+        <a href="#toolcallid">ToolCallId</a>
+      </span>
+      <span> | null</span>
+    </>
+  }
+>
+  Optional tool call within the session.
 </ResponseField>
 
 ## <span class="font-mono">ElicitationStringType</span>
@@ -3668,12 +3722,8 @@ URL-based elicitation mode where the client directs the user to a URL.
 
 **Variants:**
 
-<ResponseField name="Session" type="object">
+<ResponseField name="Session">
 Tied to a session, optionally to a specific tool call within that session.
-
-When `tool_call_id` is set, the elicitation is tied to a specific tool call.
-This is useful when an agent receives an elicitation from an MCP server
-during a tool call and needs to redirect it to the user.
 
 <Expandable title="Properties">
 
@@ -3701,7 +3751,7 @@ during a tool call and needs to redirect it to the user.
 </Expandable>
 </ResponseField>
 
-<ResponseField name="Request" type="object">
+<ResponseField name="Request">
 Tied to a specific JSON-RPC request outside of a session
 (e.g., during auth/configuration phases before any session is started).
 

--- a/schema/schema.unstable.json
+++ b/schema/schema.unstable.json
@@ -1646,51 +1646,6 @@
       "type": "object"
     },
     "CreateElicitationRequest": {
-      "anyOf": [
-        {
-          "description": "Tied to a session, optionally to a specific tool call within that session.\n\nWhen `tool_call_id` is set, the elicitation is tied to a specific tool call.\nThis is useful when an agent receives an elicitation from an MCP server\nduring a tool call and needs to redirect it to the user.",
-          "properties": {
-            "sessionId": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/SessionId"
-                }
-              ],
-              "description": "The session this elicitation is tied to."
-            },
-            "toolCallId": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ToolCallId"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Optional tool call within the session."
-            }
-          },
-          "required": ["sessionId"],
-          "title": "Session",
-          "type": "object"
-        },
-        {
-          "description": "Tied to a specific JSON-RPC request outside of a session\n(e.g., during auth/configuration phases before any session is started).",
-          "properties": {
-            "requestId": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/RequestId"
-                }
-              ],
-              "description": "The request this elicitation is tied to."
-            }
-          },
-          "required": ["requestId"],
-          "title": "Request",
-          "type": "object"
-        }
-      ],
       "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest from the agent to elicit structured user input.\n\nThe agent sends this to the client to request information from the user,\neither via a form or by directing them to a URL.\nElicitations are tied to a session (optionally a tool call) or a request.",
       "discriminator": {
         "propertyName": "mode"
@@ -2176,6 +2131,51 @@
       "type": "object"
     },
     "ElicitationFormMode": {
+      "anyOf": [
+        {
+          "description": "Tied to a session, optionally to a specific tool call within that session.\n\nWhen `tool_call_id` is set, the elicitation is tied to a specific tool call.\nThis is useful when an agent receives an elicitation from an MCP server\nduring a tool call and needs to redirect it to the user.",
+          "properties": {
+            "sessionId": {
+              "allOf": [
+                {
+                  "$ref": "#/$defs/SessionId"
+                }
+              ],
+              "description": "The session this elicitation is tied to."
+            },
+            "toolCallId": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ToolCallId"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional tool call within the session."
+            }
+          },
+          "required": ["sessionId"],
+          "title": "Session",
+          "type": "object"
+        },
+        {
+          "description": "Tied to a specific JSON-RPC request outside of a session\n(e.g., during auth/configuration phases before any session is started).",
+          "properties": {
+            "requestId": {
+              "allOf": [
+                {
+                  "$ref": "#/$defs/RequestId"
+                }
+              ],
+              "description": "The request this elicitation is tied to."
+            }
+          },
+          "required": ["requestId"],
+          "title": "Request",
+          "type": "object"
+        }
+      ],
       "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nForm-based elicitation mode where the client renders a form from the provided schema.",
       "properties": {
         "requestedSchema": {
@@ -2352,6 +2352,51 @@
       "type": "object"
     },
     "ElicitationUrlMode": {
+      "anyOf": [
+        {
+          "description": "Tied to a session, optionally to a specific tool call within that session.\n\nWhen `tool_call_id` is set, the elicitation is tied to a specific tool call.\nThis is useful when an agent receives an elicitation from an MCP server\nduring a tool call and needs to redirect it to the user.",
+          "properties": {
+            "sessionId": {
+              "allOf": [
+                {
+                  "$ref": "#/$defs/SessionId"
+                }
+              ],
+              "description": "The session this elicitation is tied to."
+            },
+            "toolCallId": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ToolCallId"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional tool call within the session."
+            }
+          },
+          "required": ["sessionId"],
+          "title": "Session",
+          "type": "object"
+        },
+        {
+          "description": "Tied to a specific JSON-RPC request outside of a session\n(e.g., during auth/configuration phases before any session is started).",
+          "properties": {
+            "requestId": {
+              "allOf": [
+                {
+                  "$ref": "#/$defs/RequestId"
+                }
+              ],
+              "description": "The request this elicitation is tied to."
+            }
+          },
+          "required": ["requestId"],
+          "title": "Request",
+          "type": "object"
+        }
+      ],
       "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nURL-based elicitation mode where the client directs the user to a URL.",
       "properties": {
         "elicitationId": {

--- a/schema/schema.unstable.json
+++ b/schema/schema.unstable.json
@@ -2133,47 +2133,22 @@
     "ElicitationFormMode": {
       "anyOf": [
         {
-          "description": "Tied to a session, optionally to a specific tool call within that session.\n\nWhen `tool_call_id` is set, the elicitation is tied to a specific tool call.\nThis is useful when an agent receives an elicitation from an MCP server\nduring a tool call and needs to redirect it to the user.",
-          "properties": {
-            "sessionId": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/SessionId"
-                }
-              ],
-              "description": "The session this elicitation is tied to."
-            },
-            "toolCallId": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ToolCallId"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Optional tool call within the session."
+          "allOf": [
+            {
+              "$ref": "#/$defs/ElicitationSessionScope"
             }
-          },
-          "required": ["sessionId"],
-          "title": "Session",
-          "type": "object"
+          ],
+          "description": "Tied to a session, optionally to a specific tool call within that session.",
+          "title": "Session"
         },
         {
-          "description": "Tied to a specific JSON-RPC request outside of a session\n(e.g., during auth/configuration phases before any session is started).",
-          "properties": {
-            "requestId": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/RequestId"
-                }
-              ],
-              "description": "The request this elicitation is tied to."
+          "allOf": [
+            {
+              "$ref": "#/$defs/ElicitationRequestScope"
             }
-          },
-          "required": ["requestId"],
-          "title": "Request",
-          "type": "object"
+          ],
+          "description": "Tied to a specific JSON-RPC request outside of a session\n(e.g., during auth/configuration phases before any session is started).",
+          "title": "Request"
         }
       ],
       "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nForm-based elicitation mode where the client renders a form from the provided schema.",
@@ -2282,6 +2257,21 @@
         }
       ]
     },
+    "ElicitationRequestScope": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest-scoped elicitation, tied to a specific JSON-RPC request outside of a session\n(e.g., during auth/configuration phases before any session is started).",
+      "properties": {
+        "requestId": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/RequestId"
+            }
+          ],
+          "description": "The request this elicitation is tied to."
+        }
+      },
+      "required": ["requestId"],
+      "type": "object"
+    },
     "ElicitationSchema": {
       "description": "Type-safe elicitation schema for requesting structured user input.\n\nThis represents a JSON Schema object with primitive-typed properties,\nas required by the elicitation specification.",
       "properties": {
@@ -2330,6 +2320,32 @@
         }
       ]
     },
+    "ElicitationSessionScope": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nSession-scoped elicitation, optionally tied to a specific tool call.\n\nWhen `tool_call_id` is set, the elicitation is tied to a specific tool call.\nThis is useful when an agent receives an elicitation from an MCP server\nduring a tool call and needs to redirect it to the user.",
+      "properties": {
+        "sessionId": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ],
+          "description": "The session this elicitation is tied to."
+        },
+        "toolCallId": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ToolCallId"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional tool call within the session."
+        }
+      },
+      "required": ["sessionId"],
+      "type": "object"
+    },
     "ElicitationStringType": {
       "description": "Items definition for untitled multi-select enum properties.",
       "oneOf": [
@@ -2354,47 +2370,22 @@
     "ElicitationUrlMode": {
       "anyOf": [
         {
-          "description": "Tied to a session, optionally to a specific tool call within that session.\n\nWhen `tool_call_id` is set, the elicitation is tied to a specific tool call.\nThis is useful when an agent receives an elicitation from an MCP server\nduring a tool call and needs to redirect it to the user.",
-          "properties": {
-            "sessionId": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/SessionId"
-                }
-              ],
-              "description": "The session this elicitation is tied to."
-            },
-            "toolCallId": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ToolCallId"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Optional tool call within the session."
+          "allOf": [
+            {
+              "$ref": "#/$defs/ElicitationSessionScope"
             }
-          },
-          "required": ["sessionId"],
-          "title": "Session",
-          "type": "object"
+          ],
+          "description": "Tied to a session, optionally to a specific tool call within that session.",
+          "title": "Session"
         },
         {
-          "description": "Tied to a specific JSON-RPC request outside of a session\n(e.g., during auth/configuration phases before any session is started).",
-          "properties": {
-            "requestId": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/RequestId"
-                }
-              ],
-              "description": "The request this elicitation is tied to."
+          "allOf": [
+            {
+              "$ref": "#/$defs/ElicitationRequestScope"
             }
-          },
-          "required": ["requestId"],
-          "title": "Request",
-          "type": "object"
+          ],
+          "description": "Tied to a specific JSON-RPC request outside of a session\n(e.g., during auth/configuration phases before any session is started).",
+          "title": "Request"
         }
       ],
       "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nURL-based elicitation mode where the client directs the user to a URL.",

--- a/src/elicitation.rs
+++ b/src/elicitation.rs
@@ -868,7 +868,7 @@ impl ElicitationUrlCapabilities {
 /// This capability is not part of the spec yet, and may be removed or changed at any point.
 ///
 /// The scope of an elicitation request, determining what context it's tied to.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum ElicitationScope {
@@ -908,9 +908,6 @@ pub enum ElicitationScope {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct CreateElicitationRequest {
-    /// The scope this elicitation is tied to.
-    #[serde(flatten)]
-    pub scope: ElicitationScope,
     /// The elicitation mode and its mode-specific fields.
     #[serde(flatten)]
     pub mode: ElicitationMode,
@@ -927,13 +924,18 @@ pub struct CreateElicitationRequest {
 
 impl CreateElicitationRequest {
     #[must_use]
-    pub fn new(scope: ElicitationScope, mode: ElicitationMode, message: impl Into<String>) -> Self {
+    pub fn new(mode: ElicitationMode, message: impl Into<String>) -> Self {
         Self {
-            scope,
             mode,
             message: message.into(),
             meta: None,
         }
+    }
+
+    /// Returns the scope this elicitation is tied to.
+    #[must_use]
+    pub fn scope(&self) -> &ElicitationScope {
+        self.mode.scope()
     }
 
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -964,6 +966,17 @@ pub enum ElicitationMode {
     Url(ElicitationUrlMode),
 }
 
+impl ElicitationMode {
+    /// Returns the scope this elicitation mode is tied to.
+    #[must_use]
+    pub fn scope(&self) -> &ElicitationScope {
+        match self {
+            Self::Form(f) => &f.scope,
+            Self::Url(u) => &u.scope,
+        }
+    }
+}
+
 /// **UNSTABLE**
 ///
 /// This capability is not part of the spec yet, and may be removed or changed at any point.
@@ -973,14 +986,20 @@ pub enum ElicitationMode {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ElicitationFormMode {
+    /// The scope this elicitation is tied to.
+    #[serde(flatten)]
+    pub scope: ElicitationScope,
     /// A JSON Schema describing the form fields to present to the user.
     pub requested_schema: ElicitationSchema,
 }
 
 impl ElicitationFormMode {
     #[must_use]
-    pub fn new(requested_schema: ElicitationSchema) -> Self {
-        Self { requested_schema }
+    pub fn new(scope: ElicitationScope, requested_schema: ElicitationSchema) -> Self {
+        Self {
+            scope,
+            requested_schema,
+        }
     }
 }
 
@@ -993,6 +1012,9 @@ impl ElicitationFormMode {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ElicitationUrlMode {
+    /// The scope this elicitation is tied to.
+    #[serde(flatten)]
+    pub scope: ElicitationScope,
     /// The unique identifier for this elicitation.
     pub elicitation_id: ElicitationId,
     /// The URL to direct the user to.
@@ -1002,8 +1024,13 @@ pub struct ElicitationUrlMode {
 
 impl ElicitationUrlMode {
     #[must_use]
-    pub fn new(elicitation_id: impl Into<ElicitationId>, url: impl Into<String>) -> Self {
+    pub fn new(
+        scope: ElicitationScope,
+        elicitation_id: impl Into<ElicitationId>,
+        url: impl Into<String>,
+    ) -> Self {
         Self {
+            scope,
             elicitation_id: elicitation_id.into(),
             url: url.into(),
         }
@@ -1282,11 +1309,13 @@ mod tests {
     fn form_mode_request_serialization() {
         let schema = ElicitationSchema::new().string("name", true);
         let req = CreateElicitationRequest::new(
-            ElicitationScope::Session {
-                session_id: SessionId::new("sess_1"),
-                tool_call_id: None,
-            },
-            ElicitationMode::Form(ElicitationFormMode::new(schema)),
+            ElicitationMode::Form(ElicitationFormMode::new(
+                ElicitationScope::Session {
+                    session_id: SessionId::new("sess_1"),
+                    tool_call_id: None,
+                },
+                schema,
+            )),
             "Please enter your name",
         );
 
@@ -1304,7 +1333,7 @@ mod tests {
 
         let roundtripped: CreateElicitationRequest = serde_json::from_value(json).unwrap();
         assert_eq!(
-            roundtripped.scope,
+            *roundtripped.scope(),
             ElicitationScope::Session {
                 session_id: SessionId::new("sess_1"),
                 tool_call_id: None,
@@ -1317,11 +1346,11 @@ mod tests {
     #[test]
     fn url_mode_request_serialization() {
         let req = CreateElicitationRequest::new(
-            ElicitationScope::Session {
-                session_id: SessionId::new("sess_2"),
-                tool_call_id: Some(ToolCallId::new("tc_1")),
-            },
             ElicitationMode::Url(ElicitationUrlMode::new(
+                ElicitationScope::Session {
+                    session_id: SessionId::new("sess_2"),
+                    tool_call_id: Some(ToolCallId::new("tc_1")),
+                },
                 "elic_1",
                 "https://example.com/auth",
             )),
@@ -1338,7 +1367,7 @@ mod tests {
 
         let roundtripped: CreateElicitationRequest = serde_json::from_value(json).unwrap();
         assert_eq!(
-            roundtripped.scope,
+            *roundtripped.scope(),
             ElicitationScope::Session {
                 session_id: SessionId::new("sess_2"),
                 tool_call_id: Some(ToolCallId::new("tc_1")),
@@ -1395,11 +1424,11 @@ mod tests {
     #[test]
     fn session_only_request_serialization() {
         let req = CreateElicitationRequest::new(
-            ElicitationScope::Session {
-                session_id: SessionId::new("sess_1"),
-                tool_call_id: None,
-            },
             ElicitationMode::Form(ElicitationFormMode::new(
+                ElicitationScope::Session {
+                    session_id: SessionId::new("sess_1"),
+                    tool_call_id: None,
+                },
                 ElicitationSchema::new().string("name", true),
             )),
             "Enter your name",
@@ -1411,7 +1440,7 @@ mod tests {
 
         let roundtripped: CreateElicitationRequest = serde_json::from_value(json).unwrap();
         assert_eq!(
-            roundtripped.scope,
+            *roundtripped.scope(),
             ElicitationScope::Session {
                 session_id: SessionId::new("sess_1"),
                 tool_call_id: None,
@@ -1422,10 +1451,10 @@ mod tests {
     #[test]
     fn request_scope_request_serialization() {
         let req = CreateElicitationRequest::new(
-            ElicitationScope::Request {
-                request_id: RequestId::Number(99),
-            },
             ElicitationMode::Form(ElicitationFormMode::new(
+                ElicitationScope::Request {
+                    request_id: RequestId::Number(99),
+                },
                 ElicitationSchema::new().string("workspace", true),
             )),
             "Enter workspace name",
@@ -1437,7 +1466,7 @@ mod tests {
 
         let roundtripped: CreateElicitationRequest = serde_json::from_value(json).unwrap();
         assert_eq!(
-            roundtripped.scope,
+            *roundtripped.scope(),
             ElicitationScope::Request {
                 request_id: RequestId::Number(99),
             }
@@ -1518,7 +1547,7 @@ mod tests {
 
         let req: CreateElicitationRequest = serde_json::from_value(json).unwrap();
         assert_eq!(
-            req.scope,
+            *req.scope(),
             ElicitationScope::Session {
                 session_id: SessionId::new("sess_1"),
                 tool_call_id: None,

--- a/src/elicitation.rs
+++ b/src/elicitation.rs
@@ -1477,6 +1477,33 @@ mod tests {
     }
 
     #[test]
+    fn url_mode_request_scope_serialization() {
+        let req = CreateElicitationRequest::new(
+            ElicitationMode::Url(ElicitationUrlMode::new(
+                ElicitationScope::Request(ElicitationRequestScope::new(RequestId::Number(42))),
+                "elic_2",
+                "https://example.com/setup",
+            )),
+            "Please complete setup",
+        );
+
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["requestId"], 42);
+        assert!(json.get("sessionId").is_none());
+        assert_eq!(json["mode"], "url");
+        assert_eq!(json["elicitationId"], "elic_2");
+        assert_eq!(json["url"], "https://example.com/setup");
+        assert_eq!(json["message"], "Please complete setup");
+
+        let roundtripped: CreateElicitationRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            *roundtripped.scope(),
+            ElicitationScope::Request(ElicitationRequestScope::new(RequestId::Number(42)))
+        );
+        assert!(matches!(roundtripped.mode, ElicitationMode::Url(_)));
+    }
+
+    #[test]
     fn request_scope_request_serialization() {
         let req = CreateElicitationRequest::new(
             ElicitationMode::Form(ElicitationFormMode::new(

--- a/src/elicitation.rs
+++ b/src/elicitation.rs
@@ -938,6 +938,18 @@ impl ElicitationRequestScope {
     }
 }
 
+impl From<ElicitationSessionScope> for ElicitationScope {
+    fn from(scope: ElicitationSessionScope) -> Self {
+        Self::Session(scope)
+    }
+}
+
+impl From<ElicitationRequestScope> for ElicitationScope {
+    fn from(scope: ElicitationRequestScope) -> Self {
+        Self::Request(scope)
+    }
+}
+
 /// **UNSTABLE**
 ///
 /// This capability is not part of the spec yet, and may be removed or changed at any point.
@@ -968,9 +980,9 @@ pub struct CreateElicitationRequest {
 
 impl CreateElicitationRequest {
     #[must_use]
-    pub fn new(mode: ElicitationMode, message: impl Into<String>) -> Self {
+    pub fn new(mode: impl Into<ElicitationMode>, message: impl Into<String>) -> Self {
         Self {
-            mode,
+            mode: mode.into(),
             message: message.into(),
             meta: None,
         }
@@ -1010,6 +1022,18 @@ pub enum ElicitationMode {
     Url(ElicitationUrlMode),
 }
 
+impl From<ElicitationFormMode> for ElicitationMode {
+    fn from(mode: ElicitationFormMode) -> Self {
+        Self::Form(mode)
+    }
+}
+
+impl From<ElicitationUrlMode> for ElicitationMode {
+    fn from(mode: ElicitationUrlMode) -> Self {
+        Self::Url(mode)
+    }
+}
+
 impl ElicitationMode {
     /// Returns the scope this elicitation mode is tied to.
     #[must_use]
@@ -1039,9 +1063,9 @@ pub struct ElicitationFormMode {
 
 impl ElicitationFormMode {
     #[must_use]
-    pub fn new(scope: ElicitationScope, requested_schema: ElicitationSchema) -> Self {
+    pub fn new(scope: impl Into<ElicitationScope>, requested_schema: ElicitationSchema) -> Self {
         Self {
-            scope,
+            scope: scope.into(),
             requested_schema,
         }
     }
@@ -1069,12 +1093,12 @@ pub struct ElicitationUrlMode {
 impl ElicitationUrlMode {
     #[must_use]
     pub fn new(
-        scope: ElicitationScope,
+        scope: impl Into<ElicitationScope>,
         elicitation_id: impl Into<ElicitationId>,
         url: impl Into<String>,
     ) -> Self {
         Self {
-            scope,
+            scope: scope.into(),
             elicitation_id: elicitation_id.into(),
             url: url.into(),
         }
@@ -1353,10 +1377,7 @@ mod tests {
     fn form_mode_request_serialization() {
         let schema = ElicitationSchema::new().string("name", true);
         let req = CreateElicitationRequest::new(
-            ElicitationMode::Form(ElicitationFormMode::new(
-                ElicitationScope::Session(ElicitationSessionScope::new("sess_1")),
-                schema,
-            )),
+            ElicitationFormMode::new(ElicitationSessionScope::new("sess_1"), schema),
             "Please enter your name",
         );
 
@@ -1375,7 +1396,7 @@ mod tests {
         let roundtripped: CreateElicitationRequest = serde_json::from_value(json).unwrap();
         assert_eq!(
             *roundtripped.scope(),
-            ElicitationScope::Session(ElicitationSessionScope::new("sess_1"))
+            ElicitationSessionScope::new("sess_1").into()
         );
         assert_eq!(roundtripped.message, "Please enter your name");
         assert!(matches!(roundtripped.mode, ElicitationMode::Form(_)));
@@ -1384,13 +1405,11 @@ mod tests {
     #[test]
     fn url_mode_request_serialization() {
         let req = CreateElicitationRequest::new(
-            ElicitationMode::Url(ElicitationUrlMode::new(
-                ElicitationScope::Session(
-                    ElicitationSessionScope::new("sess_2").tool_call_id("tc_1"),
-                ),
+            ElicitationUrlMode::new(
+                ElicitationSessionScope::new("sess_2").tool_call_id("tc_1"),
                 "elic_1",
                 "https://example.com/auth",
-            )),
+            ),
             "Please authenticate",
         );
 
@@ -1405,7 +1424,9 @@ mod tests {
         let roundtripped: CreateElicitationRequest = serde_json::from_value(json).unwrap();
         assert_eq!(
             *roundtripped.scope(),
-            ElicitationScope::Session(ElicitationSessionScope::new("sess_2").tool_call_id("tc_1"),)
+            ElicitationSessionScope::new("sess_2")
+                .tool_call_id("tc_1")
+                .into()
         );
         assert!(matches!(roundtripped.mode, ElicitationMode::Url(_)));
     }
@@ -1456,34 +1477,13 @@ mod tests {
     }
 
     #[test]
-    fn session_only_request_serialization() {
-        let req = CreateElicitationRequest::new(
-            ElicitationMode::Form(ElicitationFormMode::new(
-                ElicitationScope::Session(ElicitationSessionScope::new("sess_1")),
-                ElicitationSchema::new().string("name", true),
-            )),
-            "Enter your name",
-        );
-
-        let json = serde_json::to_value(&req).unwrap();
-        assert_eq!(json["sessionId"], "sess_1");
-        assert!(json.get("toolCallId").is_none());
-
-        let roundtripped: CreateElicitationRequest = serde_json::from_value(json).unwrap();
-        assert_eq!(
-            *roundtripped.scope(),
-            ElicitationScope::Session(ElicitationSessionScope::new("sess_1"))
-        );
-    }
-
-    #[test]
     fn url_mode_request_scope_serialization() {
         let req = CreateElicitationRequest::new(
-            ElicitationMode::Url(ElicitationUrlMode::new(
-                ElicitationScope::Request(ElicitationRequestScope::new(RequestId::Number(42))),
+            ElicitationUrlMode::new(
+                ElicitationRequestScope::new(RequestId::Number(42)),
                 "elic_2",
                 "https://example.com/setup",
-            )),
+            ),
             "Please complete setup",
         );
 
@@ -1498,7 +1498,7 @@ mod tests {
         let roundtripped: CreateElicitationRequest = serde_json::from_value(json).unwrap();
         assert_eq!(
             *roundtripped.scope(),
-            ElicitationScope::Request(ElicitationRequestScope::new(RequestId::Number(42)))
+            ElicitationRequestScope::new(RequestId::Number(42)).into()
         );
         assert!(matches!(roundtripped.mode, ElicitationMode::Url(_)));
     }
@@ -1506,10 +1506,10 @@ mod tests {
     #[test]
     fn request_scope_request_serialization() {
         let req = CreateElicitationRequest::new(
-            ElicitationMode::Form(ElicitationFormMode::new(
-                ElicitationScope::Request(ElicitationRequestScope::new(RequestId::Number(99))),
+            ElicitationFormMode::new(
+                ElicitationRequestScope::new(RequestId::Number(99)),
                 ElicitationSchema::new().string("workspace", true),
-            )),
+            ),
             "Enter workspace name",
         );
 
@@ -1520,7 +1520,7 @@ mod tests {
         let roundtripped: CreateElicitationRequest = serde_json::from_value(json).unwrap();
         assert_eq!(
             *roundtripped.scope(),
-            ElicitationScope::Request(ElicitationRequestScope::new(RequestId::Number(99)))
+            ElicitationRequestScope::new(RequestId::Number(99)).into()
         );
     }
 
@@ -1597,10 +1597,7 @@ mod tests {
         });
 
         let req: CreateElicitationRequest = serde_json::from_value(json).unwrap();
-        assert_eq!(
-            *req.scope(),
-            ElicitationScope::Session(ElicitationSessionScope::new("sess_1"))
-        );
+        assert_eq!(*req.scope(), ElicitationSessionScope::new("sess_1").into());
         assert_eq!(req.message, "Enter your name");
         assert!(matches!(req.mode, ElicitationMode::Form(_)));
     }

--- a/src/elicitation.rs
+++ b/src/elicitation.rs
@@ -873,25 +873,69 @@ impl ElicitationUrlCapabilities {
 #[non_exhaustive]
 pub enum ElicitationScope {
     /// Tied to a session, optionally to a specific tool call within that session.
-    ///
-    /// When `tool_call_id` is set, the elicitation is tied to a specific tool call.
-    /// This is useful when an agent receives an elicitation from an MCP server
-    /// during a tool call and needs to redirect it to the user.
-    #[serde(rename_all = "camelCase")]
-    Session {
-        /// The session this elicitation is tied to.
-        session_id: SessionId,
-        /// Optional tool call within the session.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        tool_call_id: Option<ToolCallId>,
-    },
+    Session(ElicitationSessionScope),
     /// Tied to a specific JSON-RPC request outside of a session
     /// (e.g., during auth/configuration phases before any session is started).
-    #[serde(rename_all = "camelCase")]
-    Request {
-        /// The request this elicitation is tied to.
-        request_id: RequestId,
-    },
+    Request(ElicitationRequestScope),
+}
+
+/// **UNSTABLE**
+///
+/// This capability is not part of the spec yet, and may be removed or changed at any point.
+///
+/// Session-scoped elicitation, optionally tied to a specific tool call.
+///
+/// When `tool_call_id` is set, the elicitation is tied to a specific tool call.
+/// This is useful when an agent receives an elicitation from an MCP server
+/// during a tool call and needs to redirect it to the user.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct ElicitationSessionScope {
+    /// The session this elicitation is tied to.
+    pub session_id: SessionId,
+    /// Optional tool call within the session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<ToolCallId>,
+}
+
+impl ElicitationSessionScope {
+    #[must_use]
+    pub fn new(session_id: impl Into<SessionId>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            tool_call_id: None,
+        }
+    }
+
+    #[must_use]
+    pub fn tool_call_id(mut self, tool_call_id: impl Into<ToolCallId>) -> Self {
+        self.tool_call_id = Some(tool_call_id.into());
+        self
+    }
+}
+
+/// **UNSTABLE**
+///
+/// This capability is not part of the spec yet, and may be removed or changed at any point.
+///
+/// Request-scoped elicitation, tied to a specific JSON-RPC request outside of a session
+/// (e.g., during auth/configuration phases before any session is started).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct ElicitationRequestScope {
+    /// The request this elicitation is tied to.
+    pub request_id: RequestId,
+}
+
+impl ElicitationRequestScope {
+    #[must_use]
+    pub fn new(request_id: impl Into<RequestId>) -> Self {
+        Self {
+            request_id: request_id.into(),
+        }
+    }
 }
 
 /// **UNSTABLE**
@@ -1310,10 +1354,7 @@ mod tests {
         let schema = ElicitationSchema::new().string("name", true);
         let req = CreateElicitationRequest::new(
             ElicitationMode::Form(ElicitationFormMode::new(
-                ElicitationScope::Session {
-                    session_id: SessionId::new("sess_1"),
-                    tool_call_id: None,
-                },
+                ElicitationScope::Session(ElicitationSessionScope::new("sess_1")),
                 schema,
             )),
             "Please enter your name",
@@ -1334,10 +1375,7 @@ mod tests {
         let roundtripped: CreateElicitationRequest = serde_json::from_value(json).unwrap();
         assert_eq!(
             *roundtripped.scope(),
-            ElicitationScope::Session {
-                session_id: SessionId::new("sess_1"),
-                tool_call_id: None,
-            }
+            ElicitationScope::Session(ElicitationSessionScope::new("sess_1"))
         );
         assert_eq!(roundtripped.message, "Please enter your name");
         assert!(matches!(roundtripped.mode, ElicitationMode::Form(_)));
@@ -1347,10 +1385,9 @@ mod tests {
     fn url_mode_request_serialization() {
         let req = CreateElicitationRequest::new(
             ElicitationMode::Url(ElicitationUrlMode::new(
-                ElicitationScope::Session {
-                    session_id: SessionId::new("sess_2"),
-                    tool_call_id: Some(ToolCallId::new("tc_1")),
-                },
+                ElicitationScope::Session(
+                    ElicitationSessionScope::new("sess_2").tool_call_id("tc_1"),
+                ),
                 "elic_1",
                 "https://example.com/auth",
             )),
@@ -1368,10 +1405,7 @@ mod tests {
         let roundtripped: CreateElicitationRequest = serde_json::from_value(json).unwrap();
         assert_eq!(
             *roundtripped.scope(),
-            ElicitationScope::Session {
-                session_id: SessionId::new("sess_2"),
-                tool_call_id: Some(ToolCallId::new("tc_1")),
-            }
+            ElicitationScope::Session(ElicitationSessionScope::new("sess_2").tool_call_id("tc_1"),)
         );
         assert!(matches!(roundtripped.mode, ElicitationMode::Url(_)));
     }
@@ -1425,10 +1459,7 @@ mod tests {
     fn session_only_request_serialization() {
         let req = CreateElicitationRequest::new(
             ElicitationMode::Form(ElicitationFormMode::new(
-                ElicitationScope::Session {
-                    session_id: SessionId::new("sess_1"),
-                    tool_call_id: None,
-                },
+                ElicitationScope::Session(ElicitationSessionScope::new("sess_1")),
                 ElicitationSchema::new().string("name", true),
             )),
             "Enter your name",
@@ -1441,10 +1472,7 @@ mod tests {
         let roundtripped: CreateElicitationRequest = serde_json::from_value(json).unwrap();
         assert_eq!(
             *roundtripped.scope(),
-            ElicitationScope::Session {
-                session_id: SessionId::new("sess_1"),
-                tool_call_id: None,
-            }
+            ElicitationScope::Session(ElicitationSessionScope::new("sess_1"))
         );
     }
 
@@ -1452,9 +1480,7 @@ mod tests {
     fn request_scope_request_serialization() {
         let req = CreateElicitationRequest::new(
             ElicitationMode::Form(ElicitationFormMode::new(
-                ElicitationScope::Request {
-                    request_id: RequestId::Number(99),
-                },
+                ElicitationScope::Request(ElicitationRequestScope::new(RequestId::Number(99))),
                 ElicitationSchema::new().string("workspace", true),
             )),
             "Enter workspace name",
@@ -1467,9 +1493,7 @@ mod tests {
         let roundtripped: CreateElicitationRequest = serde_json::from_value(json).unwrap();
         assert_eq!(
             *roundtripped.scope(),
-            ElicitationScope::Request {
-                request_id: RequestId::Number(99),
-            }
+            ElicitationScope::Request(ElicitationRequestScope::new(RequestId::Number(99)))
         );
     }
 
@@ -1526,8 +1550,8 @@ mod tests {
         assert!(matches!(roundtripped.action, ElicitationAction::Cancel));
     }
 
-    /// Guard against serde regressions with the `flatten` + `untagged` + `flatten` (tagged)
-    /// combination. Extra fields in the JSON must not cause deserialization failures.
+    /// Guard against serde regressions with the `flatten` + internally-tagged combination.
+    /// Extra fields in the JSON must not cause deserialization failures.
     #[test]
     fn request_tolerates_extra_fields() {
         let json = json!({
@@ -1548,10 +1572,7 @@ mod tests {
         let req: CreateElicitationRequest = serde_json::from_value(json).unwrap();
         assert_eq!(
             *req.scope(),
-            ElicitationScope::Session {
-                session_id: SessionId::new("sess_1"),
-                tool_call_id: None,
-            }
+            ElicitationScope::Session(ElicitationSessionScope::new("sess_1"))
         );
         assert_eq!(req.message, "Enter your name");
         assert!(matches!(req.mode, ElicitationMode::Form(_)));

--- a/src/elicitation.rs
+++ b/src/elicitation.rs
@@ -909,8 +909,8 @@ impl ElicitationSessionScope {
     }
 
     #[must_use]
-    pub fn tool_call_id(mut self, tool_call_id: impl Into<ToolCallId>) -> Self {
-        self.tool_call_id = Some(tool_call_id.into());
+    pub fn tool_call_id(mut self, tool_call_id: impl IntoOption<ToolCallId>) -> Self {
+        self.tool_call_id = tool_call_id.into_option();
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,12 @@ impl IntoOption<PathBuf> for Cow<'_, Path> {
     }
 }
 
+impl IntoOption<ToolCallId> for &str {
+    fn into_option(self) -> Option<ToolCallId> {
+        Some(ToolCallId::new(self))
+    }
+}
+
 impl IntoOption<serde_json::Value> for &str {
     fn into_option(self) -> Option<serde_json::Value> {
         Some(self.into())


### PR DESCRIPTION
Align elicitation request types and generated schema by storing
scope on form and URL modes instead of the top-level request.
