### PR TITLE
Add agentrq to clients and move gemini to alphanumeric sorted order

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -30,12 +30,13 @@ The following projects implement ACP directly, connect ACP agents to other envir
 ## Desktop and Web
 
 - [ACP UI](https://github.com/formulahendry/acp-ui) (Windows, macOS, Linux, iOS, Android, Web)
-- [gemini-cli-desktop](https://github.com/Piebald-AI/gemini-cli-desktop)
 - [Agent Studio](https://github.com/sxhxliang/agent-studio)
+- [AgentRQ](https://github.com/agentrq/agentrq) — Human-in-the-loop realtime task management and collaboration (Web)
 - [AionUi](https://github.com/iOfficeAI/AionUi)
 - [aizen](https://aizen.win)
 - [DeepChat](https://github.com/ThinkInAIXYZ/deepchat)
 - [fabriqa.ai](https://fabriqa.ai)
+- [gemini-cli-desktop](https://github.com/Piebald-AI/gemini-cli-desktop)
 - [Harnss](https://github.com/OpenSource03/harnss)
 - [Jockey](https://github.com/recailai/jockey) — open-source multi-agent orchestrator (Tauri + Rust + SolidJS) that coordinates Claude Code, Gemini CLI, and Codex CLI via ACP
 - [Lody](https://lody.ai)


### PR DESCRIPTION
- Add opensource AgentRQ to the client list
- Move gemini to the alphanumeric correct order