### PR TITLE
docs: add latest unity acp support client

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -15,6 +15,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
   - through the [carlos-algms/agentic.nvim](https://github.com/carlos-algms/agentic.nvim) plugin
   - through the [yetone/avante.nvim](https://github.com/yetone/avante.nvim) plugin
 - [Obsidian](https://obsidian.md) — through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
+- [Unity ACP Client](https://github.com/3DLabInstruments/UnityACPClient)(Unity plugin)
 - [Unity Agent Client](https://github.com/nuskey8/UnityAgentClient) (Unity editor)
 - Visual Studio Code — through the [ACP Client](https://github.com/formulahendry/vscode-acp) extension
 - [Zed](https://zed.dev/docs/ai/external-agents)


### PR DESCRIPTION
because the unity agent client is no maintain, now I create a new one, which take the latest feature from ACP, contains
1. Session management
2. Elicitation
3. RequestPermission
4. SessionNotification
5. show token, cost

demo: https://www.youtube.com/watch?v=l-bPIjnnkso