### PR TITLE
transports: Revisions on streamable-http/ws transport request patterns

### DIFF
--- a/docs/rfds/streamable-http-websocket-transport.mdx
+++ b/docs/rfds/streamable-http-websocket-transport.mdx
@@ -297,20 +297,20 @@ The agent task is spawned once per connection. A single GET SSE stream delivers 
 
 ### Comparing to MCP Streamable HTTP
 
-| MCP Requirement                            | ACP Implementation                                | Status               |
-| ------------------------------------------ | ------------------------------------------------- | -------------------- |
-| POST for all client→server messages        | ✅                                                | Compliant            |
-| Accept header validation (406)             | ✅                                                | Compliant            |
-| Notifications/responses return 202         | ✅ (except `initialize` returns 200)              | Mostly compliant     |
-| Requests return SSE stream                 | ❌ (single long-lived GET stream instead)         | Documented deviation |
-| Session ID on initialize response          | ✅ (`Acp-Connection-Id`)                          | Compliant (renamed)  |
-| Session ID required on subsequent requests | ✅ (`Acp-Connection-Id` + `Acp-Session-Id`)       | Compliant (extended) |
-| GET opens SSE stream                       | ✅ (single connection-scoped stream)              | Compliant            |
-| DELETE terminates session                  | ✅ (terminates connection)                        | Compliant            |
-| 404 for unknown sessions                   | ✅ (unknown connection IDs)                       | Compliant            |
-| Batch requests                             | ❌ (returns 501)                                  | Documented deviation |
-| Resumability (Last-Event-ID)               | ❌                                                | Future work          |
-| Protocol version header                    | ❌                                                | Future work          |
+| MCP Requirement                            | ACP Implementation                          | Status               |
+| ------------------------------------------ | ------------------------------------------- | -------------------- |
+| POST for all client→server messages        | ✅                                          | Compliant            |
+| Accept header validation (406)             | ✅                                          | Compliant            |
+| Notifications/responses return 202         | ✅ (except `initialize` returns 200)        | Mostly compliant     |
+| Requests return SSE stream                 | ❌ (single long-lived GET stream instead)   | Documented deviation |
+| Session ID on initialize response          | ✅ (`Acp-Connection-Id`)                    | Compliant (renamed)  |
+| Session ID required on subsequent requests | ✅ (`Acp-Connection-Id` + `Acp-Session-Id`) | Compliant (extended) |
+| GET opens SSE stream                       | ✅ (single connection-scoped stream)        | Compliant            |
+| DELETE terminates session                  | ✅ (terminates connection)                  | Compliant            |
+| 404 for unknown sessions                   | ✅ (unknown connection IDs)                 | Compliant            |
+| Batch requests                             | ❌ (returns 501)                            | Documented deviation |
+| Resumability (Last-Event-ID)               | ❌                                          | Future work          |
+| Protocol version header                    | ❌                                          | Future work          |
 
 ### Deviations from MCP Streamable HTTP
 
@@ -318,10 +318,10 @@ The agent task is spawned once per connection. A single GET SSE stream delivers 
 2. **Initialize returns JSON directly**: MCP's `initialize` returns an SSE stream. ACP's `initialize` returns `200 OK` with a JSON response body containing capabilities and `connectionId`. The `Acp-Connection-Id` is also included in the response header.
 3. **HTTP/2 required**: ACP requires HTTP/2 for multiplexing concurrent POST requests alongside the long-lived GET stream.
 4. **Two-header model**: ACP uses both `Acp-Connection-Id` (for connection identity) and `Acp-Session-Id` (for session identity on POST requests). MCP only uses `Mcp-Session-Id`. This allows ACP to distinguish connection-level state from session-level operations while supporting multiple concurrent sessions on one connection.
-6. **WebSocket extension**: MCP doesn't define WebSocket. ACP adds it as a required client capability. Clients MUST support WebSocket, and servers MAY choose to only support WebSocket connections.
-7. **Cookie support required**: Clients MUST handle cookies on HTTP transports for the duration of the connection, enabling sticky sessions and per-connection server state.
-8. **No batch requests**: Returns 501. May be added later.
-9. **No resumability yet in reference implementation**: SSE event IDs and `Last-Event-ID` resumption planned as follow-up.
+5. **WebSocket extension**: MCP doesn't define WebSocket. ACP adds it as a required client capability. Clients MUST support WebSocket, and servers MAY choose to only support WebSocket connections.
+6. **Cookie support required**: Clients MUST handle cookies on HTTP transports for the duration of the connection, enabling sticky sessions and per-connection server state.
+7. **No batch requests**: Returns 501. May be added later.
+8. **No resumability yet in reference implementation**: SSE event IDs and `Last-Event-ID` resumption planned as follow-up.
 
 ### Implementation Plan
 

--- a/docs/rfds/streamable-http-websocket-transport.mdx
+++ b/docs/rfds/streamable-http-websocket-transport.mdx
@@ -9,9 +9,9 @@ title: "Streamable HTTP & WebSocket Transport"
 
 > What are you proposing to change?
 
-ACP needs a standard remote transport. We propose adopting **MCP Streamable HTTP** (2025-11-25) with ACP-specific headers, and extending it with a **WebSocket upgrade** on the same endpoint. A single `/acp` endpoint supports two connectivity profiles:
+ACP needs a standard remote transport. We propose a **single long-lived GET stream** for all server→client messages, with **POST** for client→server messages, and **WebSocket upgrade** as an alternative on the same endpoint. A single `/acp` endpoint supports two connectivity profiles:
 
-- **Streamable HTTP (POST/GET/DELETE)** — stateless-friendly, SSE-based streaming, aligned with MCP Streamable HTTP.
+- **Streamable HTTP (POST/GET/DELETE)** — Single long-lived SSE stream per connection for all server→client messages (responses and notifications). POST requests return immediately (202 Accepted, except `initialize`). Requires HTTP/2.
 - **WebSocket upgrade (GET with `Upgrade: websocket`)** — persistent, full-duplex, low-latency bidirectional messaging.
 
 Clients that support remote ACP over HTTP MUST support both Streamable HTTP and WebSocket. This allows servers to support only WebSocket if they choose, simplifying deployment.
@@ -22,55 +22,44 @@ Both profiles share the same JSON-RPC message format and ACP lifecycle as the ex
 
 > How do things work today and what problems does this cause? Why would we change things?
 
-ACP only has stdio (inherited from MCP). There is no standard remote transport, which causes:
-
-1. **Fragmentation** — implementers invent their own HTTP layers, leading to incompatible SDKs and deployments.
-2. **Missed alignment** — MCP Streamable HTTP is well-designed; ACP should adopt it rather than diverge.
+ACP only has stdio. There is no standard remote transport, which causes fragmentation as implementers invent their own HTTP layers, leading to incompatible SDKs and deployments.
 
 ## What we propose to do about it
 
 > What are you proposing to improve the situation?
 
-### 1. Mostly adopts MCP Streamable HTTP semantics with ACP-specific headers
+### 1. Adds an HTTP Transport
 
-Follows the MCP 2025-11-25 Streamable HTTP spec with these adaptations:
+ACP adopts a streamable HTTP transport with three key characteristics:
 
-- Connection header: `Acp-Connection-Id` (similar to `Mcp-Session-Id`)
-- Session header: `Acp-Session-Id` (new, no MCP equivalent)
-- Protocol version header: `Acp-Protocol-Version`
-- Endpoint path: conventionally `/acp`
+1. **Single long-lived GET stream per connection** — All server→client messages (responses to requests and unsolicited notifications) are delivered via a single SSE stream opened with GET. This includes responses to client requests (correlated by JSON-RPC `id`), server-initiated notifications (no `id`), and server-to-client requests like `request_permission` (with `id`, client responds via POST). The GET stream is scoped to `Acp-Connection-Id` and delivers messages for all sessions within that connection. Session identity is carried in the JSON-RPC message body (`sessionId` field).
 
-### 2. Separates connection identity from session identity with two headers
+2. **POST requests return immediately (except initialize)** — Client→server messages are sent via POST. Most POST requests return `202 Accepted` immediately with an empty body. The actual response comes later on the GET stream, correlated by JSON-RPC `id`. The `initialize` request is special: it returns `200 OK` with a JSON response body containing capabilities and the `Acp-Connection-Id`. The `Acp-Connection-Id` is also included in the response header.
 
-ACP introduces two HTTP headers that together identify the full request context:
+3. **Requires HTTP/2** — Streamable HTTP transport MUST use HTTP/2. This provides multiplexing for concurrent POST requests while maintaining a single long-lived GET stream, and improves efficiency for high-frequency message exchanges.
 
-- **`Acp-Connection-Id`** (HTTP header) — A transport-level identifier returned by the server in the `initialize` response. It binds all subsequent HTTP requests to the initialized connection and its negotiated capabilities. This is analogous to `Mcp-Session-Id` in MCP Streamable HTTP. Required on all requests after `initialize`.
-- **`Acp-Session-Id`** (HTTP header) — A session-level identifier returned by the server in the `session/new` response (both in the `Acp-Session-Id` response header and the JSON-RPC result body). It identifies a specific conversation. Clients MUST include it on all subsequent requests that operate within a session (e.g., `session/prompt`, `session/cancel`). The same value appears in JSON-RPC params as `sessionId` for methods that require it.
-
-A single `Acp-Connection-Id` may span multiple ACP sessions. Before `session/new` is called, only `Acp-Connection-Id` is present. After `session/new`, both headers are included.
-
-### 3. Adds WebSocket as a first-class upgrade on the same endpoint
+### 4. Adds WebSocket as a first-class upgrade on the same endpoint
 
 A GET with `Upgrade: websocket` upgrades to a persistent bidirectional channel — same endpoint, same lifecycle model.
 
 This is important for ACP, as it is more bidirectional in its nature as a protocol.
 
-### 4. Requires cookie support on HTTP transports
+### 5. Requires cookie support on HTTP transports
 
 Clients MUST accept, store, and return cookies set by the server on all HTTP-based transports (Streamable HTTP and WebSocket). Cookies MUST be sent on subsequent requests to the server for the duration of the connection. Clients MAY discard all cookies when a connection is terminated. This allows servers to rely on cookies for session affinity (e.g., sticky sessions behind a load balancer) and other small amounts of per-connection state.
 
-### 5. Defines a unified routing model
+### 6. Defines a unified routing model
 
-| Method   | Upgrade Header?      | Behavior                                                                                                                           |
-| -------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `POST`   | —                    | Send JSON-RPC request/notification/response (Streamable HTTP)                                                                      |
-| `GET`    | No                   | Open session-scoped SSE stream for server-initiated messages (Streamable HTTP). Requires `Acp-Connection-Id` and `Acp-Session-Id`. |
-| `GET`    | `Upgrade: websocket` | Upgrade to WebSocket for full-duplex messaging                                                                                     |
-| `DELETE` | —                    | Terminate the connection                                                                                                           |
+| Method   | Upgrade Header?      | Behavior                                                                                                    |
+| -------- | -------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `POST`   | —                    | Send JSON-RPC message. `initialize` returns 200 with JSON body. All others return 202 Accepted immediately. |
+| `GET`    | No                   | Open connection-scoped SSE stream for all server→client messages. Requires `Acp-Connection-Id`.             |
+| `GET`    | `Upgrade: websocket` | Upgrade to WebSocket for full-duplex messaging                                                              |
+| `DELETE` | —                    | Terminate the connection                                                                                    |
 
-### 6. Preserves the full ACP lifecycle
+### 7. Preserves the full ACP lifecycle
 
-The `initialize` → `initialized` → messages → close lifecycle is identical regardless of transport. The `Acp-Connection-Id` header binds requests to the initialized connection and its negotiated capabilities. The `Acp-Session-Id` header (introduced after `session/new`) identifies an active ACP session.
+The `initialize` → `initialized` → messages → close lifecycle is identical regardless of transport. The `Acp-Connection-Id` binds requests to the initialized connection and its negotiated capabilities. Session identity is carried in JSON-RPC message bodies via the `sessionId` field.
 
 ## Shiny future
 
@@ -105,135 +94,142 @@ The `initialize` → `initialized` → messages → close lifecycle is identical
 
 ### Identity Model
 
-ACP over Streamable HTTP uses two HTTP headers that together identify the full request context:
+ACP over Streamable HTTP uses two HTTP headers for connection and session identity, plus JSON-RPC message fields:
 
-|                  | `Acp-Connection-Id`                              | `Acp-Session-Id`                                                              |
-| ---------------- | ------------------------------------------------ | ----------------------------------------------------------------------------- |
-| **Purpose**      | Binds HTTP requests to an initialized connection | Identifies an ACP conversation/session                                        |
-| **Created by**   | Server, on `initialize` response                 | Server, on `session/new` response                                             |
-| **Location**     | HTTP header (all requests after `initialize`)    | HTTP header (all requests after `session/new`) + JSON-RPC body as `sessionId` |
-| **Scope**        | One per `initialize` handshake                   | One per `session/new` call                                                    |
-| **Multiplicity** | May span multiple sessions                       | Belongs to exactly one connection                                             |
-| **Used for**     | Request routing, capability lookup               | Session-scoped request routing, session-scoped GET listener filtering         |
-| **Required**     | After `initialize`                               | After `session/new`                                                           |
+- **`Acp-Connection-Id`** (HTTP header) — Transport-level identifier returned by the server in the `initialize` response. Required on all HTTP requests after `initialize` and on the GET stream. Binds requests to an initialized connection and its negotiated capabilities.
+- **`Acp-Session-Id`** (HTTP header) — Session-level identifier returned in the `session/new` response body. Required on all session-scoped POST requests (`session/prompt`, `session/cancel`, permission responses, etc.). Enables routing and debugging.
+- **`sessionId`** (JSON-RPC field) — Session-level identifier also included in JSON-RPC `params` for session-scoped methods and in responses on the GET stream. A single connection may host multiple sessions, each with its own `sessionId`.
 
 ### Streamable HTTP Message Flow
 
 ```
-Client                              Server
-  │                                   │
-  │  ═══ Connection Initialization ═══│
-  │                                   │
-  │─── POST /acp ─────────────────────>│  { method: "initialize", id: 1 }
-  │    Accept: application/json,       │  (no Acp-Connection-Id header)
-  │            text/event-stream       │
-  │              ┌─────────────────────│  Server creates connection
-  │              │ (SSE stream open)   │
-  │<─────────────│─ SSE event ─────────│  { id: 1, result: { capabilities } }
-  │              │                     │  Response includes Acp-Connection-Id header
-  │              ▼                     │
+Client                             Server
   │                                    │
+  │  ═══ Connection Initialization ═══ │
+  │                                    │
+  │─── POST /acp ─────────────────────>│  { method: "initialize", id: 1 }
+  │    Content-Type: application/json  │  (no Acp-Connection-Id header)
+  │                                    │
+  │<────── 200 OK ─────────────────────│  { id: 1, result: { capabilities, connectionId } }
+  │    Acp-Connection-Id: <conn_id>    │  Response includes Acp-Connection-Id header
+  │    Content-Type: application/json  │
+  │                                    │
+  │  ═══ Open GET Stream ═══           │
+  │                                    │
+  │─── GET /acp ──────────────────────>│  Open long-lived SSE stream
+  │    Acp-Connection-Id: <conn_id>    │  for all server→client messages
+  │    Accept: text/event-stream       │
+  │              ┌─────────────────────│  (SSE stream open)
+  │              │                     │
+  │              │                     │
   │  ═══ Session Creation ═══          │
   │                                    │
   │─── POST /acp ─────────────────────>│  { method: "session/new", id: 2,
   │    Acp-Connection-Id: <conn_id>    │    params: { cwd, mcpServers } }
-  │              ┌─────────────────────│  Opens new SSE stream for response
+  │                                    │
+  │<────── 202 Accepted ───────────────│  (returns immediately)
+  │              │                     │
   │<─────────────│─ SSE event ─────────│  { id: 2, result: { sessionId: "sess_abc123" } }
-  │              │                     │  Response includes Acp-Session-Id header
-  │              ▼                     │
-  │                                    │
-  │  ═══ Optional: GET Listener ════════│
-  │                                    │
-  │─── GET /acp ──────────────────────>│  Open SSE listener for
-  │    Acp-Connection-Id: <conn_id>    │  server-initiated messages
-  │    Acp-Session-Id: <session_id>    │  (scoped to this session)
-  │    Accept: text/event-stream       │
-  │              ┌─────────────────────│  Only events for this session
-  │              │ (SSE stream open)   │  are delivered on this stream
-  │              ▼                     │
-  │                                    │
+  │              │                     │  (response comes on GET stream)
+  │              │                     │
   │  ═══ Prompt Flow ═══               │
   │                                    │
   │─── POST /acp ─────────────────────>│  { method: "session/prompt", id: 3,
   │    Acp-Connection-Id: <conn_id>    │    params: { sessionId: "sess_abc123", prompt } }
-  │    Acp-Session-Id: <session_id>    │
-  │              ┌─────────────────────│  Opens new SSE stream for response
-  │<─────────────│─ SSE event ─────────│  notification: AgentMessageChunk
-  │<─────────────│─ SSE event ─────────│  notification: AgentThoughtChunk (if reasoning)
-  │<─────────────│─ SSE event ─────────│  notification: ToolCall (status: pending)
-  │<─────────────│─ SSE event ─────────│  notification: ToolCallUpdate (status: completed)
-  │<─────────────│─ SSE event ─────────│  notification: AgentMessageChunk
-  │<─────────────│─ SSE event ─────────│  { id: 3, result: { stop_reason: "end_turn" } }
-  │              ▼                     │
+  │    Acp-Session-Id: sess_abc123     │
   │                                    │
+  │<────── 202 Accepted ───────────────│  (returns immediately)
+  │              │                     │
+  │<─────────────│─ SSE event ─────────│  notification: AgentMessageChunk (sessionId: "sess_abc123")
+  │<─────────────│─ SSE event ─────────│  notification: AgentThoughtChunk (sessionId: "sess_abc123")
+  │<─────────────│─ SSE event ─────────│  notification: ToolCall (sessionId: "sess_abc123")
+  │<─────────────│─ SSE event ─────────│  notification: ToolCallUpdate (sessionId: "sess_abc123")
+  │<─────────────│─ SSE event ─────────│  notification: AgentMessageChunk (sessionId: "sess_abc123")
+  │<─────────────│─ SSE event ─────────│  { id: 3, result: { sessionId: "sess_abc123", ... } }
+  │              │                     │  (response comes on GET stream)
+  │              │                     │
   │  ═══ Permission Flow ═══           │
   │  (when tool requires confirmation) │
   │                                    │
   │─── POST /acp ─────────────────────>│  { method: "session/prompt", id: 4, ... }
   │    Acp-Connection-Id: <conn_id>    │
-  │    Acp-Session-Id: <session_id>    │
-  │              ┌─────────────────────│
-  │<─────────────│─ SSE event ─────────│  notification: ToolCall (status: pending)
-  │<─────────────│─ SSE event ─────────│  { method: "request_permission", id: 99, params: {...} }
-  │              │                     │  (server-to-client request)
-  │              │                     │
-  │─── POST /acp ┼────────────────────>│  { id: 99, result: { outcome: "allow_once" } }
-  │    Acp-Connection-Id: <conn_id>    │  (client response, returns 202 Accepted)
-  │    Acp-Session-Id: <session_id>    │
-  │              │                     │
-  │<─────────────│─ SSE event ─────────│  notification: ToolCallUpdate (status: completed)
-  │<─────────────│─ SSE event ─────────│  { id: 4, result: { stop_reason: "end_turn" } }
-  │              ▼                     │
+  │    Acp-Session-Id: sess_abc123     │
   │                                    │
+  │<────── 202 Accepted ───────────────│
+  │              │                     │
+  │<─────────────│─ SSE event ─────────│  notification: ToolCall (sessionId: "sess_abc123")
+  │<─────────────│─ SSE event ─────────│  { method: "request_permission", id: 99,
+  │              │                     │    params: { sessionId: "sess_abc123", ... } }
+  │              │                     │  (server-to-client request)
+  │─── POST /acp ────────────────────>│  { id: 99, result: { outcome: "allow_once" } }
+  │    Acp-Connection-Id: <conn_id>    │  (client response)
+  │    Acp-Session-Id: sess_abc123     │
+  │                                    │
+  │<────── 202 Accepted ───────────────│
+  │              │                     │
+  │<─────────────│─ SSE event ─────────│  notification: ToolCallUpdate (sessionId: "sess_abc123")
+  │<─────────────│─ SSE event ─────────│  { id: 4, result: { sessionId: "sess_abc123", ... } }
+  │              │                     │  (response comes on GET stream)
+  │              │                     │
   │  ═══ Cancel Flow ═══               │
   │                                    │
   │─── POST /acp ─────────────────────>│  { method: "session/prompt", id: 5, ... }
   │    Acp-Connection-Id: <conn_id>    │
-  │    Acp-Session-Id: <session_id>    │
-  │              ┌─────────────────────│
-  │<─────────────│─ SSE event ─────────│  notification: AgentMessageChunk
-  │              │                     │
-  │─── POST /acp ┼────────────────────>│  { method: "session/cancel" }
-  │    Acp-Connection-Id: <conn_id>    │  (notification, no id - returns 202 Accepted)
-  │    Acp-Session-Id: <session_id>    │
-  │              │                     │
-  │<─────────────│─ SSE event ─────────│  { id: 5, result: { stop_reason: "cancelled" } }
-  │              ▼                     │
+  │    Acp-Session-Id: sess_abc123     │
   │                                    │
+  │<────── 202 Accepted ───────────────│
+  │              │                     │
+  │<─────────────│─ SSE event ─────────│  notification: AgentMessageChunk (sessionId: "sess_abc123")
+  │              │                     │
+  │─── POST /acp ─────────────────────>│  { method: "session/cancel",
+  │    Acp-Connection-Id: <conn_id>    │    params: { sessionId: "sess_abc123" } }
+  │    Acp-Session-Id: sess_abc123     │
+  │                                    │
+  │<────── 202 Accepted ───────────────│  (notification, no id)
+  │              │                     │
+  │<─────────────│─ SSE event ─────────│  { id: 5, result: { sessionId: "sess_abc123", ... } }
+  │              │                     │  (response comes on GET stream)
+  │              │                     │
   │  ═══ Resume Session Flow ═══       │
   │  (new connection, existing session)│
   │                                    │
   │─── POST /acp ─────────────────────>│  { method: "initialize", id: 1 }
   │    (no Acp-Connection-Id)          │  New connection
-  │              ┌─────────────────────│
-  │<─────────────│─ SSE event ─────────│  { id: 1, result: { capabilities } }
-  │              │                     │  Response includes new Acp-Connection-Id
-  │              ▼                     │
+  │<────── 200 OK ─────────────────────│  { id: 1, result: { capabilities, connectionId } }
+  │    Acp-Connection-Id: <new_conn>   │
   │                                    │
-  │─── POST /acp ─────────────────────>│  { method: "session/load", id: 2,
-  │    Acp-Connection-Id: <conn_id>    │    params: { sessionId: "sess_abc123", cwd } }
-  │    Acp-Session-Id: <session_id>    │
+  │─── GET /acp ──────────────────────>│  Open new GET stream
+  │    Acp-Connection-Id: <new_conn>   │
+  │              ┌─────────────────────│  (SSE stream open)
   │              │                     │
-  │              ┌─────────────────────│  Response includes Acp-Session-Id header
-  │<─────────────│─ SSE event ─────────│  notification: UserMessageChunk (history replay)
-  │<─────────────│─ SSE event ─────────│  notification: AgentMessageChunk (history replay)
-  │<─────────────│─ SSE event ─────────│  notification: ToolCall (history replay)
-  │<─────────────│─ SSE event ─────────│  notification: ToolCallUpdate (history replay)
-  │<─────────────│─ SSE event ─────────│  { id: 2, result: {} }
-  │              ▼                     │
+  │─── POST /acp ─────────────────────>│  { method: "session/load", id: 2,
+  │    Acp-Connection-Id: <new_conn>   │    params: { sessionId: "sess_abc123", cwd } }
+  │    Acp-Session-Id: sess_abc123     │
   │                                    │
+  │<────── 202 Accepted ───────────────│
+  │              │                     │
+  │<─────────────│─ SSE event ─────────│  notification: UserMessageChunk (sessionId: "sess_abc123")
+  │<─────────────│─ SSE event ─────────│  notification: AgentMessageChunk (sessionId: "sess_abc123")
+  │<─────────────│─ SSE event ─────────│  notification: ToolCall (sessionId: "sess_abc123")
+  │<─────────────│─ SSE event ─────────│  notification: ToolCallUpdate (sessionId: "sess_abc123")
+  │<─────────────│─ SSE event ─────────│  { id: 2, result: { sessionId: "sess_abc123" } }
+  │              │                     │  (response comes on GET stream)
+  │              │                     │
   │  ═══ Connection Termination ═══    │
   │                                    │
   │─── DELETE /acp ───────────────────>│  Terminate connection
   │    Acp-Connection-Id: <conn_id>    │
   │<────────── 202 Accepted ───────────│
+  │              ▼                     │  (GET stream closes)
 ```
 
 #### Content Negotiation and Validation
 
-- `Content-Type` **MUST** be `application/json` (415 otherwise).
-- `Accept` **MUST** include both `application/json` and `text/event-stream` (406 otherwise).
+- POST `Content-Type` **MUST** be `application/json` (415 otherwise).
+- GET `Accept` **MUST** include `text/event-stream` (406 otherwise).
+- POST requests for session-scoped operations **MUST** include both `Acp-Connection-Id` and `Acp-Session-Id` headers.
 - Batch JSON-RPC requests return 501.
+- HTTP/2 is **REQUIRED** for Streamable HTTP transport.
 
 ### WebSocket Request Flow
 
@@ -261,76 +257,76 @@ All messages are WebSocket text frames containing JSON-RPC. Binary frames are ig
 ```
 GET /acp
   ├── Has Upgrade: websocket? → WebSocket handler
-  └── No → SSE stream handler (requires Acp-Connection-Id and Acp-Session-Id)
-        ├── Missing Acp-Connection-Id or Acp-Session-Id? → 400 Bad Request
-        └── Valid headers → Session-scoped stream (only events for that session)
+  └── No → SSE stream handler
+        ├── Missing Acp-Connection-Id? → 400 Bad Request
+        ├── Unknown Acp-Connection-Id? → 404 Not Found
+        └── Valid Acp-Connection-Id → Open connection-scoped SSE stream
 
 POST /acp
-  ├── Initialize request? → Create connection, return SSE with Acp-Connection-Id
+  ├── Initialize request (no Acp-Connection-Id)? → Create connection, return 200 with JSON
   ├── No Acp-Connection-Id? → 400 Bad Request
   ├── Unknown Acp-Connection-Id? → 404 Not Found
-  └── Has valid Acp-Connection-Id
-        ├── session/new or session/load → Forward, return SSE with Acp-Session-Id
-        ├── Session method without Acp-Session-Id → 400 Bad Request
-        ├── JSON-RPC request → Forward, return SSE
-        └── Notification/response → Forward, return 202
+  ├── Session-scoped request missing Acp-Session-Id? → 400 Bad Request
+  └── Has valid Acp-Connection-Id (and Acp-Session-Id if required) → Forward to agent, return 202 Accepted
 
 DELETE /acp
-  ├── Has Acp-Connection-Id? → Terminate connection and all associated sessions
-  └── No → 400 Bad Request
+  ├── Has Acp-Connection-Id? → Terminate connection and all associated sessions, return 202
+  └── No Acp-Connection-Id? → 400 Bad Request
 ```
 
-### Session Model
+### Connection and Session Model
 
 ```
 Connection {
     connection_id:  String,                          // Acp-Connection-Id
     capabilities:   NegotiatedCapabilities,
-    sessions:       HashMap<String, Session>,         // keyed by Acp-Session-Id
+    sessions:       HashMap<String, Session>,        // keyed by sessionId (JSON-RPC field)
+    get_stream:     Option<SseStream>,               // Single GET stream for this connection
     to_agent_tx:    mpsc::Sender<String>,
     from_agent_rx:  Arc<Mutex<Receiver<String>>>,
     handle:         JoinHandle<()>,
 }
 
 Session {
-    session_id:     String,                          // Acp-Session-Id / sessionId
-    get_listeners:  Vec<SseStream>,                  // GET SSE streams for this session
+    session_id:     String,                          // sessionId (JSON-RPC field)
+    // session-specific state
 }
 ```
 
-The agent task is spawned once per connection. Sessions are created within a connection via `session/new`, which returns the `Acp-Session-Id` in both the HTTP response header and the JSON-RPC result body. The transport layer adapts channels to the wire format (SSE events for HTTP, text frames for WebSocket). GET listeners are always session-scoped — both `Acp-Connection-Id` and `Acp-Session-Id` are required, and the server delivers only events belonging to that session.
+The agent task is spawned once per connection. A single GET SSE stream delivers all server→client messages for that connection, regardless of which session they belong to. Sessions are identified by the `sessionId` field in JSON-RPC messages. The transport layer adapts channels to the wire format (SSE events for HTTP, text frames for WebSocket).
 
-### MCP Streamable HTTP Compliance
+### Comparing to MCP Streamable HTTP
 
-| MCP Requirement                            | ACP Implementation                                                               | Status               |
-| ------------------------------------------ | -------------------------------------------------------------------------------- | -------------------- |
-| POST for all client→server messages        | ✅                                                                               | Compliant            |
-| Accept header validation (406)             | ✅                                                                               | Compliant            |
-| Notifications/responses return 202         | ✅                                                                               | Compliant            |
-| Requests return SSE stream                 | ✅                                                                               | Compliant            |
-| Session ID on initialize response          | ✅ (`Acp-Connection-Id`)                                                         | Compliant (renamed)  |
-| Session ID required on subsequent requests | ✅ (`Acp-Connection-Id` required; `Acp-Session-Id` required after `session/new`) | Compliant (extended) |
-| GET opens SSE stream                       | ✅                                                                               | Compliant            |
-| DELETE terminates session                  | ✅ (terminates connection)                                                       | Compliant            |
-| 404 for unknown sessions                   | ✅ (unknown connection IDs)                                                      | Compliant            |
-| Batch requests                             | ❌ (returns 501)                                                                 | Documented deviation |
-| Resumability (Last-Event-ID)               | ❌                                                                               | Future work          |
-| Protocol version header                    | ❌                                                                               | Future work          |
+| MCP Requirement                            | ACP Implementation                                | Status               |
+| ------------------------------------------ | ------------------------------------------------- | -------------------- |
+| POST for all client→server messages        | ✅                                                | Compliant            |
+| Accept header validation (406)             | ✅                                                | Compliant            |
+| Notifications/responses return 202         | ✅ (except `initialize` returns 200)              | Mostly compliant     |
+| Requests return SSE stream                 | ❌ (single long-lived GET stream instead)         | Documented deviation |
+| Session ID on initialize response          | ✅ (`Acp-Connection-Id`)                          | Compliant (renamed)  |
+| Session ID required on subsequent requests | ✅ (`Acp-Connection-Id` + `Acp-Session-Id`)       | Compliant (extended) |
+| GET opens SSE stream                       | ✅ (single connection-scoped stream)              | Compliant            |
+| DELETE terminates session                  | ✅ (terminates connection)                        | Compliant            |
+| 404 for unknown sessions                   | ✅ (unknown connection IDs)                       | Compliant            |
+| Batch requests                             | ❌ (returns 501)                                  | Documented deviation |
+| Resumability (Last-Event-ID)               | ❌                                                | Future work          |
+| Protocol version header                    | ❌                                                | Future work          |
 
 ### Deviations from MCP Streamable HTTP
 
-1. **Header naming**: `Acp-Connection-Id` / `Acp-Session-Id` / `Acp-Protocol-Version` instead of MCP equivalents. `Acp-Connection-Id` maps to MCP's `Mcp-Session-Id` but is deliberately renamed to avoid confusion with ACP's session concept (see [Identity Model](#identity-model)).
-2. **Two-header model**: MCP uses a single `Mcp-Session-Id` for both transport binding and session identity. ACP separates these into `Acp-Connection-Id` (connection-scoped, from `initialize`) and `Acp-Session-Id` (session-scoped, from `session/new`), because ACP sessions are an explicit protocol concept with their own lifecycle (`session/new`, `session/load`, `session/cancel`). The `Acp-Session-Id` also enables session-scoped GET listener streams.
-3. **Session-scoped GET streams**: GET listeners require both `Acp-Connection-Id` and `Acp-Session-Id`. The server MUST only deliver events belonging to that session. There is no connection-scoped GET stream. MCP has no equivalent concept.
-4. **WebSocket extension**: MCP doesn't define WebSocket. ACP adds it as a required client capability. Clients MUST support WebSocket, and servers MAY choose to only support WebSocket connections.
-5. **Cookie support required**: Clients MUST handle cookies on HTTP transports for the duration of the connection, enabling sticky sessions and per-connection server state.
-6. **No batch requests**: Returns 501. May be added later.
-7. **No resumability yet in reference implementation**: SSE event IDs and `Last-Event-ID` resumption planned as follow-up.
+1. **Single long-lived GET stream**: MCP opens a new SSE stream for each request response. ACP uses a single long-lived GET stream per connection for all server→client messages. POST requests (except `initialize`) return 202 Accepted immediately, and responses arrive on the GET stream correlated by JSON-RPC `id`.
+2. **Initialize returns JSON directly**: MCP's `initialize` returns an SSE stream. ACP's `initialize` returns `200 OK` with a JSON response body containing capabilities and `connectionId`. The `Acp-Connection-Id` is also included in the response header.
+3. **HTTP/2 required**: ACP requires HTTP/2 for multiplexing concurrent POST requests alongside the long-lived GET stream.
+4. **Two-header model**: ACP uses both `Acp-Connection-Id` (for connection identity) and `Acp-Session-Id` (for session identity on POST requests). MCP only uses `Mcp-Session-Id`. This allows ACP to distinguish connection-level state from session-level operations while supporting multiple concurrent sessions on one connection.
+6. **WebSocket extension**: MCP doesn't define WebSocket. ACP adds it as a required client capability. Clients MUST support WebSocket, and servers MAY choose to only support WebSocket connections.
+7. **Cookie support required**: Clients MUST handle cookies on HTTP transports for the duration of the connection, enabling sticky sessions and per-connection server state.
+8. **No batch requests**: Returns 501. May be added later.
+9. **No resumability yet in reference implementation**: SSE event IDs and `Last-Event-ID` resumption planned as follow-up.
 
 ### Implementation Plan
 
 1. **Phase 1 — Specification** (this RFD): Define the transport spec and align terminology.
-2. **Phase 2 — Reference Implementation** (in progress): Working implementation in Goose (`block/goose`) at `crates/goose-acp/src/transport/` (`transport.rs`, `http.rs`, `websocket.rs`).
+2. **Phase 2 — Reference Implementation** (in progress): Working implementation in Goose (`block/goose`).
 3. **Phase 3 — SDK Support**: Add Streamable HTTP and WebSocket client support to Rust SDK (`sacp`), then TypeScript SDK.
 4. **Phase 4 — Hardening**: Origin validation, `Acp-Protocol-Version`, SSE resumability, batch requests, security audit.
 
@@ -340,15 +336,15 @@ The agent task is spawned once per connection. Sessions are created within a con
 
 ### Why not just use MCP Streamable HTTP as-is?
 
-We largely do. The differences are: header naming (`Acp-Connection-Id` + `Acp-Session-Id` vs MCP's single `Mcp-Session-Id`), the WebSocket extension for long-running agent sessions, the two-header model that separates connection identity from session identity, and session-scoped GET listener streams.
+MCP opens a new SSE stream for each request response, which creates many long-lived connections and complicates load balancing. ACP uses a single long-lived GET stream per connection for all server→client messages, dramatically reducing connection count and simplifying sticky session routing. This is better suited for ACP's bidirectional, multi-session nature.
 
-### Why two headers (`Acp-Connection-Id` and `Acp-Session-Id`) instead of one?
+### How are sessions identified?
 
-MCP uses a single `Mcp-Session-Id` because MCP has no protocol-level concept of sessions. ACP does — `session/new` creates a conversation with its own lifecycle. Using one header for both would conflate the initialized connection (capabilities, protocol version, auth state) with the active session (conversation context, history). Two headers let the server immediately distinguish which connection _and_ which session a request belongs to, enable session-scoped GET listener streams, and support multiple concurrent sessions within a single connection.
+ACP uses `Acp-Connection-Id` in HTTP headers to identify the connection, and `sessionId` in JSON-RPC message bodies to identify sessions. A single connection may host multiple sessions. The single GET stream delivers messages for all sessions, and clients demux by the `sessionId` field in each message.
 
 ### Why add WebSocket support?
 
-A single `prompt` can generate dozens of streaming updates and ACP is more bidirectional in nature than MCP. With Streamable HTTP, the server can only push via SSE on POST responses or a separate GET stream. WebSocket provides true bidirectional messaging, lower per-message overhead, and connection persistence. Clients MUST support WebSocket so that servers can choose to only support WebSocket connections, simplifying deployment. Streamable HTTP remains available as an additional option for environments where WebSocket is not viable on the server side (e.g., serverless).
+ACP is highly bidirectional with frequent streaming updates. WebSocket provides true bidirectional messaging with lower per-message overhead than HTTP. Clients MUST support WebSocket so that servers can choose to only support WebSocket connections, simplifying deployment. Streamable HTTP remains available as an additional option for environments where WebSocket is not viable on the server side (e.g., serverless).
 
 ### How does the server distinguish WebSocket from SSE on GET?
 
@@ -356,13 +352,14 @@ By inspecting the `Upgrade: websocket` header. This is standard HTTP behavior.
 
 ### Can a client have multiple sessions on one connection?
 
-Yes. A client may call `session/new` multiple times within a single `Acp-Connection-Id`. Each returns a distinct `Acp-Session-Id`. The client includes the appropriate `Acp-Session-Id` header (and `sessionId` in the JSON-RPC params) on subsequent requests. The `Acp-Connection-Id` header remains the same across all of them. The client may also open separate GET listener streams per session, each requiring both `Acp-Connection-Id` and `Acp-Session-Id`.
+Yes. A client may call `session/new` multiple times within a single `Acp-Connection-Id`. Each returns a distinct `sessionId` in the response body. All messages for all sessions are delivered on the single GET stream. The client demuxes messages by the `sessionId` field in each JSON-RPC message.
 
 ### What alternative approaches did you consider, and why did you settle on this one?
 
+- **Per-request SSE streams (like MCP)**: Rejected — creates too many long-lived connections, complicates load balancing, and wastes resources.
 - **Separate endpoints** (`/acp/http`, `/acp/ws`): Rejected — single endpoint is simpler; WebSocket upgrade is natural HTTP.
-- **WebSocket only**: Rejected — doesn't work through all proxies; Streamable HTTP is better for stateless/serverless.
-- **Single header for both connection and session**: Rejected — conflates connection lifecycle with session lifecycle, prevents session-scoped GET streams, and makes multi-session connections ambiguous.
+- **WebSocket only**: Rejected — doesn't work through all proxies.
+- **Session-scoped GET streams**: Rejected — still creates multiple long-lived connections per client. Connection-scoped stream with JSON-RPC demuxing is simpler.
 
 ### How does this interact with authentication?
 
@@ -372,8 +369,13 @@ Authentication (see auth-methods RFD) is orthogonal and layered on top via HTTP 
 
 Clients SHOULD include it on all requests after initialization. Not yet implemented; part of Phase 4 hardening.
 
+### Why require HTTP/2?
+
+HTTP/2 provides multiplexing, allowing many concurrent POST requests alongside the long-lived GET stream on a single TCP connection. This is essential for efficient operation with the single-stream model. HTTP/1.1 would require separate TCP connections for each concurrent POST, defeating the efficiency gains.
+
 ## Revision history
 
 - **2025-03-10**: Initial draft based on the RFC template and goose reference implementation.
 - **2026-04-01**: Introduced a two-header identity model: `Acp-Connection-Id` (returned at `initialize`, binds to the connection) and `Acp-Session-Id` (returned at `session/new`, scopes to a session). This addresses feedback that the original single `Acp-Session-Id` conflated transport binding with ACP session identity, and enables session-scoped GET listener streams for targeted server-to-client event delivery. Removed connection-scoped GET streams — all GET SSE listeners now require both `Acp-Connection-Id` and `Acp-Session-Id`.
 - **2026-04-15**: Minor edits
+- **2026-04-23**: Major revision to single long-lived GET stream model. Changed from per-request SSE streams to a single connection-scoped GET stream for all server→client messages. POST requests (except `initialize`) now return 202 Accepted immediately. `initialize` returns 200 OK with JSON response body. Required HTTP/2 for multiplexing. This change makes the HTTP usage more similar to WebSocket and supports better the bidirectional nature of ACP.


### PR DESCRIPTION
Per [discussion](https://agentclientprotocol.zulipchat.com/#narrow/channel/590951-transports/topic/Updated.20Reference.20Implementation.20of.20RFD.20721.20Available/near/587693507) in the Transports WG Zulip here is a revision to the request patterns for consideration.

# Summary

* A single `Acp-Connection-Id` scoped GET stream delivers all server -> client responses and messages within a connection
* POSTS now return immediately with 202 Accepted
* We now will require HTTP/2 for multiplexing and using a single TCP connection
* Websocket implementation is unchanged

cc @anna239 @benbrandt