### PR TITLE
Add Ferngeist to mobile clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -55,6 +55,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 These mobile-first tools bring ACP and related coding-agent workflows to phones and tablets:
 
 - [Agmente](https://agmente.halliharp.com) ([GitHub](https://github.com/rebornix/Agmente)) (iOS)
+- [Ferngeist](https://github.com/arafatamim/Ferngeist) (Android)
 - [Happy](https://happy.engineering/) ([GitHub](https://github.com/slopus/happy)) (iOS, Android, Web)
 - [Mobvibe](https://github.com/Eric-Song-Nop/mobvibe) (iOS, Android, Web)
 


### PR DESCRIPTION
This PR adds [Ferngeist](https://github.com/arafatamim/ferngeist), an open-source Android client for ACP-compatible agents, to the clients list.

