### PR TITLE
docs: Add acp-components to ACP clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -48,6 +48,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Sidequery _(coming soon)_](https://sidequery.dev)
 - [Tidewave](https://tidewave.ai/)
 - [Web Browser with AI SDK](https://github.com/mcpc-tech/ai-elements-remix-template) (powered by [@mcpc/acp-ai-provider](https://github.com/mcpc-tech/mcpc/tree/main/packages/acp-ai-provider))
+- [ACP Components](https://github.com/zvzuola/acp-components) - A universal frontend component library for building AI Agent interfaces based on the ACP
 
 ## Notebook and data tools
 


### PR DESCRIPTION
## Summary

Adds acp-components to the Desktop and Web section of the ACP clients list.

acp-components is a universal frontend component library for building AI Agent interfaces based on the ACP.

## Why

acp-components provides a complete set of components to build agentic coding interfaces that communicate with AI agents like Claude Code

## Change

- Added acp-components to `## Desktop and Web`