### PR TITLE
Add session/setTitle method

### DIFF
--- a/agent-client-protocol-schema/Cargo.toml
+++ b/agent-client-protocol-schema/Cargo.toml
@@ -24,6 +24,7 @@ workspace = true
 [features]
 unstable = [
     "unstable_auth_methods",
+    "unstable_cancel_request",
     "unstable_elicitation",
     "unstable_llm_providers",
     "unstable_mcp_over_acp",
@@ -38,6 +39,7 @@ unstable = [
 # version, so it must be opted into explicitly.
 unstable_protocol_v2 = []
 unstable_auth_methods = []
+unstable_cancel_request = []
 unstable_elicitation = []
 unstable_llm_providers = []
 unstable_mcp_over_acp = []

--- a/agent-client-protocol-schema/src/v1/agent.rs
+++ b/agent-client-protocol-schema/src/v1/agent.rs
@@ -2242,6 +2242,92 @@ impl SetSessionModeResponse {
     }
 }
 
+/// Request parameters for setting a session title.
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[schemars(extend("x-side" = "agent", "x-method" = SESSION_SET_TITLE_METHOD_NAME))]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct SetSessionTitleRequest {
+    /// The ID of the session to set the title for.
+    pub session_id: SessionId,
+    /// The new title for the session.
+    pub title: String,
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
+    #[serde(default)]
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+impl SetSessionTitleRequest {
+    /// Builds [`SetSessionTitleRequest`] with the required request fields set; optional fields start unset or empty.
+    #[must_use]
+    pub fn new(session_id: impl Into<SessionId>, title: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            title: title.into(),
+            meta: None,
+        }
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// Response to `session/setTitle` method.
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[schemars(extend("x-side" = "agent", "x-method" = SESSION_SET_TITLE_METHOD_NAME))]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct SetSessionTitleResponse {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
+    #[serde(default)]
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+impl SetSessionTitleResponse {
+    /// Builds [`SetSessionTitleResponse`] with the required response fields set; optional fields start unset or empty.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
 // Session config options
 
 /// Unique identifier for a session configuration option.
@@ -4293,6 +4379,11 @@ pub struct SessionCapabilities {
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
     pub close: Option<SessionCloseCapabilities>,
+    /// Whether the agent supports `session/setTitle`.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
+    #[serde(default)]
+    pub set_title: Option<SessionSetTitleCapabilities>,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
     /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
     /// these keys.
@@ -4378,6 +4469,13 @@ impl SessionCapabilities {
     #[must_use]
     pub fn close(mut self, close: impl IntoOption<SessionCloseCapabilities>) -> Self {
         self.close = close.into_option();
+        self
+    }
+
+    /// Whether the agent supports `session/setTitle`.
+    #[must_use]
+    pub fn set_title(mut self, set_title: impl IntoOption<SessionSetTitleCapabilities>) -> Self {
+        self.set_title = set_title.into_option();
         self
     }
 
@@ -4636,6 +4734,45 @@ impl SessionCloseCapabilities {
     }
 }
 
+/// Capabilities for the `session/setTitle` method.
+///
+/// By supplying `{}` it means that the agent supports setting session titles.
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SessionSetTitleCapabilities {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
+    #[serde(default)]
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+impl SessionSetTitleCapabilities {
+    /// Builds an empty [`SessionSetTitleCapabilities`]; use builder methods to advertise supported sub-capabilities.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
 /// Prompt capabilities supported by the agent in `session/prompt` requests.
 ///
 /// Baseline agent functionality requires support for [`ContentBlock::Text`]
@@ -4838,6 +4975,8 @@ pub struct AgentMethodNames {
     pub session_load: &'static str,
     /// Method for setting the mode for a session.
     pub session_set_mode: &'static str,
+    /// Method for setting the title for a session.
+    pub session_set_title: &'static str,
     /// Method for setting a configuration option for a session.
     pub session_set_config_option: &'static str,
     /// Method for sending a prompt to the agent.
@@ -4905,6 +5044,7 @@ pub const AGENT_METHOD_NAMES: AgentMethodNames = AgentMethodNames {
     session_new: SESSION_NEW_METHOD_NAME,
     session_load: SESSION_LOAD_METHOD_NAME,
     session_set_mode: SESSION_SET_MODE_METHOD_NAME,
+    session_set_title: SESSION_SET_TITLE_METHOD_NAME,
     session_set_config_option: SESSION_SET_CONFIG_OPTION_METHOD_NAME,
     session_prompt: SESSION_PROMPT_METHOD_NAME,
     session_cancel: SESSION_CANCEL_METHOD_NAME,
@@ -4958,6 +5098,8 @@ pub(crate) const SESSION_NEW_METHOD_NAME: &str = "session/new";
 pub(crate) const SESSION_LOAD_METHOD_NAME: &str = "session/load";
 /// Method name for setting the mode for a session.
 pub(crate) const SESSION_SET_MODE_METHOD_NAME: &str = "session/set_mode";
+/// Method name for setting the title for a session.
+pub(crate) const SESSION_SET_TITLE_METHOD_NAME: &str = "session/setTitle";
 /// Method name for setting a configuration option for a session.
 pub(crate) const SESSION_SET_CONFIG_OPTION_METHOD_NAME: &str = "session/set_config_option";
 /// Method name for sending a prompt.
@@ -5112,6 +5254,13 @@ pub enum ClientRequest {
     ///
     /// See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/session-modes)
     SetSessionModeRequest(SetSessionModeRequest),
+    /// Sets the title for a session.
+    ///
+    /// Empty titles are valid and request that the agent clear the session title.
+    ///
+    /// This method can be called at any time during a session, whether the Agent is
+    /// idle or actively generating a response.
+    SetSessionTitleRequest(SetSessionTitleRequest),
     /// Sets the current value for a session configuration option.
     SetSessionConfigOptionRequest(SetSessionConfigOptionRequest),
     /// Processes a user prompt within a session.
@@ -5189,6 +5338,7 @@ impl ClientRequest {
             Self::ResumeSessionRequest(_) => AGENT_METHOD_NAMES.session_resume,
             Self::CloseSessionRequest(_) => AGENT_METHOD_NAMES.session_close,
             Self::SetSessionModeRequest(_) => AGENT_METHOD_NAMES.session_set_mode,
+            Self::SetSessionTitleRequest(_) => AGENT_METHOD_NAMES.session_set_title,
             Self::SetSessionConfigOptionRequest(_) => AGENT_METHOD_NAMES.session_set_config_option,
             Self::PromptRequest(_) => AGENT_METHOD_NAMES.session_prompt,
             #[cfg(feature = "unstable_nes")]
@@ -5248,6 +5398,8 @@ pub enum AgentResponse {
     CloseSessionResponse(#[serde(default)] CloseSessionResponse),
     /// Successful result returned for a `session/set_mode` request.
     SetSessionModeResponse(#[serde(default)] SetSessionModeResponse),
+    /// Successful result returned for a `session/setTitle` request.
+    SetSessionTitleResponse(#[serde(default)] SetSessionTitleResponse),
     /// Successful result returned for a `session/set_config_option` request.
     SetSessionConfigOptionResponse(SetSessionConfigOptionResponse),
     /// Successful result returned for a `session/prompt` request.
@@ -6134,6 +6286,43 @@ mod test_serialization {
             }
             _ => panic!("Expected Terminal variant"),
         }
+    }
+
+    #[test]
+    fn test_set_session_title_request_roundtrip() {
+        let original = SetSessionTitleRequest::new("sess_1", "A clearer thread title");
+        let json = serde_json::to_value(&original).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "sessionId": "sess_1",
+                "title": "A clearer thread title"
+            })
+        );
+        let roundtripped: SetSessionTitleRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(original, roundtripped);
+    }
+
+    #[test]
+    fn test_set_session_title_response_roundtrip() {
+        let original = SetSessionTitleResponse::new();
+        let json = serde_json::to_value(&original).unwrap();
+        assert_eq!(json, json!({}));
+        let roundtripped: SetSessionTitleResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(original, roundtripped);
+    }
+
+    #[test]
+    fn test_set_session_title_capabilities_serialization() {
+        assert_eq!(
+            serde_json::to_value(
+                SessionCapabilities::new().set_title(SessionSetTitleCapabilities::new())
+            )
+            .unwrap(),
+            json!({
+                "setTitle": {}
+            })
+        );
     }
 
     #[cfg(feature = "unstable_boolean_config")]

--- a/agent-client-protocol-schema/src/v2/agent.rs
+++ b/agent-client-protocol-schema/src/v2/agent.rs
@@ -2026,6 +2026,92 @@ impl SessionInfo {
     }
 }
 
+/// Request parameters for setting a session title.
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[schemars(extend("x-side" = "agent", "x-method" = SESSION_SET_TITLE_METHOD_NAME))]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct SetSessionTitleRequest {
+    /// The ID of the session to set the title for.
+    pub session_id: SessionId,
+    /// The new title for the session.
+    pub title: String,
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
+    #[serde(default)]
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+impl SetSessionTitleRequest {
+    /// Builds [`SetSessionTitleRequest`] with the required request fields set; optional fields start unset or empty.
+    #[must_use]
+    pub fn new(session_id: impl Into<SessionId>, title: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            title: title.into(),
+            meta: None,
+        }
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// Response to `session/setTitle` method.
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[schemars(extend("x-side" = "agent", "x-method" = SESSION_SET_TITLE_METHOD_NAME))]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct SetSessionTitleResponse {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
+    #[serde(default)]
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+impl SetSessionTitleResponse {
+    /// Builds [`SetSessionTitleResponse`] with the required response fields set; optional fields start unset or empty.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
 // Session config options
 
 /// Unique identifier for a session configuration option.
@@ -4281,6 +4367,11 @@ pub struct SessionCapabilities {
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
     pub fork: Option<SessionForkCapabilities>,
+    /// Whether the agent supports `session/setTitle`.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
+    #[serde(default)]
+    pub set_title: Option<SessionSetTitleCapabilities>,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
     /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
     /// these keys.
@@ -4356,6 +4447,13 @@ impl SessionCapabilities {
     #[must_use]
     pub fn fork(mut self, fork: impl IntoOption<SessionForkCapabilities>) -> Self {
         self.fork = fork.into_option();
+        self
+    }
+
+    /// Whether the agent supports `session/setTitle`.
+    #[must_use]
+    pub fn set_title(mut self, set_title: impl IntoOption<SessionSetTitleCapabilities>) -> Self {
+        self.set_title = set_title.into_option();
         self
     }
 
@@ -4480,6 +4578,45 @@ pub struct SessionForkCapabilities {
 #[cfg(feature = "unstable_session_fork")]
 impl SessionForkCapabilities {
     /// Builds an empty [`SessionForkCapabilities`]; use builder methods to advertise supported sub-capabilities.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// Capabilities for the `session/setTitle` method.
+///
+/// By supplying `{}` it means that the agent supports setting session titles.
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SessionSetTitleCapabilities {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
+    #[serde(default)]
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+impl SessionSetTitleCapabilities {
+    /// Builds an empty [`SessionSetTitleCapabilities`]; use builder methods to advertise supported sub-capabilities.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -5022,6 +5159,8 @@ pub struct AgentMethodNames {
     pub session_new: &'static str,
     /// Method for loading an existing session.
     pub session_load: &'static str,
+    /// Method for setting the title for a session.
+    pub session_set_title: &'static str,
     /// Method for setting a configuration option for a session.
     pub session_set_config_option: &'static str,
     /// Method for sending a prompt to the agent.
@@ -5088,6 +5227,7 @@ pub const AGENT_METHOD_NAMES: AgentMethodNames = AgentMethodNames {
     providers_disable: PROVIDERS_DISABLE_METHOD_NAME,
     session_new: SESSION_NEW_METHOD_NAME,
     session_load: SESSION_LOAD_METHOD_NAME,
+    session_set_title: SESSION_SET_TITLE_METHOD_NAME,
     session_set_config_option: SESSION_SET_CONFIG_OPTION_METHOD_NAME,
     session_prompt: SESSION_PROMPT_METHOD_NAME,
     session_cancel: SESSION_CANCEL_METHOD_NAME,
@@ -5139,6 +5279,8 @@ pub(crate) const PROVIDERS_DISABLE_METHOD_NAME: &str = "providers/disable";
 pub(crate) const SESSION_NEW_METHOD_NAME: &str = "session/new";
 /// Method name for loading an existing session.
 pub(crate) const SESSION_LOAD_METHOD_NAME: &str = "session/load";
+/// Method name for setting the title for a session.
+pub(crate) const SESSION_SET_TITLE_METHOD_NAME: &str = "session/setTitle";
 /// Method name for setting a configuration option for a session.
 pub(crate) const SESSION_SET_CONFIG_OPTION_METHOD_NAME: &str = "session/set_config_option";
 /// Method name for sending a prompt.
@@ -5270,6 +5412,13 @@ pub enum ClientRequest {
     /// The agent must cancel any ongoing work (as if `session/cancel` was called)
     /// and then free up any resources associated with the session.
     CloseSessionRequest(Box<CloseSessionRequest>),
+    /// Sets the title for a session.
+    ///
+    /// Empty titles are valid and request that the agent clear the session title.
+    ///
+    /// This method can be called at any time during a session, whether the Agent is
+    /// idle or actively generating a response.
+    SetSessionTitleRequest(Box<SetSessionTitleRequest>),
     /// Sets the current value for a session configuration option.
     SetSessionConfigOptionRequest(Box<SetSessionConfigOptionRequest>),
     /// Processes a user prompt within a session.
@@ -5346,6 +5495,7 @@ impl ClientRequest {
             Self::ForkSessionRequest(_) => AGENT_METHOD_NAMES.session_fork,
             Self::ResumeSessionRequest(_) => AGENT_METHOD_NAMES.session_resume,
             Self::CloseSessionRequest(_) => AGENT_METHOD_NAMES.session_close,
+            Self::SetSessionTitleRequest(_) => AGENT_METHOD_NAMES.session_set_title,
             Self::SetSessionConfigOptionRequest(_) => AGENT_METHOD_NAMES.session_set_config_option,
             Self::PromptRequest(_) => AGENT_METHOD_NAMES.session_prompt,
             #[cfg(feature = "unstable_nes")]
@@ -5402,6 +5552,8 @@ pub enum AgentResponse {
     ResumeSessionResponse(#[serde(default)] Box<ResumeSessionResponse>),
     /// Successful result returned for a `session/close` request.
     CloseSessionResponse(#[serde(default)] Box<CloseSessionResponse>),
+    /// Successful result returned for a `session/setTitle` request.
+    SetSessionTitleResponse(#[serde(default)] Box<SetSessionTitleResponse>),
     /// Successful result returned for a `session/set_config_option` request.
     SetSessionConfigOptionResponse(Box<SetSessionConfigOptionResponse>),
     /// Successful result returned for a `session/prompt` request.
@@ -6406,6 +6558,43 @@ mod test_serialization {
             }
             _ => panic!("Expected Terminal variant"),
         }
+    }
+
+    #[test]
+    fn test_set_session_title_request_roundtrip() {
+        let original = SetSessionTitleRequest::new("sess_1", "A clearer thread title");
+        let json = serde_json::to_value(&original).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "sessionId": "sess_1",
+                "title": "A clearer thread title"
+            })
+        );
+        let roundtripped: SetSessionTitleRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(original, roundtripped);
+    }
+
+    #[test]
+    fn test_set_session_title_response_roundtrip() {
+        let original = SetSessionTitleResponse::new();
+        let json = serde_json::to_value(&original).unwrap();
+        assert_eq!(json, json!({}));
+        let roundtripped: SetSessionTitleResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(original, roundtripped);
+    }
+
+    #[test]
+    fn test_set_session_title_capabilities_serialization() {
+        assert_eq!(
+            serde_json::to_value(
+                SessionCapabilities::new().set_title(SessionSetTitleCapabilities::new())
+            )
+            .unwrap(),
+            json!({
+                "setTitle": {}
+            })
+        );
     }
 
     #[cfg(feature = "unstable_boolean_config")]

--- a/agent-client-protocol-schema/src/v2/conversion.rs
+++ b/agent-client-protocol-schema/src/v2/conversion.rs
@@ -3752,6 +3752,61 @@ impl IntoV2 for crate::v1::SessionInfo {
     }
 }
 
+impl IntoV1 for super::SetSessionTitleRequest {
+    type Output = crate::v1::SetSessionTitleRequest;
+
+    fn into_v1(self) -> Result<Self::Output> {
+        let Self {
+            session_id,
+            title,
+            meta,
+        } = self;
+        Ok(crate::v1::SetSessionTitleRequest {
+            session_id: session_id.into_v1()?,
+            title,
+            meta: meta.into_v1()?,
+        })
+    }
+}
+
+impl IntoV2 for crate::v1::SetSessionTitleRequest {
+    type Output = super::SetSessionTitleRequest;
+
+    fn into_v2(self) -> Result<Self::Output> {
+        let Self {
+            session_id,
+            title,
+            meta,
+        } = self;
+        Ok(super::SetSessionTitleRequest {
+            session_id: session_id.into_v2()?,
+            title,
+            meta: meta.into_v2()?,
+        })
+    }
+}
+
+impl IntoV1 for super::SetSessionTitleResponse {
+    type Output = crate::v1::SetSessionTitleResponse;
+
+    fn into_v1(self) -> Result<Self::Output> {
+        let Self { meta } = self;
+        Ok(crate::v1::SetSessionTitleResponse {
+            meta: meta.into_v1()?,
+        })
+    }
+}
+
+impl IntoV2 for crate::v1::SetSessionTitleResponse {
+    type Output = super::SetSessionTitleResponse;
+
+    fn into_v2(self) -> Result<Self::Output> {
+        let Self { meta } = self;
+        Ok(super::SetSessionTitleResponse {
+            meta: meta.into_v2()?,
+        })
+    }
+}
 impl IntoV1 for super::SessionConfigId {
     type Output = crate::v1::SessionConfigId;
 
@@ -4967,6 +5022,7 @@ impl super::SessionCapabilities {
             additional_directories,
             #[cfg(feature = "unstable_session_fork")]
             fork,
+            set_title,
             meta,
         } = self;
 
@@ -4979,6 +5035,7 @@ impl super::SessionCapabilities {
                 fork: into_v1_default_on_error(fork),
                 resume: Some(crate::v1::SessionResumeCapabilities::new()),
                 close: Some(crate::v1::SessionCloseCapabilities::new()),
+                set_title: into_v1_default_on_error(set_title),
                 meta: meta.into_v1()?,
             },
             prompt_capabilities: prompt.unwrap_or_default().into_v1()?,
@@ -5008,6 +5065,7 @@ impl super::SessionCapabilities {
             fork,
             resume: _,
             close: _,
+            set_title,
             meta,
         } = session_capabilities;
 
@@ -5018,6 +5076,7 @@ impl super::SessionCapabilities {
             additional_directories: into_v2_default_on_error(additional_directories),
             #[cfg(feature = "unstable_session_fork")]
             fork: into_v2_default_on_error(fork),
+            set_title: into_v2_default_on_error(set_title),
             meta: meta.into_v2()?,
         })
     }
@@ -5085,6 +5144,28 @@ impl IntoV2 for crate::v1::SessionForkCapabilities {
     fn into_v2(self) -> Result<Self::Output> {
         let Self { meta } = self;
         Ok(super::SessionForkCapabilities {
+            meta: meta.into_v2()?,
+        })
+    }
+}
+
+impl IntoV1 for super::SessionSetTitleCapabilities {
+    type Output = crate::v1::SessionSetTitleCapabilities;
+
+    fn into_v1(self) -> Result<Self::Output> {
+        let Self { meta } = self;
+        Ok(crate::v1::SessionSetTitleCapabilities {
+            meta: meta.into_v1()?,
+        })
+    }
+}
+
+impl IntoV2 for crate::v1::SessionSetTitleCapabilities {
+    type Output = super::SessionSetTitleCapabilities;
+
+    fn into_v2(self) -> Result<Self::Output> {
+        let Self { meta } = self;
+        Ok(super::SessionSetTitleCapabilities {
             meta: meta.into_v2()?,
         })
     }
@@ -5218,6 +5299,9 @@ impl IntoV1 for super::ClientRequest {
             Self::CloseSessionRequest(value) => {
                 crate::v1::ClientRequest::CloseSessionRequest(value.into_v1()?)
             }
+            Self::SetSessionTitleRequest(value) => {
+                crate::v1::ClientRequest::SetSessionTitleRequest(value.into_v1()?)
+            }
             Self::SetSessionConfigOptionRequest(value) => {
                 crate::v1::ClientRequest::SetSessionConfigOptionRequest(value.into_v1()?)
             }
@@ -5296,6 +5380,9 @@ impl IntoV2 for crate::v1::ClientRequest {
             Self::SetSessionModeRequest(_) => {
                 return Err(removed_v1_enum_variant("ClientRequest", "session/set_mode"));
             }
+            Self::SetSessionTitleRequest(value) => {
+                super::ClientRequest::SetSessionTitleRequest(Box::new(value.into_v2()?))
+            }
             Self::SetSessionConfigOptionRequest(value) => {
                 super::ClientRequest::SetSessionConfigOptionRequest(Box::new(value.into_v2()?))
             }
@@ -5372,6 +5459,9 @@ impl IntoV1 for super::AgentResponse {
             }
             Self::CloseSessionResponse(value) => {
                 crate::v1::AgentResponse::CloseSessionResponse(value.into_v1()?)
+            }
+            Self::SetSessionTitleResponse(value) => {
+                crate::v1::AgentResponse::SetSessionTitleResponse(value.into_v1()?)
             }
             Self::SetSessionConfigOptionResponse(value) => {
                 crate::v1::AgentResponse::SetSessionConfigOptionResponse(value.into_v1()?)
@@ -5452,6 +5542,9 @@ impl IntoV2 for crate::v1::AgentResponse {
             }
             Self::SetSessionModeResponse(_) => {
                 return Err(removed_v1_enum_variant("AgentResponse", "session/set_mode"));
+            }
+            Self::SetSessionTitleResponse(value) => {
+                super::AgentResponse::SetSessionTitleResponse(Box::new(value.into_v2()?))
             }
             Self::SetSessionConfigOptionResponse(value) => {
                 super::AgentResponse::SetSessionConfigOptionResponse(Box::new(value.into_v2()?))

--- a/docs/protocol/v1/draft/schema.mdx
+++ b/docs/protocol/v1/draft/schema.mdx
@@ -1491,6 +1491,56 @@ See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/v1/d
 
 </ResponseField>
 
+<a id="session-settitle"></a>
+### <span class="font-mono">session/setTitle</span>
+
+Sets the title for a session.
+
+Empty titles are valid and request that the agent clear the session title.
+
+This method can be called at any time during a session, whether the Agent is
+idle or actively generating a response.
+
+#### <span class="font-mono">SetSessionTitleRequest</span>
+
+Request parameters for setting a session title.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/draft/extensibility)
+
+</ResponseField>
+<ResponseField name="sessionId" type={<a href="#sessionid">SessionId</a>} required>
+  The ID of the session to set the title for.
+</ResponseField>
+<ResponseField name="title" type={"string"} required>
+  The new title for the session.
+</ResponseField>
+
+#### <span class="font-mono">SetSessionTitleResponse</span>
+
+Response to `session/setTitle` method.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/draft/extensibility)
+
+</ResponseField>
+
 <a id="session-set_config_option"></a>
 ### <span class="font-mono">session/set_config_option</span>
 
@@ -7109,6 +7159,9 @@ Optional. Omitted or `null` both mean the agent does not advertise support.
 Supplying `\{\}` means the agent supports resuming sessions.
 
 </ResponseField>
+<ResponseField name="setTitle" type={<><span><a href="#sessionsettitlecapabilities">SessionSetTitleCapabilities</a></span><span> | null</span></>} >
+  Whether the agent supports `session/setTitle`.
+</ResponseField>
 
 ## <span class="font-mono">SessionCloseCapabilities</span>
 
@@ -7589,6 +7642,25 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
 Capabilities for the `session/resume` method.
 
 Supplying `\{\}` means the agent supports resuming sessions.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/draft/extensibility)
+
+</ResponseField>
+
+## <span class="font-mono">SessionSetTitleCapabilities</span>
+
+Capabilities for the `session/setTitle` method.
+
+By supplying `\{\}` it means that the agent supports setting session titles.
 
 **Type:** Object
 

--- a/docs/protocol/v1/schema.mdx
+++ b/docs/protocol/v1/schema.mdx
@@ -719,6 +719,56 @@ See protocol docs: [Session Modes](https://agentclientprotocol.com/protocol/v1/s
 
 </ResponseField>
 
+<a id="session-settitle"></a>
+### <span class="font-mono">session/setTitle</span>
+
+Sets the title for a session.
+
+Empty titles are valid and request that the agent clear the session title.
+
+This method can be called at any time during a session, whether the Agent is
+idle or actively generating a response.
+
+#### <span class="font-mono">SetSessionTitleRequest</span>
+
+Request parameters for setting a session title.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/extensibility)
+
+</ResponseField>
+<ResponseField name="sessionId" type={<a href="#sessionid">SessionId</a>} required>
+  The ID of the session to set the title for.
+</ResponseField>
+<ResponseField name="title" type={"string"} required>
+  The new title for the session.
+</ResponseField>
+
+#### <span class="font-mono">SetSessionTitleResponse</span>
+
+Response to `session/setTitle` method.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/extensibility)
+
+</ResponseField>
+
 <a id="session-set_config_option"></a>
 ### <span class="font-mono">session/set_config_option</span>
 
@@ -3092,6 +3142,9 @@ Optional. Omitted or `null` both mean the agent does not advertise support.
 Supplying `\{\}` means the agent supports resuming sessions.
 
 </ResponseField>
+<ResponseField name="setTitle" type={<><span><a href="#sessionsettitlecapabilities">SessionSetTitleCapabilities</a></span><span> | null</span></>} >
+  Whether the agent supports `session/setTitle`.
+</ResponseField>
 
 ## <span class="font-mono">SessionCloseCapabilities</span>
 
@@ -3455,6 +3508,25 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/e
 Capabilities for the `session/resume` method.
 
 Supplying `\{\}` means the agent supports resuming sessions.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/extensibility)
+
+</ResponseField>
+
+## <span class="font-mono">SessionSetTitleCapabilities</span>
+
+Capabilities for the `session/setTitle` method.
+
+By supplying `\{\}` it means that the agent supports setting session titles.
 
 **Type:** Object
 

--- a/docs/protocol/v2/draft/schema.mdx
+++ b/docs/protocol/v2/draft/schema.mdx
@@ -1440,6 +1440,56 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
   Initial session configuration options.
 </ResponseField>
 
+<a id="session-settitle"></a>
+### <span class="font-mono">session/setTitle</span>
+
+Sets the title for a session.
+
+Empty titles are valid and request that the agent clear the session title.
+
+This method can be called at any time during a session, whether the Agent is
+idle or actively generating a response.
+
+#### <span class="font-mono">SetSessionTitleRequest</span>
+
+Request parameters for setting a session title.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
+
+</ResponseField>
+<ResponseField name="sessionId" type={<a href="#sessionid">SessionId</a>} required>
+  The ID of the session to set the title for.
+</ResponseField>
+<ResponseField name="title" type={"string"} required>
+  The new title for the session.
+</ResponseField>
+
+#### <span class="font-mono">SetSessionTitleResponse</span>
+
+Response to `session/setTitle` method.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
+
+</ResponseField>
+
 <a id="session-set_config_option"></a>
 ### <span class="font-mono">session/set_config_option</span>
 
@@ -6993,6 +7043,9 @@ prompt extensions beyond the baseline text and resource-link content
 required by `session/prompt`.
 
 </ResponseField>
+<ResponseField name="setTitle" type={<><span><a href="#sessionsettitlecapabilities">SessionSetTitleCapabilities</a></span><span> | null</span></>} >
+  Whether the agent supports `session/setTitle`.
+</ResponseField>
 
 ## <span class="font-mono">SessionConfigBoolean</span>
 
@@ -7374,6 +7427,25 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 </ResponseField>
 <ResponseField name="updatedAt" type={"string | null"} >
   ISO 8601 timestamp of last activity. Set to null to clear.
+</ResponseField>
+
+## <span class="font-mono">SessionSetTitleCapabilities</span>
+
+Capabilities for the `session/setTitle` method.
+
+By supplying `\{\}` it means that the agent supports setting session titles.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
+
 </ResponseField>
 
 ## <span class="font-mono">SessionUpdate</span>

--- a/docs/protocol/v2/schema.mdx
+++ b/docs/protocol/v2/schema.mdx
@@ -682,6 +682,56 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
   Initial session configuration options.
 </ResponseField>
 
+<a id="session-settitle"></a>
+### <span class="font-mono">session/setTitle</span>
+
+Sets the title for a session.
+
+Empty titles are valid and request that the agent clear the session title.
+
+This method can be called at any time during a session, whether the Agent is
+idle or actively generating a response.
+
+#### <span class="font-mono">SetSessionTitleRequest</span>
+
+Request parameters for setting a session title.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)
+
+</ResponseField>
+<ResponseField name="sessionId" type={<a href="#sessionid">SessionId</a>} required>
+  The ID of the session to set the title for.
+</ResponseField>
+<ResponseField name="title" type={"string"} required>
+  The new title for the session.
+</ResponseField>
+
+#### <span class="font-mono">SetSessionTitleResponse</span>
+
+Response to `session/setTitle` method.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)
+
+</ResponseField>
+
 <a id="session-set_config_option"></a>
 ### <span class="font-mono">session/set_config_option</span>
 
@@ -3060,6 +3110,9 @@ prompt extensions beyond the baseline text and resource-link content
 required by `session/prompt`.
 
 </ResponseField>
+<ResponseField name="setTitle" type={<><span><a href="#sessionsettitlecapabilities">SessionSetTitleCapabilities</a></span><span> | null</span></>} >
+  Whether the agent supports `session/setTitle`.
+</ResponseField>
 
 ## <span class="font-mono">SessionConfigGroupId</span>
 
@@ -3383,6 +3436,25 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 </ResponseField>
 <ResponseField name="updatedAt" type={"string | null"} >
   ISO 8601 timestamp of last activity. Set to null to clear.
+</ResponseField>
+
+## <span class="font-mono">SessionSetTitleCapabilities</span>
+
+Capabilities for the `session/setTitle` method.
+
+By supplying `\{\}` it means that the agent supports setting session titles.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)
+
 </ResponseField>
 
 ## <span class="font-mono">SessionUpdate</span>

--- a/schema-generator/src/main.rs
+++ b/schema-generator/src/main.rs
@@ -1861,6 +1861,7 @@ starting with '$/' it is free to ignore the notification."
                 "session/fork" => self.agent.get("ForkSessionRequest").unwrap(),
                 "session/resume" => self.agent.get("ResumeSessionRequest").unwrap(),
                 "session/set_mode" => self.agent.get("SetSessionModeRequest").unwrap(),
+                "session/setTitle" => self.agent.get("SetSessionTitleRequest").unwrap(),
                 "session/set_config_option" => {
                     self.agent.get("SetSessionConfigOptionRequest").unwrap()
                 }

--- a/schema/v1/meta.json
+++ b/schema/v1/meta.json
@@ -6,6 +6,7 @@
     "session_new": "session/new",
     "session_load": "session/load",
     "session_set_mode": "session/set_mode",
+    "session_set_title": "session/setTitle",
     "session_set_config_option": "session/set_config_option",
     "session_prompt": "session/prompt",
     "session_cancel": "session/cancel",

--- a/schema/v1/meta.unstable.json
+++ b/schema/v1/meta.unstable.json
@@ -9,6 +9,7 @@
     "session_new": "session/new",
     "session_load": "session/load",
     "session_set_mode": "session/set_mode",
+    "session_set_title": "session/setTitle",
     "session_set_config_option": "session/set_config_option",
     "session_prompt": "session/prompt",
     "session_cancel": "session/cancel",

--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -1456,6 +1456,15 @@
                   ]
                 },
                 {
+                  "title": "SetSessionTitleResponse",
+                  "description": "Successful result returned for a `session/setTitle` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/SetSessionTitleResponse"
+                    }
+                  ]
+                },
+                {
                   "title": "SetSessionConfigOptionResponse",
                   "description": "Successful result returned for a `session/set_config_option` request.",
                   "allOf": [
@@ -1772,6 +1781,18 @@
           ],
           "x-deserialize-default-on-error": true
         },
+        "setTitle": {
+          "description": "Whether the agent supports `session/setTitle`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionSetTitleCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
         "_meta": {
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": ["object", "null"],
@@ -1830,6 +1851,18 @@
     },
     "SessionCloseCapabilities": {
       "description": "Capabilities for the `session/close` method.\n\nSupplying `{}` means the agent supports closing sessions.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "SessionSetTitleCapabilities": {
+      "description": "Capabilities for the `session/setTitle` method.\n\nBy supplying `{}` it means that the agent supports setting session titles.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -2483,6 +2516,20 @@
       },
       "x-side": "agent",
       "x-method": "session/set_mode"
+    },
+    "SetSessionTitleResponse": {
+      "description": "Response to `session/setTitle` method.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "x-side": "agent",
+      "x-method": "session/setTitle"
     },
     "SetSessionConfigOptionResponse": {
       "description": "Response to `session/set_config_option` method.",
@@ -3439,6 +3486,15 @@
                   ]
                 },
                 {
+                  "title": "SetSessionTitleRequest",
+                  "description": "Sets the title for a session.\n\nEmpty titles are valid and request that the agent clear the session title.\n\nThis method can be called at any time during a session, whether the Agent is\nidle or actively generating a response.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/SetSessionTitleRequest"
+                    }
+                  ]
+                },
+                {
                   "title": "SetSessionConfigOptionRequest",
                   "description": "Sets the current value for a session configuration option.",
                   "allOf": [
@@ -4012,6 +4068,33 @@
       "required": ["sessionId", "modeId"],
       "x-side": "agent",
       "x-method": "session/set_mode"
+    },
+    "SetSessionTitleRequest": {
+      "description": "Request parameters for setting a session title.",
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "description": "The ID of the session to set the title for.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ]
+        },
+        "title": {
+          "description": "The new title for the session.",
+          "type": "string"
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessionId", "title"],
+      "x-side": "agent",
+      "x-method": "session/setTitle"
     },
     "SetSessionConfigOptionRequest": {
       "description": "Request parameters for setting a session configuration option.",

--- a/schema/v1/schema.unstable.json
+++ b/schema/v1/schema.unstable.json
@@ -2451,6 +2451,15 @@
                   ]
                 },
                 {
+                  "title": "SetSessionTitleResponse",
+                  "description": "Successful result returned for a `session/setTitle` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/SetSessionTitleResponse"
+                    }
+                  ]
+                },
+                {
                   "title": "SetSessionConfigOptionResponse",
                   "description": "Successful result returned for a `session/set_config_option` request.",
                   "allOf": [
@@ -2859,6 +2868,18 @@
           ],
           "x-deserialize-default-on-error": true
         },
+        "setTitle": {
+          "description": "Whether the agent supports `session/setTitle`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionSetTitleCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
         "_meta": {
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": ["object", "null"],
@@ -2929,6 +2950,18 @@
     },
     "SessionCloseCapabilities": {
       "description": "Capabilities for the `session/close` method.\n\nSupplying `{}` means the agent supports closing sessions.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "SessionSetTitleCapabilities": {
+      "description": "Capabilities for the `session/setTitle` method.\n\nBy supplying `{}` it means that the agent supports setting session titles.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -4397,6 +4430,20 @@
       },
       "x-side": "agent",
       "x-method": "session/set_mode"
+    },
+    "SetSessionTitleResponse": {
+      "description": "Response to `session/setTitle` method.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "x-side": "agent",
+      "x-method": "session/setTitle"
     },
     "SetSessionConfigOptionResponse": {
       "description": "Response to `session/set_config_option` method.",
@@ -6116,6 +6163,15 @@
                   ]
                 },
                 {
+                  "title": "SetSessionTitleRequest",
+                  "description": "Sets the title for a session.\n\nEmpty titles are valid and request that the agent clear the session title.\n\nThis method can be called at any time during a session, whether the Agent is\nidle or actively generating a response.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/SetSessionTitleRequest"
+                    }
+                  ]
+                },
+                {
                   "title": "SetSessionConfigOptionRequest",
                   "description": "Sets the current value for a session configuration option.",
                   "allOf": [
@@ -7197,6 +7253,33 @@
       "required": ["sessionId", "modeId"],
       "x-side": "agent",
       "x-method": "session/set_mode"
+    },
+    "SetSessionTitleRequest": {
+      "description": "Request parameters for setting a session title.",
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "description": "The ID of the session to set the title for.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ]
+        },
+        "title": {
+          "description": "The new title for the session.",
+          "type": "string"
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessionId", "title"],
+      "x-side": "agent",
+      "x-method": "session/setTitle"
     },
     "SetSessionConfigOptionRequest": {
       "description": "Request parameters for setting a session configuration option.",

--- a/schema/v2/meta.json
+++ b/schema/v2/meta.json
@@ -5,6 +5,7 @@
     "auth_login": "auth/login",
     "session_new": "session/new",
     "session_load": "session/load",
+    "session_set_title": "session/setTitle",
     "session_set_config_option": "session/set_config_option",
     "session_prompt": "session/prompt",
     "session_cancel": "session/cancel",

--- a/schema/v2/meta.unstable.json
+++ b/schema/v2/meta.unstable.json
@@ -8,6 +8,7 @@
     "providers_disable": "providers/disable",
     "session_new": "session/new",
     "session_load": "session/load",
+    "session_set_title": "session/setTitle",
     "session_set_config_option": "session/set_config_option",
     "session_prompt": "session/prompt",
     "session_cancel": "session/cancel",

--- a/schema/v2/schema.json
+++ b/schema/v2/schema.json
@@ -234,6 +234,15 @@
                     ]
                   },
                   {
+                    "title": "SetSessionTitleResponse",
+                    "description": "Successful result returned for a `session/setTitle` request.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/SetSessionTitleResponse"
+                      }
+                    ]
+                  },
+                  {
                     "title": "SetSessionConfigOptionResponse",
                     "description": "Successful result returned for a `session/set_config_option` request.",
                     "allOf": [
@@ -1690,6 +1699,15 @@
                   ]
                 },
                 {
+                  "title": "SetSessionTitleResponse",
+                  "description": "Successful result returned for a `session/setTitle` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/SetSessionTitleResponse"
+                    }
+                  ]
+                },
+                {
                   "title": "SetSessionConfigOptionResponse",
                   "description": "Successful result returned for a `session/set_config_option` request.",
                   "allOf": [
@@ -1919,6 +1937,18 @@
           ],
           "x-deserialize-default-on-error": true
         },
+        "setTitle": {
+          "description": "Whether the agent supports `session/setTitle`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionSetTitleCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
         "_meta": {
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
           "type": ["object", "null"],
@@ -2085,6 +2115,18 @@
     },
     "SessionAdditionalDirectoriesCapabilities": {
       "description": "Capabilities for additional session directories support.\n\nSupplying `{}` means the agent supports the `additionalDirectories` field on\nsupported session lifecycle requests. Agents that also support\n`session/list` may return `SessionInfo.additionalDirectories` to report the\ncomplete ordered additional-root list associated with a listed session.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "SessionSetTitleCapabilities": {
+      "description": "Capabilities for the `session/setTitle` method.\n\nBy supplying `{}` it means that the agent supports setting session titles.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -2658,6 +2700,20 @@
       },
       "x-side": "agent",
       "x-method": "session/close"
+    },
+    "SetSessionTitleResponse": {
+      "description": "Response to `session/setTitle` method.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "x-side": "agent",
+      "x-method": "session/setTitle"
     },
     "SetSessionConfigOptionResponse": {
       "description": "Response to `session/set_config_option` method.",
@@ -4141,6 +4197,15 @@
                   ]
                 },
                 {
+                  "title": "SetSessionTitleRequest",
+                  "description": "Sets the title for a session.\n\nEmpty titles are valid and request that the agent clear the session title.\n\nThis method can be called at any time during a session, whether the Agent is\nidle or actively generating a response.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/SetSessionTitleRequest"
+                    }
+                  ]
+                },
+                {
                   "title": "SetSessionConfigOptionRequest",
                   "description": "Sets the current value for a session configuration option.",
                   "allOf": [
@@ -4653,6 +4718,33 @@
       "required": ["sessionId"],
       "x-side": "agent",
       "x-method": "session/close"
+    },
+    "SetSessionTitleRequest": {
+      "description": "Request parameters for setting a session title.",
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "description": "The ID of the session to set the title for.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ]
+        },
+        "title": {
+          "description": "The new title for the session.",
+          "type": "string"
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessionId", "title"],
+      "x-side": "agent",
+      "x-method": "session/setTitle"
     },
     "SetSessionConfigOptionRequest": {
       "description": "Request parameters for setting a session configuration option.",

--- a/schema/v2/schema.unstable.json
+++ b/schema/v2/schema.unstable.json
@@ -270,6 +270,15 @@
                     ]
                   },
                   {
+                    "title": "SetSessionTitleResponse",
+                    "description": "Successful result returned for a `session/setTitle` request.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/SetSessionTitleResponse"
+                      }
+                    ]
+                  },
+                  {
                     "title": "SetSessionConfigOptionResponse",
                     "description": "Successful result returned for a `session/set_config_option` request.",
                     "allOf": [
@@ -2798,6 +2807,15 @@
                   ]
                 },
                 {
+                  "title": "SetSessionTitleResponse",
+                  "description": "Successful result returned for a `session/setTitle` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/SetSessionTitleResponse"
+                    }
+                  ]
+                },
+                {
                   "title": "SetSessionConfigOptionResponse",
                   "description": "Successful result returned for a `session/set_config_option` request.",
                   "allOf": [
@@ -3111,6 +3129,18 @@
           ],
           "x-deserialize-default-on-error": true
         },
+        "setTitle": {
+          "description": "Whether the agent supports `session/setTitle`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionSetTitleCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
         "_meta": {
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)",
           "type": ["object", "null"],
@@ -3313,6 +3343,18 @@
     },
     "SessionForkCapabilities": {
       "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for the `session/fork` method.\n\nSupplying `{}` means the agent supports forking sessions.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "SessionSetTitleCapabilities": {
+      "description": "Capabilities for the `session/setTitle` method.\n\nBy supplying `{}` it means that the agent supports setting session titles.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -4741,6 +4783,20 @@
       },
       "x-side": "agent",
       "x-method": "session/close"
+    },
+    "SetSessionTitleResponse": {
+      "description": "Response to `session/setTitle` method.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "x-side": "agent",
+      "x-method": "session/setTitle"
     },
     "SetSessionConfigOptionResponse": {
       "description": "Response to `session/set_config_option` method.",
@@ -6967,6 +7023,15 @@
                   ]
                 },
                 {
+                  "title": "SetSessionTitleRequest",
+                  "description": "Sets the title for a session.\n\nEmpty titles are valid and request that the agent clear the session title.\n\nThis method can be called at any time during a session, whether the Agent is\nidle or actively generating a response.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/SetSessionTitleRequest"
+                    }
+                  ]
+                },
+                {
                   "title": "SetSessionConfigOptionRequest",
                   "description": "Sets the current value for a session configuration option.",
                   "allOf": [
@@ -7895,6 +7960,33 @@
       "required": ["sessionId"],
       "x-side": "agent",
       "x-method": "session/close"
+    },
+    "SetSessionTitleRequest": {
+      "description": "Request parameters for setting a session title.",
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "description": "The ID of the session to set the title for.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ]
+        },
+        "title": {
+          "description": "The new title for the session.",
+          "type": "string"
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessionId", "title"],
+      "x-side": "agent",
+      "x-method": "session/setTitle"
     },
     "SetSessionConfigOptionRequest": {
       "description": "Request parameters for setting a session configuration option.",


### PR DESCRIPTION
## Summary

Adds `session/setTitle` to the Agent Client Protocol, giving clients a standard way to ask an agent to rename an existing session.

```text
Request:  { sessionId: SessionId, title: String }
Response: {}
```

Title is plain UTF-8. Empty string remains valid at the protocol level so agents can decide whether that means "clear", "reset", or "use an empty title".

## Why

Zed's first-party agent can already rename sessions, but ACP-backed sessions cannot, because there is no protocol method for the client to push a new title to the agent. The user-visible symptom is that the title editor in the agent panel appears for ACP threads but the rename cannot be persisted.

`SessionInfoUpdate` already exists in the reverse direction (agent -> client) and carries `title` -- this PR adds the missing client -> agent half of the round-trip.

## How

- Adds `SetSessionTitleRequest` and `SetSessionTitleResponse` to the generated v1 and v2 agent schemas.
- Adds `SESSION_SET_TITLE_METHOD_NAME = "session/setTitle"` to the generated metadata.
- Wires v2-to-v1 and v1-to-v2 conversion for the new request/response while keeping removed v1 `session/set_mode` variants non-convertible to v2.
- Updates generated schema docs and JSON schema artifacts.
- Extends the schema generator's generated-type set for `SetSessionTitle`.

## Tests

```text
npm run generate
npm run check
```

`npm run check` covers clippy with all features, Prettier/cargo formatting checks, spellcheck, all-feature unit tests, generated-bin tests, and doctests.

## Companion PRs

Companion codex-acp PRs:

- zed-industries/codex-acp#286 -- handle `session/setTitle` and emit `SessionInfoUpdate`.
- zed-industries/codex-acp#287 -- add `/rename <new title>` as an ACP-client-friendly shortcut.
