### PR TITLE
docs: add eino-contrib/acp to community Go libraries

### DIFF
--- a/docs/libraries/community.mdx
+++ b/docs/libraries/community.mdx
@@ -19,6 +19,7 @@ description: "Community managed libraries for the Agent Client Protocol"
 
 - [acp-go-sdk](https://github.com/coder/acp-go-sdk)
 - [acp-go](https://github.com/ironpark/acp-go)
+- [acp](https://github.com/eino-contrib/acp)
 
 ## React
 


### PR DESCRIPTION
Adds [eino-contrib/acp](https://github.com/eino-contrib/acp) to the Go section of the community libraries page.

This is a Go SDK for Agent Client Protocol that provides:
- Bidirectional RPC abstraction (JSON-RPC 2.0)
- Three transport layers: stdio (subprocess), Streamable HTTP (POST + SSE), and WebSocket
- Remote server (ACPServer) and transparent proxy (ACPProxy) support
- Protocol extensibility for custom methods