### PR TITLE
docs: Clients page: create CLI/TUI category

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -20,7 +20,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - Visual Studio Code — through the [ACP Client](https://github.com/formulahendry/vscode-acp) extension
 - [Zed](https://zed.dev/docs/ai/external-agents)
 
-## CLI/TUI
+## CLI and TUI
 
 - [acpx (CLI)](https://github.com/openclaw/acpx)
 - [Nori CLI](https://github.com/tilework-tech/nori-cli)

--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -20,10 +20,16 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - Visual Studio Code — through the [ACP Client](https://github.com/formulahendry/vscode-acp) extension
 - [Zed](https://zed.dev/docs/ai/external-agents)
 
-## Clients and apps
+## CLI/TUI
+
+- [acpx (CLI)](https://github.com/openclaw/acpx)
+- [Nori CLI](https://github.com/tilework-tech/nori-cli)
+- [pool](https://github.com/poolsideai/pool)
+- [Toad](https://www.batrachian.ai/)
+
+## Desktop and Web
 
 - [ACP UI](https://github.com/formulahendry/acp-ui) (Windows, macOS, Linux, iOS, Android, Web)
-- [acpx (CLI)](https://github.com/openclaw/acpx)
 - [gemini-cli-desktop](https://github.com/Piebald-AI/gemini-cli-desktop)
 - [Agent Studio](https://github.com/sxhxliang/agent-studio)
 - [AionUi](https://github.com/iOfficeAI/AionUi)
@@ -31,19 +37,15 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [DeepChat](https://github.com/ThinkInAIXYZ/deepchat)
 - [fabriqa.ai](https://fabriqa.ai)
 - [Harnss](https://github.com/OpenSource03/harnss)
-- [iflow-cli](https://github.com/iflow-ai/iflow-cli)
 - [Jockey](https://github.com/recailai/jockey) — open-source multi-agent orchestrator (Tauri + Rust + SolidJS) that coordinates Claude Code, Gemini CLI, and Codex CLI via ACP
 - [Lody](https://lody.ai)
 - [Minion Mind](https://minion-mind.nebulame.com/) — through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
 - [Mitto](https://github.com/inercia/mitto)
-- [Nori CLI](https://github.com/tilework-tech/nori-cli)
 - [Ngent](https://github.com/beyond5959/ngent)
-- [pool](https://github.com/poolsideai/pool)
 - [RayClaw](https://github.com/rayclaw/rayclaw?tab=readme-ov-file#acp-agent-client-protocol)
 - [RLM Code](https://github.com/SuperagenticAI/rlm-code)
 - [Sidequery _(coming soon)_](https://sidequery.dev)
 - [Tidewave](https://tidewave.ai/)
-- [Toad](https://www.batrachian.ai/)
 - [Web Browser with AI SDK](https://github.com/mcpc-tech/ai-elements-remix-template) (powered by [@mcpc/acp-ai-provider](https://github.com/mcpc-tech/mcpc/tree/main/packages/acp-ai-provider))
 
 ## Notebook and data tools


### PR DESCRIPTION
I think this improves page navigation.

I also removed `iflow-cli`, since it appears that [the project has been closed](https://github.com/iflow-ai/iflow-cli/commit/4642808afbc6580ac117d930f6c64ac0d84955c7).