### PR TITLE
docs: Add Sniptail to ACP clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -73,6 +73,7 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 - [Telegram ACP Bot](https://github.com/mgaitan/telegram-acp-bot) (Telegram) — through the [`telegram-acp-bot`](https://github.com/mgaitan/telegram-acp-bot) connector
 - [Telegram-ACP](https://github.com/SuperKenVery/Telegram-ACP/) (Telegram) — Supports multi-thread chat and message streaming
 - [WeChat ACP](https://github.com/formulahendry/wechat-acp) (WeChat)
+- [Sniptail](https://github.com/Justkog/sniptail) (Discord, Slack) - self-hosted chat bridge for running coding agents across your team’s repositories
 
 ## Frameworks
 


### PR DESCRIPTION
## Summary

Adds Sniptail to the Messaging section of the ACP clients list.

Sniptail is a self-hosted Slack, Discord, and Telegram chat bridge for running coding agents across a team’s repositories.

## Why

Sniptail supports ACP-backed coding-agent workflows and fits alongside the existing messaging clients listed for Discord, Slack, and Telegram.

## Change

- Added Sniptail to `## Messaging`