### PR TITLE
Fix typo on repository name

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -83,7 +83,7 @@ These frameworks add ACP support through dedicated integrations or adapters:
 
 These connectors bridge ACP into other environments and transport layers:
 
-- [AgentRQ Bridge](https://github.com/agenrq/acp-gateway) — bridges stdio-based ACP agents to the AgentRQ - Human-in-the-loop task collaboration service using MCP server.
+- [AgentRQ](https://github.com/agentrq/acp-gateway) — bridges stdio-based ACP agents to the AgentRQ - Human-in-the-loop task collaboration service using MCP server.
 - [Aptove Bridge](https://github.com/aptove/bridge) — bridges stdio-based ACP agents to the Aptove mobile client over WebSocket
 - [OpenClaw](https://docs.openclaw.ai/cli/acp) — through the [`openclaw acp`](https://docs.openclaw.ai/cli/acp) bridge to an OpenClaw Gateway
 - [stdio Bus](https://stdiobus.com) – deterministic stdio-based kernel providing transport-level routing for ACP/MCP-style agent protocols.


### PR DESCRIPTION
In the previous commit, made a typo on the repository name. Correct repository is https://github.com/agentrq/acp-gateway.