### PR TITLE
feat(unstable): scaffold session/delete behind unstable_session_delete

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ unstable = [
     "unstable_mcp_over_acp",
     "unstable_nes",
     "unstable_session_additional_directories",
+    "unstable_session_delete",
     "unstable_session_fork",
     "unstable_session_model",
     "unstable_session_usage",
@@ -42,6 +43,7 @@ unstable_logout = []
 unstable_mcp_over_acp = []
 unstable_nes = []
 unstable_session_additional_directories = []
+unstable_session_delete = []
 unstable_session_fork = []
 unstable_session_model = []
 unstable_session_usage = []

--- a/docs/protocol/draft/schema-v2.mdx
+++ b/docs/protocol/draft/schema-v2.mdx
@@ -889,6 +889,64 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 
 </ResponseField>
 
+<a id="session-delete"></a>
+### <span class="font-mono">session/delete</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Deletes an existing session.
+
+This method is only available if the agent advertises the `sessionCapabilities.delete` capability.
+
+#### <span class="font-mono">DeleteSessionRequest</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Request parameters for deleting a session.
+
+Only available if the Agent supports the `sessionCapabilities.delete` capability.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+
+</ResponseField>
+<ResponseField name="sessionId" type={<a href="#sessionid">SessionId</a>} required>
+  The ID of the session to delete.
+</ResponseField>
+
+#### <span class="font-mono">DeleteSessionResponse</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Response from deleting a session.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+
+</ResponseField>
+
 <a id="session-fork"></a>
 ### <span class="font-mono">session/fork</span>
 
@@ -6226,6 +6284,14 @@ Whether the agent supports `additionalDirectories` on supported session lifecycl
 <ResponseField name="close" type={<><span><a href="#sessionclosecapabilities">SessionCloseCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/close`.
 </ResponseField>
+<ResponseField name="delete" type={<><span><a href="#sessiondeletecapabilities">SessionDeleteCapabilities</a></span><span> | null</span></>} >
+  **UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Whether the agent supports `session/delete`.
+
+</ResponseField>
 <ResponseField name="fork" type={<><span><a href="#sessionforkcapabilities">SessionForkCapabilities</a></span><span> | null</span></>} >
   **UNSTABLE**
 
@@ -6488,6 +6554,29 @@ Possible values for a session configuration option.
 Unique identifier for a session configuration option value.
 
 **Type:** `string`
+
+## <span class="font-mono">SessionDeleteCapabilities</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Capabilities for the `session/delete` method.
+
+By supplying `\{\}` it means that the agent supports deletion of sessions.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+
+</ResponseField>
 
 ## <span class="font-mono">SessionForkCapabilities</span>
 

--- a/docs/protocol/draft/schema.mdx
+++ b/docs/protocol/draft/schema.mdx
@@ -889,6 +889,64 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 
 </ResponseField>
 
+<a id="session-delete"></a>
+### <span class="font-mono">session/delete</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Deletes an existing session.
+
+This method is only available if the agent advertises the `sessionCapabilities.delete` capability.
+
+#### <span class="font-mono">DeleteSessionRequest</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Request parameters for deleting a session.
+
+Only available if the Agent supports the `sessionCapabilities.delete` capability.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+
+</ResponseField>
+<ResponseField name="sessionId" type={<a href="#sessionid">SessionId</a>} required>
+  The ID of the session to delete.
+</ResponseField>
+
+#### <span class="font-mono">DeleteSessionResponse</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Response from deleting a session.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+
+</ResponseField>
+
 <a id="session-fork"></a>
 ### <span class="font-mono">session/fork</span>
 
@@ -6226,6 +6284,14 @@ Whether the agent supports `additionalDirectories` on supported session lifecycl
 <ResponseField name="close" type={<><span><a href="#sessionclosecapabilities">SessionCloseCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/close`.
 </ResponseField>
+<ResponseField name="delete" type={<><span><a href="#sessiondeletecapabilities">SessionDeleteCapabilities</a></span><span> | null</span></>} >
+  **UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Whether the agent supports `session/delete`.
+
+</ResponseField>
 <ResponseField name="fork" type={<><span><a href="#sessionforkcapabilities">SessionForkCapabilities</a></span><span> | null</span></>} >
   **UNSTABLE**
 
@@ -6488,6 +6554,29 @@ Possible values for a session configuration option.
 Unique identifier for a session configuration option value.
 
 **Type:** `string`
+
+## <span class="font-mono">SessionDeleteCapabilities</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Capabilities for the `session/delete` method.
+
+By supplying `\{\}` it means that the agent supports deletion of sessions.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+
+</ResponseField>
 
 ## <span class="font-mono">SessionForkCapabilities</span>
 

--- a/docs/rfds/session-delete.mdx
+++ b/docs/rfds/session-delete.mdx
@@ -138,6 +138,6 @@ The [`session/list` RFD](/rfds/session-list#what-about-session-deletion) explici
 
 ## Revision history
 
-- **2026-05-12**: Implemented as unstable schema feature (`unstable_session_delete`).
+- **2026-05-13**: Implemented as unstable schema feature (`unstable_session_delete`).
 - **2025-02-03**: Fixed capability example to use agent capability (initialize response)
 - **2025-01-24**: Initial draft

--- a/docs/rfds/session-delete.mdx
+++ b/docs/rfds/session-delete.mdx
@@ -138,5 +138,6 @@ The [`session/list` RFD](/rfds/session-list#what-about-session-deletion) explici
 
 ## Revision history
 
+- **2026-05-12**: Implemented as unstable schema feature (`unstable_session_delete`).
 - **2025-02-03**: Fixed capability example to use agent capability (initialize response)
 - **2025-01-24**: Initial draft

--- a/schema/meta.unstable.json
+++ b/schema/meta.unstable.json
@@ -18,6 +18,7 @@
     "providers_set": "providers/set",
     "session_cancel": "session/cancel",
     "session_close": "session/close",
+    "session_delete": "session/delete",
     "session_fork": "session/fork",
     "session_list": "session/list",
     "session_load": "session/load",

--- a/schema/meta.v2.unstable.json
+++ b/schema/meta.v2.unstable.json
@@ -18,6 +18,7 @@
     "providers_set": "providers/set",
     "session_cancel": "session/cancel",
     "session_close": "session/close",
+    "session_delete": "session/delete",
     "session_fork": "session/fork",
     "session_list": "session/list",
     "session_load": "session/load",

--- a/schema/schema.unstable.json
+++ b/schema/schema.unstable.json
@@ -396,6 +396,14 @@
                 {
                   "allOf": [
                     {
+                      "$ref": "#/$defs/DeleteSessionResponse"
+                    }
+                  ],
+                  "title": "DeleteSessionResponse"
+                },
+                {
+                  "allOf": [
+                    {
                       "$ref": "#/$defs/ResumeSessionResponse"
                     }
                   ],
@@ -1236,6 +1244,15 @@
                 {
                   "allOf": [
                     {
+                      "$ref": "#/$defs/DeleteSessionRequest"
+                    }
+                  ],
+                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nDeletes an existing session.\n\nThis method is only available if the agent advertises the `sessionCapabilities.delete` capability.",
+                  "title": "DeleteSessionRequest"
+                },
+                {
+                  "allOf": [
+                    {
                       "$ref": "#/$defs/ResumeSessionRequest"
                     }
                   ],
@@ -1906,6 +1923,41 @@
       },
       "required": ["currentModeId"],
       "type": "object"
+    },
+    "DeleteSessionRequest": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest parameters for deleting a session.\n\nOnly available if the Agent supports the `sessionCapabilities.delete` capability.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        },
+        "sessionId": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ],
+          "description": "The ID of the session to delete."
+        }
+      },
+      "required": ["sessionId"],
+      "type": "object",
+      "x-method": "session/delete",
+      "x-side": "agent"
+    },
+    "DeleteSessionResponse": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nResponse from deleting a session.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        }
+      },
+      "type": "object",
+      "x-method": "session/delete",
+      "x-side": "agent"
     },
     "DidChangeDocumentNotification": {
       "description": "Notification sent when a file is edited.",
@@ -5417,6 +5469,17 @@
           ],
           "description": "Whether the agent supports `session/close`."
         },
+        "delete": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionDeleteCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/delete`."
+        },
         "fork": {
           "anyOf": [
             {
@@ -5690,6 +5753,17 @@
     "SessionConfigValueId": {
       "description": "Unique identifier for a session configuration option value.",
       "type": "string"
+    },
+    "SessionDeleteCapabilities": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for the `session/delete` method.\n\nBy supplying `{}` it means that the agent supports deletion of sessions.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        }
+      },
+      "type": "object"
     },
     "SessionForkCapabilities": {
       "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for the `session/fork` method.\n\nBy supplying `{}` it means that the agent supports forking of sessions.",

--- a/schema/schema.v2.unstable.json
+++ b/schema/schema.v2.unstable.json
@@ -396,6 +396,14 @@
                 {
                   "allOf": [
                     {
+                      "$ref": "#/$defs/DeleteSessionResponse"
+                    }
+                  ],
+                  "title": "DeleteSessionResponse"
+                },
+                {
+                  "allOf": [
+                    {
                       "$ref": "#/$defs/ResumeSessionResponse"
                     }
                   ],
@@ -1236,6 +1244,15 @@
                 {
                   "allOf": [
                     {
+                      "$ref": "#/$defs/DeleteSessionRequest"
+                    }
+                  ],
+                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nDeletes an existing session.\n\nThis method is only available if the agent advertises the `sessionCapabilities.delete` capability.",
+                  "title": "DeleteSessionRequest"
+                },
+                {
+                  "allOf": [
+                    {
                       "$ref": "#/$defs/ResumeSessionRequest"
                     }
                   ],
@@ -1906,6 +1923,41 @@
       },
       "required": ["currentModeId"],
       "type": "object"
+    },
+    "DeleteSessionRequest": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest parameters for deleting a session.\n\nOnly available if the Agent supports the `sessionCapabilities.delete` capability.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        },
+        "sessionId": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ],
+          "description": "The ID of the session to delete."
+        }
+      },
+      "required": ["sessionId"],
+      "type": "object",
+      "x-method": "session/delete",
+      "x-side": "agent"
+    },
+    "DeleteSessionResponse": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nResponse from deleting a session.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        }
+      },
+      "type": "object",
+      "x-method": "session/delete",
+      "x-side": "agent"
     },
     "DidChangeDocumentNotification": {
       "description": "Notification sent when a file is edited.",
@@ -5417,6 +5469,17 @@
           ],
           "description": "Whether the agent supports `session/close`."
         },
+        "delete": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionDeleteCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/delete`."
+        },
         "fork": {
           "anyOf": [
             {
@@ -5690,6 +5753,17 @@
     "SessionConfigValueId": {
       "description": "Unique identifier for a session configuration option value.",
       "type": "string"
+    },
+    "SessionDeleteCapabilities": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for the `session/delete` method.\n\nBy supplying `{}` it means that the agent supports deletion of sessions.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        }
+      },
+      "type": "object"
     },
     "SessionForkCapabilities": {
       "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for the `session/fork` method.\n\nBy supplying `{}` it means that the agent supports forking of sessions.",

--- a/src/bin/generate.rs
+++ b/src/bin/generate.rs
@@ -1128,6 +1128,7 @@ starting with '$/' it is free to ignore the notification."
                 "session/load" => self.agent.get("LoadSessionRequest").unwrap(),
                 "session/list" => self.agent.get("ListSessionsRequest").unwrap(),
                 "session/fork" => self.agent.get("ForkSessionRequest").unwrap(),
+                "session/delete" => self.agent.get("DeleteSessionRequest").unwrap(),
                 "session/resume" => self.agent.get("ResumeSessionRequest").unwrap(),
                 "session/set_mode" => self.agent.get("SetSessionModeRequest").unwrap(),
                 "session/set_config_option" => {

--- a/src/v1/agent.rs
+++ b/src/v1/agent.rs
@@ -1714,11 +1714,13 @@ impl CloseSessionResponse {
 /// Only available if the Agent supports the `sessionCapabilities.delete` capability.
 #[cfg(feature = "unstable_session_delete")]
 #[skip_serializing_none]
-#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[schemars(extend("x-side" = "agent", "x-method" = SESSION_DELETE_METHOD_NAME))]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct DeleteSessionRequest {
+    /// The ID of the session to delete.
+    pub session_id: SessionId,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
     /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
     /// these keys.
@@ -1731,8 +1733,11 @@ pub struct DeleteSessionRequest {
 #[cfg(feature = "unstable_session_delete")]
 impl DeleteSessionRequest {
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(session_id: impl Into<SessionId>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            meta: None,
+        }
     }
 
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -5010,7 +5015,7 @@ pub enum ClientRequest {
     ///
     /// Deletes an existing session.
     ///
-    /// This method is only available if the agent advertises the `session.delete` capability.
+    /// This method is only available if the agent advertises the `sessionCapabilities.delete` capability.
     DeleteSessionRequest(DeleteSessionRequest),
     /// Resumes an existing session without returning previous messages.
     ///
@@ -5734,6 +5739,37 @@ mod test_serialization {
             .unwrap(),
             json!({
                 "additionalDirectories": {}
+            })
+        );
+    }
+
+    #[cfg(feature = "unstable_session_delete")]
+    #[test]
+    fn test_delete_session_request_serialization() {
+        let request = DeleteSessionRequest::new("sess_abc123");
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "sessionId": "sess_abc123",
+            })
+        );
+
+        let deserialized: DeleteSessionRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized.session_id, SessionId::from("sess_abc123"));
+    }
+
+    #[cfg(feature = "unstable_session_delete")]
+    #[test]
+    fn test_delete_session_capabilities_serialization() {
+        assert_eq!(
+            serde_json::to_value(
+                SessionCapabilities::new().delete(SessionDeleteCapabilities::new())
+            )
+            .unwrap(),
+            json!({
+                "delete": {}
             })
         );
     }

--- a/src/v1/agent.rs
+++ b/src/v1/agent.rs
@@ -1703,6 +1703,90 @@ impl CloseSessionResponse {
     }
 }
 
+// Delete session
+
+/// **UNSTABLE**
+///
+/// This capability is not part of the spec yet, and may be removed or changed at any point.
+///
+/// Request parameters for deleting a session.
+///
+/// Only available if the Agent supports the `sessionCapabilities.delete` capability.
+#[cfg(feature = "unstable_session_delete")]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[schemars(extend("x-side" = "agent", "x-method" = SESSION_DELETE_METHOD_NAME))]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct DeleteSessionRequest {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+#[cfg(feature = "unstable_session_delete")]
+impl DeleteSessionRequest {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// **UNSTABLE**
+///
+/// This capability is not part of the spec yet, and may be removed or changed at any point.
+///
+/// Response from deleting a session.
+#[cfg(feature = "unstable_session_delete")]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[schemars(extend("x-side" = "agent", "x-method" = SESSION_DELETE_METHOD_NAME))]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct DeleteSessionResponse {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+#[cfg(feature = "unstable_session_delete")]
+impl DeleteSessionResponse {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
 // List sessions
 
 /// Request parameters for listing existing sessions.
@@ -4160,6 +4244,15 @@ pub struct SessionCapabilities {
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[serde(default)]
     pub fork: Option<SessionForkCapabilities>,
+    /// **UNSTABLE**
+    ///
+    /// This capability is not part of the spec yet, and may be removed or changed at any point.
+    ///
+    /// Whether the agent supports `session/delete`.
+    #[cfg(feature = "unstable_session_delete")]
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[serde(default)]
+    pub delete: Option<SessionDeleteCapabilities>,
     /// Whether the agent supports `session/resume`.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[serde(default)]
@@ -4210,6 +4303,18 @@ impl SessionCapabilities {
     #[must_use]
     pub fn fork(mut self, fork: impl IntoOption<SessionForkCapabilities>) -> Self {
         self.fork = fork.into_option();
+        self
+    }
+
+    /// **UNSTABLE**
+    ///
+    /// This capability is not part of the spec yet, and may be removed or changed at any point.
+    ///
+    /// Whether the agent supports `session/delete`.
+    #[cfg(feature = "unstable_session_delete")]
+    #[must_use]
+    pub fn delete(mut self, delete: impl IntoOption<SessionDeleteCapabilities>) -> Self {
+        self.delete = delete.into_option();
         self
     }
 
@@ -4337,6 +4442,46 @@ pub struct SessionForkCapabilities {
 
 #[cfg(feature = "unstable_session_fork")]
 impl SessionForkCapabilities {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// **UNSTABLE**
+///
+/// This capability is not part of the spec yet, and may be removed or changed at any point.
+///
+/// Capabilities for the `session/delete` method.
+///
+/// By supplying `{}` it means that the agent supports deletion of sessions.
+#[cfg(feature = "unstable_session_delete")]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SessionDeleteCapabilities {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+#[cfg(feature = "unstable_session_delete")]
+impl SessionDeleteCapabilities {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -4616,6 +4761,9 @@ pub struct AgentMethodNames {
     /// Method for forking an existing session.
     #[cfg(feature = "unstable_session_fork")]
     pub session_fork: &'static str,
+    /// Method for deleting an existing session.
+    #[cfg(feature = "unstable_session_delete")]
+    pub session_delete: &'static str,
     /// Method for resuming an existing session.
     pub session_resume: &'static str,
     /// Method for closing an active session.
@@ -4676,6 +4824,8 @@ pub const AGENT_METHOD_NAMES: AgentMethodNames = AgentMethodNames {
     session_list: SESSION_LIST_METHOD_NAME,
     #[cfg(feature = "unstable_session_fork")]
     session_fork: SESSION_FORK_METHOD_NAME,
+    #[cfg(feature = "unstable_session_delete")]
+    session_delete: SESSION_DELETE_METHOD_NAME,
     session_resume: SESSION_RESUME_METHOD_NAME,
     session_close: SESSION_CLOSE_METHOD_NAME,
     #[cfg(feature = "unstable_logout")]
@@ -4735,6 +4885,9 @@ pub(crate) const SESSION_LIST_METHOD_NAME: &str = "session/list";
 /// Method name for forking an existing session.
 #[cfg(feature = "unstable_session_fork")]
 pub(crate) const SESSION_FORK_METHOD_NAME: &str = "session/fork";
+/// Method name for deleting an existing session.
+#[cfg(feature = "unstable_session_delete")]
+pub(crate) const SESSION_DELETE_METHOD_NAME: &str = "session/delete";
 /// Method name for resuming an existing session.
 pub(crate) const SESSION_RESUME_METHOD_NAME: &str = "session/resume";
 /// Method name for closing an active session.
@@ -4850,6 +5003,15 @@ pub enum ClientRequest {
     /// original, allowing operations like generating summaries without affecting the
     /// original session's history.
     ForkSessionRequest(ForkSessionRequest),
+    #[cfg(feature = "unstable_session_delete")]
+    /// **UNSTABLE**
+    ///
+    /// This capability is not part of the spec yet, and may be removed or changed at any point.
+    ///
+    /// Deletes an existing session.
+    ///
+    /// This method is only available if the agent advertises the `session.delete` capability.
+    DeleteSessionRequest(DeleteSessionRequest),
     /// Resumes an existing session without returning previous messages.
     ///
     /// This method is only available if the agent advertises the `sessionCapabilities.resume` capability.
@@ -4952,6 +5114,8 @@ impl ClientRequest {
             Self::ListSessionsRequest(_) => AGENT_METHOD_NAMES.session_list,
             #[cfg(feature = "unstable_session_fork")]
             Self::ForkSessionRequest(_) => AGENT_METHOD_NAMES.session_fork,
+            #[cfg(feature = "unstable_session_delete")]
+            Self::DeleteSessionRequest(_) => AGENT_METHOD_NAMES.session_delete,
             Self::ResumeSessionRequest(_) => AGENT_METHOD_NAMES.session_resume,
             Self::CloseSessionRequest(_) => AGENT_METHOD_NAMES.session_close,
             Self::SetSessionModeRequest(_) => AGENT_METHOD_NAMES.session_set_mode,
@@ -4997,6 +5161,8 @@ pub enum AgentResponse {
     ListSessionsResponse(ListSessionsResponse),
     #[cfg(feature = "unstable_session_fork")]
     ForkSessionResponse(ForkSessionResponse),
+    #[cfg(feature = "unstable_session_delete")]
+    DeleteSessionResponse(#[serde(default)] DeleteSessionResponse),
     ResumeSessionResponse(#[serde(default)] ResumeSessionResponse),
     CloseSessionResponse(#[serde(default)] CloseSessionResponse),
     SetSessionModeResponse(#[serde(default)] SetSessionModeResponse),

--- a/src/v2/agent.rs
+++ b/src/v2/agent.rs
@@ -1714,11 +1714,13 @@ impl CloseSessionResponse {
 /// Only available if the Agent supports the `sessionCapabilities.delete` capability.
 #[cfg(feature = "unstable_session_delete")]
 #[skip_serializing_none]
-#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[schemars(extend("x-side" = "agent", "x-method" = SESSION_DELETE_METHOD_NAME))]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct DeleteSessionRequest {
+    /// The ID of the session to delete.
+    pub session_id: SessionId,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
     /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
     /// these keys.
@@ -1731,8 +1733,11 @@ pub struct DeleteSessionRequest {
 #[cfg(feature = "unstable_session_delete")]
 impl DeleteSessionRequest {
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(session_id: impl Into<SessionId>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            meta: None,
+        }
     }
 
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -5010,7 +5015,7 @@ pub enum ClientRequest {
     ///
     /// Deletes an existing session.
     ///
-    /// This method is only available if the agent advertises the `session.delete` capability.
+    /// This method is only available if the agent advertises the `sessionCapabilities.delete` capability.
     DeleteSessionRequest(DeleteSessionRequest),
     /// Resumes an existing session without returning previous messages.
     ///

--- a/src/v2/agent.rs
+++ b/src/v2/agent.rs
@@ -1703,6 +1703,90 @@ impl CloseSessionResponse {
     }
 }
 
+// Delete session
+
+/// **UNSTABLE**
+///
+/// This capability is not part of the spec yet, and may be removed or changed at any point.
+///
+/// Request parameters for deleting a session.
+///
+/// Only available if the Agent supports the `sessionCapabilities.delete` capability.
+#[cfg(feature = "unstable_session_delete")]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[schemars(extend("x-side" = "agent", "x-method" = SESSION_DELETE_METHOD_NAME))]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct DeleteSessionRequest {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+#[cfg(feature = "unstable_session_delete")]
+impl DeleteSessionRequest {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// **UNSTABLE**
+///
+/// This capability is not part of the spec yet, and may be removed or changed at any point.
+///
+/// Response from deleting a session.
+#[cfg(feature = "unstable_session_delete")]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[schemars(extend("x-side" = "agent", "x-method" = SESSION_DELETE_METHOD_NAME))]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct DeleteSessionResponse {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+#[cfg(feature = "unstable_session_delete")]
+impl DeleteSessionResponse {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
 // List sessions
 
 /// Request parameters for listing existing sessions.
@@ -4160,6 +4244,15 @@ pub struct SessionCapabilities {
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[serde(default)]
     pub fork: Option<SessionForkCapabilities>,
+    /// **UNSTABLE**
+    ///
+    /// This capability is not part of the spec yet, and may be removed or changed at any point.
+    ///
+    /// Whether the agent supports `session/delete`.
+    #[cfg(feature = "unstable_session_delete")]
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[serde(default)]
+    pub delete: Option<SessionDeleteCapabilities>,
     /// Whether the agent supports `session/resume`.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[serde(default)]
@@ -4210,6 +4303,18 @@ impl SessionCapabilities {
     #[must_use]
     pub fn fork(mut self, fork: impl IntoOption<SessionForkCapabilities>) -> Self {
         self.fork = fork.into_option();
+        self
+    }
+
+    /// **UNSTABLE**
+    ///
+    /// This capability is not part of the spec yet, and may be removed or changed at any point.
+    ///
+    /// Whether the agent supports `session/delete`.
+    #[cfg(feature = "unstable_session_delete")]
+    #[must_use]
+    pub fn delete(mut self, delete: impl IntoOption<SessionDeleteCapabilities>) -> Self {
+        self.delete = delete.into_option();
         self
     }
 
@@ -4337,6 +4442,46 @@ pub struct SessionForkCapabilities {
 
 #[cfg(feature = "unstable_session_fork")]
 impl SessionForkCapabilities {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// **UNSTABLE**
+///
+/// This capability is not part of the spec yet, and may be removed or changed at any point.
+///
+/// Capabilities for the `session/delete` method.
+///
+/// By supplying `{}` it means that the agent supports deletion of sessions.
+#[cfg(feature = "unstable_session_delete")]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SessionDeleteCapabilities {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+#[cfg(feature = "unstable_session_delete")]
+impl SessionDeleteCapabilities {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -4616,6 +4761,9 @@ pub struct AgentMethodNames {
     /// Method for forking an existing session.
     #[cfg(feature = "unstable_session_fork")]
     pub session_fork: &'static str,
+    /// Method for deleting an existing session.
+    #[cfg(feature = "unstable_session_delete")]
+    pub session_delete: &'static str,
     /// Method for resuming an existing session.
     pub session_resume: &'static str,
     /// Method for closing an active session.
@@ -4676,6 +4824,8 @@ pub const AGENT_METHOD_NAMES: AgentMethodNames = AgentMethodNames {
     session_list: SESSION_LIST_METHOD_NAME,
     #[cfg(feature = "unstable_session_fork")]
     session_fork: SESSION_FORK_METHOD_NAME,
+    #[cfg(feature = "unstable_session_delete")]
+    session_delete: SESSION_DELETE_METHOD_NAME,
     session_resume: SESSION_RESUME_METHOD_NAME,
     session_close: SESSION_CLOSE_METHOD_NAME,
     #[cfg(feature = "unstable_logout")]
@@ -4735,6 +4885,9 @@ pub(crate) const SESSION_LIST_METHOD_NAME: &str = "session/list";
 /// Method name for forking an existing session.
 #[cfg(feature = "unstable_session_fork")]
 pub(crate) const SESSION_FORK_METHOD_NAME: &str = "session/fork";
+/// Method name for deleting an existing session.
+#[cfg(feature = "unstable_session_delete")]
+pub(crate) const SESSION_DELETE_METHOD_NAME: &str = "session/delete";
 /// Method name for resuming an existing session.
 pub(crate) const SESSION_RESUME_METHOD_NAME: &str = "session/resume";
 /// Method name for closing an active session.
@@ -4850,6 +5003,15 @@ pub enum ClientRequest {
     /// original, allowing operations like generating summaries without affecting the
     /// original session's history.
     ForkSessionRequest(ForkSessionRequest),
+    #[cfg(feature = "unstable_session_delete")]
+    /// **UNSTABLE**
+    ///
+    /// This capability is not part of the spec yet, and may be removed or changed at any point.
+    ///
+    /// Deletes an existing session.
+    ///
+    /// This method is only available if the agent advertises the `session.delete` capability.
+    DeleteSessionRequest(DeleteSessionRequest),
     /// Resumes an existing session without returning previous messages.
     ///
     /// This method is only available if the agent advertises the `sessionCapabilities.resume` capability.
@@ -4952,6 +5114,8 @@ impl ClientRequest {
             Self::ListSessionsRequest(_) => AGENT_METHOD_NAMES.session_list,
             #[cfg(feature = "unstable_session_fork")]
             Self::ForkSessionRequest(_) => AGENT_METHOD_NAMES.session_fork,
+            #[cfg(feature = "unstable_session_delete")]
+            Self::DeleteSessionRequest(_) => AGENT_METHOD_NAMES.session_delete,
             Self::ResumeSessionRequest(_) => AGENT_METHOD_NAMES.session_resume,
             Self::CloseSessionRequest(_) => AGENT_METHOD_NAMES.session_close,
             Self::SetSessionModeRequest(_) => AGENT_METHOD_NAMES.session_set_mode,
@@ -4997,6 +5161,8 @@ pub enum AgentResponse {
     ListSessionsResponse(ListSessionsResponse),
     #[cfg(feature = "unstable_session_fork")]
     ForkSessionResponse(ForkSessionResponse),
+    #[cfg(feature = "unstable_session_delete")]
+    DeleteSessionResponse(#[serde(default)] DeleteSessionResponse),
     ResumeSessionResponse(#[serde(default)] ResumeSessionResponse),
     CloseSessionResponse(#[serde(default)] CloseSessionResponse),
     SetSessionModeResponse(#[serde(default)] SetSessionModeResponse),

--- a/src/v2/conversion.rs
+++ b/src/v2/conversion.rs
@@ -3333,8 +3333,9 @@ impl IntoV1 for super::DeleteSessionRequest {
     type Output = crate::v1::DeleteSessionRequest;
 
     fn into_v1(self) -> Result<Self::Output> {
-        let Self { meta } = self;
+        let Self { session_id, meta } = self;
         Ok(crate::v1::DeleteSessionRequest {
+            session_id: session_id.into_v1()?,
             meta: meta.into_v1()?,
         })
     }
@@ -3345,8 +3346,9 @@ impl IntoV2 for crate::v1::DeleteSessionRequest {
     type Output = super::DeleteSessionRequest;
 
     fn into_v2(self) -> Result<Self::Output> {
-        let Self { meta } = self;
+        let Self { session_id, meta } = self;
         Ok(super::DeleteSessionRequest {
+            session_id: session_id.into_v2()?,
             meta: meta.into_v2()?,
         })
     }

--- a/src/v2/conversion.rs
+++ b/src/v2/conversion.rs
@@ -3328,6 +3328,54 @@ impl IntoV2 for crate::v1::ResumeSessionResponse {
     }
 }
 
+#[cfg(feature = "unstable_session_delete")]
+impl IntoV1 for super::DeleteSessionRequest {
+    type Output = crate::v1::DeleteSessionRequest;
+
+    fn into_v1(self) -> Result<Self::Output> {
+        let Self { meta } = self;
+        Ok(crate::v1::DeleteSessionRequest {
+            meta: meta.into_v1()?,
+        })
+    }
+}
+
+#[cfg(feature = "unstable_session_delete")]
+impl IntoV2 for crate::v1::DeleteSessionRequest {
+    type Output = super::DeleteSessionRequest;
+
+    fn into_v2(self) -> Result<Self::Output> {
+        let Self { meta } = self;
+        Ok(super::DeleteSessionRequest {
+            meta: meta.into_v2()?,
+        })
+    }
+}
+
+#[cfg(feature = "unstable_session_delete")]
+impl IntoV1 for super::DeleteSessionResponse {
+    type Output = crate::v1::DeleteSessionResponse;
+
+    fn into_v1(self) -> Result<Self::Output> {
+        let Self { meta } = self;
+        Ok(crate::v1::DeleteSessionResponse {
+            meta: meta.into_v1()?,
+        })
+    }
+}
+
+#[cfg(feature = "unstable_session_delete")]
+impl IntoV2 for crate::v1::DeleteSessionResponse {
+    type Output = super::DeleteSessionResponse;
+
+    fn into_v2(self) -> Result<Self::Output> {
+        let Self { meta } = self;
+        Ok(super::DeleteSessionResponse {
+            meta: meta.into_v2()?,
+        })
+    }
+}
+
 impl IntoV1 for super::CloseSessionRequest {
     type Output = crate::v1::CloseSessionRequest;
 
@@ -4986,6 +5034,8 @@ impl IntoV1 for super::SessionCapabilities {
             additional_directories,
             #[cfg(feature = "unstable_session_fork")]
             fork,
+            #[cfg(feature = "unstable_session_delete")]
+            delete,
             resume,
             close,
             meta,
@@ -4996,6 +5046,8 @@ impl IntoV1 for super::SessionCapabilities {
             additional_directories: additional_directories.into_v1()?,
             #[cfg(feature = "unstable_session_fork")]
             fork: fork.into_v1()?,
+            #[cfg(feature = "unstable_session_delete")]
+            delete: delete.into_v1()?,
             resume: resume.into_v1()?,
             close: close.into_v1()?,
             meta: meta.into_v1()?,
@@ -5013,6 +5065,8 @@ impl IntoV2 for crate::v1::SessionCapabilities {
             additional_directories,
             #[cfg(feature = "unstable_session_fork")]
             fork,
+            #[cfg(feature = "unstable_session_delete")]
+            delete,
             resume,
             close,
             meta,
@@ -5023,6 +5077,8 @@ impl IntoV2 for crate::v1::SessionCapabilities {
             additional_directories: additional_directories.into_v2()?,
             #[cfg(feature = "unstable_session_fork")]
             fork: fork.into_v2()?,
+            #[cfg(feature = "unstable_session_delete")]
+            delete: delete.into_v2()?,
             resume: resume.into_v2()?,
             close: close.into_v2()?,
             meta: meta.into_v2()?,
@@ -5095,6 +5151,30 @@ impl IntoV2 for crate::v1::SessionForkCapabilities {
     fn into_v2(self) -> Result<Self::Output> {
         let Self { meta } = self;
         Ok(super::SessionForkCapabilities {
+            meta: meta.into_v2()?,
+        })
+    }
+}
+
+#[cfg(feature = "unstable_session_delete")]
+impl IntoV1 for super::SessionDeleteCapabilities {
+    type Output = crate::v1::SessionDeleteCapabilities;
+
+    fn into_v1(self) -> Result<Self::Output> {
+        let Self { meta } = self;
+        Ok(crate::v1::SessionDeleteCapabilities {
+            meta: meta.into_v1()?,
+        })
+    }
+}
+
+#[cfg(feature = "unstable_session_delete")]
+impl IntoV2 for crate::v1::SessionDeleteCapabilities {
+    type Output = super::SessionDeleteCapabilities;
+
+    fn into_v2(self) -> Result<Self::Output> {
+        let Self { meta } = self;
+        Ok(super::SessionDeleteCapabilities {
             meta: meta.into_v2()?,
         })
     }
@@ -5262,6 +5342,10 @@ impl IntoV1 for super::ClientRequest {
             Self::ForkSessionRequest(value) => {
                 crate::v1::ClientRequest::ForkSessionRequest(value.into_v1()?)
             }
+            #[cfg(feature = "unstable_session_delete")]
+            Self::DeleteSessionRequest(value) => {
+                crate::v1::ClientRequest::DeleteSessionRequest(value.into_v1()?)
+            }
             Self::ResumeSessionRequest(value) => {
                 crate::v1::ClientRequest::ResumeSessionRequest(value.into_v1()?)
             }
@@ -5336,6 +5420,10 @@ impl IntoV2 for crate::v1::ClientRequest {
             Self::ForkSessionRequest(value) => {
                 super::ClientRequest::ForkSessionRequest(value.into_v2()?)
             }
+            #[cfg(feature = "unstable_session_delete")]
+            Self::DeleteSessionRequest(value) => {
+                super::ClientRequest::DeleteSessionRequest(value.into_v2()?)
+            }
             Self::ResumeSessionRequest(value) => {
                 super::ClientRequest::ResumeSessionRequest(value.into_v2()?)
             }
@@ -5407,6 +5495,10 @@ impl IntoV1 for super::AgentResponse {
             #[cfg(feature = "unstable_session_fork")]
             Self::ForkSessionResponse(value) => {
                 crate::v1::AgentResponse::ForkSessionResponse(value.into_v1()?)
+            }
+            #[cfg(feature = "unstable_session_delete")]
+            Self::DeleteSessionResponse(value) => {
+                crate::v1::AgentResponse::DeleteSessionResponse(value.into_v1()?)
             }
             Self::ResumeSessionResponse(value) => {
                 crate::v1::AgentResponse::ResumeSessionResponse(value.into_v1()?)
@@ -5483,6 +5575,10 @@ impl IntoV2 for crate::v1::AgentResponse {
             #[cfg(feature = "unstable_session_fork")]
             Self::ForkSessionResponse(value) => {
                 super::AgentResponse::ForkSessionResponse(value.into_v2()?)
+            }
+            #[cfg(feature = "unstable_session_delete")]
+            Self::DeleteSessionResponse(value) => {
+                super::AgentResponse::DeleteSessionResponse(value.into_v2()?)
             }
             Self::ResumeSessionResponse(value) => {
                 super::AgentResponse::ResumeSessionResponse(value.into_v2()?)


### PR DESCRIPTION
## Summary

Scaffolds `session/delete` as the unstable schema feature `unstable_session_delete`, mirroring how `session/list` (#226) and `session/fork` (#311) first landed. The [session-delete RFD](docs/rfds/session-delete.mdx) was moved to Draft; this is the implementation step.

- New `unstable_session_delete` feature flag (in the `unstable` umbrella).
- `DeleteSessionRequest` (carries `sessionId: SessionId`) / `DeleteSessionResponse`, mirrored in v1 and v2.
- `SessionDeleteCapabilities` and `sessionCapabilities.delete` builder.
- Method-name constant, `AgentMethodNames.session_delete`, `ClientRequest`/`AgentResponse` variants, generate.rs routing.
- v1↔v2 conversion impls + `SessionCapabilities` arms.
- Two round-trip serialization tests.
- Regenerated schemas + draft mdx.
- RFD revision-history entry.

## Question for reviewers

session/list updated `docs/protocol/initialization.mdx` Session Capabilities when it landed unstable; session/fork did not. **Should this PR add a paragraph to `initialization.mdx` for `delete` now, or defer until the Preview move?** Happy either way.

## Test plan

- [x] cargo build — no-features / unstable_session_delete / unstable / unstable+unstable_protocol_v2 / --all-features
- [x] cargo clippy --all-features
- [x] cargo test --all-features
- [x] npm run generate
- [x] npx prettier --check .
- [x] ./scripts/spellcheck.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)