### PR TITLE
fix(unstable): Update additionalDirectories guidance

### DIFF
--- a/docs/protocol/draft/file-system.mdx
+++ b/docs/protocol/draft/file-system.mdx
@@ -13,7 +13,7 @@ authorize those paths against the session's effective root set.
 - by default, the effective root set is just `cwd`
 - if the unstable `sessionCapabilities.additionalDirectories` capability is in use, the effective root set becomes `[cwd, ...additionalDirectories]`
 - `cwd` remains the base for relative paths; additional roots only expand filesystem scope
-- when a Client discovers a session through `session/list`, it SHOULD treat `cwd` plus `SessionInfo.additionalDirectories` as the authoritative current root set until a later lifecycle request changes it
+- when a Client discovers a session through `session/list`, it SHOULD use `SessionInfo.additionalDirectories` together with `cwd` as the current root set when the field is present; if omitted, the Agent is not reporting additional-root state, and any later `session/load` or `session/resume` request establishes the root set explicitly
 
 Because ACP filesystem methods are client-mediated, the Client remains
 responsible for enforcing those root boundaries.

--- a/docs/protocol/draft/schema-v2.mdx
+++ b/docs/protocol/draft/schema-v2.mdx
@@ -1165,17 +1165,6 @@ these keys.
 See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
 
 </ResponseField>
-<ResponseField name="additionalDirectories" type={<><span>"string"</span><span>[]</span></>} >
-  **UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-Filter sessions by the exact ordered additional workspace roots. Each path must be absolute.
-
-This filter applies only when the field is present and non-empty. When
-omitted or empty, no additional-root filter is applied.
-
-</ResponseField>
 <ResponseField name="cursor" type={"string | null"} >
   Opaque cursor token from a previous response's nextCursor field for cursor-based pagination
 </ResponseField>
@@ -1251,7 +1240,8 @@ Additional workspace roots to activate for this session. Each path must be absol
 
 When omitted or empty, no additional roots are activated. When non-empty,
 this is the complete resulting additional-root list for the loaded
-session.
+session. It may differ from any previously used or reported list as long as
+the request `cwd` matches the session's `cwd`.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>
@@ -1544,7 +1534,8 @@ Additional workspace roots to activate for this session. Each path must be absol
 
 When omitted or empty, no additional roots are activated. When non-empty,
 this is the complete resulting additional-root list for the resumed
-session.
+session. It may differ from any previously used or reported list as long as
+the request `cwd` matches the session's `cwd`.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>
@@ -6530,8 +6521,10 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 Capabilities for additional session directories support.
 
-By supplying `\{\}` it means that the agent supports the `additionalDirectories` field on
-supported session lifecycle requests and `session/list`.
+By supplying `\{\}` it means that the agent supports the `additionalDirectories`
+field on supported session lifecycle requests. Agents that also support
+`session/list` may return `SessionInfo.additionalDirectories` when they track
+that state.
 
 **Type:** Object
 
@@ -6575,7 +6568,10 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
-Whether the agent supports `additionalDirectories` on supported session lifecycle requests and `session/list`.
+Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
+
+Agents that also support `session/list` may return
+`SessionInfo.additionalDirectories` when they track that state.
 
 </ResponseField>
 <ResponseField name="close" type={<><span><a href="#sessionclosecapabilities">SessionCloseCapabilities</a></span><span> | null</span></>} >
@@ -6933,9 +6929,11 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
-Authoritative ordered additional workspace roots for this session. Each path must be absolute.
+Additional workspace roots for this session, if the Agent reports them. Each path must be absolute.
 
-When omitted or empty, there are no additional roots for the session.
+Agents may omit this field when they do not track or surface additional-root
+state. When present, this is the complete additional-root list known to
+the Agent for the session.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>

--- a/docs/protocol/draft/schema.mdx
+++ b/docs/protocol/draft/schema.mdx
@@ -1165,17 +1165,6 @@ these keys.
 See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
 
 </ResponseField>
-<ResponseField name="additionalDirectories" type={<><span>"string"</span><span>[]</span></>} >
-  **UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-Filter sessions by the exact ordered additional workspace roots. Each path must be absolute.
-
-This filter applies only when the field is present and non-empty. When
-omitted or empty, no additional-root filter is applied.
-
-</ResponseField>
 <ResponseField name="cursor" type={"string | null"} >
   Opaque cursor token from a previous response's nextCursor field for cursor-based pagination
 </ResponseField>
@@ -1251,7 +1240,8 @@ Additional workspace roots to activate for this session. Each path must be absol
 
 When omitted or empty, no additional roots are activated. When non-empty,
 this is the complete resulting additional-root list for the loaded
-session.
+session. It may differ from any previously used or reported list as long as
+the request `cwd` matches the session's `cwd`.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>
@@ -1544,7 +1534,8 @@ Additional workspace roots to activate for this session. Each path must be absol
 
 When omitted or empty, no additional roots are activated. When non-empty,
 this is the complete resulting additional-root list for the resumed
-session.
+session. It may differ from any previously used or reported list as long as
+the request `cwd` matches the session's `cwd`.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>
@@ -6530,8 +6521,10 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 Capabilities for additional session directories support.
 
-By supplying `\{\}` it means that the agent supports the `additionalDirectories` field on
-supported session lifecycle requests and `session/list`.
+By supplying `\{\}` it means that the agent supports the `additionalDirectories`
+field on supported session lifecycle requests. Agents that also support
+`session/list` may return `SessionInfo.additionalDirectories` when they track
+that state.
 
 **Type:** Object
 
@@ -6575,7 +6568,10 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
-Whether the agent supports `additionalDirectories` on supported session lifecycle requests and `session/list`.
+Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
+
+Agents that also support `session/list` may return
+`SessionInfo.additionalDirectories` when they track that state.
 
 </ResponseField>
 <ResponseField name="close" type={<><span><a href="#sessionclosecapabilities">SessionCloseCapabilities</a></span><span> | null</span></>} >
@@ -6933,9 +6929,11 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
-Authoritative ordered additional workspace roots for this session. Each path must be absolute.
+Additional workspace roots for this session, if the Agent reports them. Each path must be absolute.
 
-When omitted or empty, there are no additional roots for the session.
+Agents may omit this field when they do not track or surface additional-root
+state. When present, this is the complete additional-root list known to
+the Agent for the session.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>

--- a/docs/protocol/draft/session-list.mdx
+++ b/docs/protocol/draft/session-list.mdx
@@ -55,10 +55,8 @@ If `sessionCapabilities.list` is not present, the Agent does not support listing
 
 <Note>
   If the Agent also advertises the unstable
-  `sessionCapabilities.additionalDirectories` capability, `session/list`
-  supports filtering by `additionalDirectories`, and any returned
-  `SessionInfo.additionalDirectories` value is the authoritative additional-root
-  list for that session.
+  `sessionCapabilities.additionalDirectories` capability, returned `SessionInfo`
+  objects may include `additionalDirectories` when the Agent tracks that state.
 </Note>
 
 <Note>
@@ -88,13 +86,6 @@ All parameters are optional. A request with an empty `params` object returns the
 <ParamField path="cwd" type="string">
   Filter sessions by working directory. Must be an absolute path. Only sessions
   with a matching `cwd` are returned.
-</ParamField>
-
-<ParamField path="additionalDirectories" type="string[]">
-  If the Agent advertises `sessionCapabilities.additionalDirectories`, filter
-  sessions by the exact ordered additional-root list when this field is present
-  and non-empty. Omitting the field or providing an empty array means no
-  additional-root filter is applied.
 </ParamField>
 
 <ParamField path="cursor" type="string">
@@ -148,10 +139,12 @@ The Agent **MUST** respond with a list of sessions and optional pagination metad
       Working directory for the session. Always an absolute path.
     </ResponseField>
     <ResponseField name="additionalDirectories" type="string[]">
-      If the Agent advertises `sessionCapabilities.additionalDirectories`, this
-      is the authoritative ordered additional-root list for the session when
-      present. Omitting the field or returning an empty array means there are no
-      additional roots.
+      If the Agent advertises `sessionCapabilities.additionalDirectories`, it
+      MAY include this field when it tracks additional-root state for the
+      session. When present, this is the complete ordered additional-root list
+      known to the Agent for that session. Omitting the field means the Agent is
+      not reporting additional-root state; an explicit empty array means the
+      Agent is reporting no additional roots.
     </ResponseField>
 
     <ResponseField name="title" type="string">

--- a/docs/protocol/draft/session-setup.mdx
+++ b/docs/protocol/draft/session-setup.mdx
@@ -367,7 +367,7 @@ When present, `additionalDirectories` has the following behavior:
 - `cwd` remains the primary working directory and the base for relative paths
 - each `additionalDirectories` entry **MUST** be an absolute path
 - omitting the field or providing an empty array activates no additional roots for the resulting session
-- on `session/load` and `session/resume`, Clients must send the full intended additional-root list again because omitting the field or providing an empty array does not restore stored roots implicitly
+- on `session/load` and `session/resume`, Clients must send the full intended additional-root list again; that list may differ from any previous or reported list as long as the request `cwd` matches the session's `cwd`, and omitting the field or providing an empty array does not restore stored roots implicitly
 
 ## Session ID
 

--- a/docs/rfds/additional-directories.mdx
+++ b/docs/rfds/additional-directories.mdx
@@ -44,7 +44,7 @@ Without a standardized field, clients and agents must rely on implementation-spe
 
 > What are you proposing to improve the situation?
 
-Add `additionalDirectories?: string[]` to the session lifecycle request schemas listed above and to `session/list`, and define protocol-level validation and semantics for it.
+Add `additionalDirectories?: string[]` to the session lifecycle request schemas listed above, and add optional additional-root discovery metadata to `session/list` responses.
 
 The proposal is scoped to session lifecycle requests, session discovery requests, and session discovery metadata only:
 
@@ -54,7 +54,7 @@ The proposal is scoped to session lifecycle requests, session discovery requests
 
 Agents advertise support with `sessionCapabilities.additionalDirectories`. Clients MUST gate usage on that capability.
 
-This proposal also extends `SessionInfo` returned by `session/list` with authoritative `additionalDirectories` state, and allows `session/list` to filter on `cwd` plus `additionalDirectories`, so clients that support session discovery can recover and query the active root set for listed sessions. `session/load` and `session/resume` nevertheless remain explicit-list only: omitting `additionalDirectories` or supplying an empty array means no additional roots are activated for the resulting session, while a non-empty array-valued `additionalDirectories` becomes the complete resulting additional-root list for that request.
+This proposal also allows Agents to include `additionalDirectories` in `SessionInfo` returned by `session/list` when they track that state. Because Agents are not required to persist additional-root metadata, Clients treat `SessionInfo.additionalDirectories` as optional discovery metadata rather than required session state. `session/load` and `session/resume` remain explicit-list only: omitting `additionalDirectories` or supplying an empty array means no additional roots are activated for the resulting session, while a non-empty array-valued `additionalDirectories` becomes the complete resulting additional-root list for that request. Clients MAY change the additional-root list on `session/load` or `session/resume` from any previously used or reported list, as long as the request `cwd` matches the session's `cwd` and the Agent accepts the requested roots.
 
 ## Shiny future
 
@@ -97,12 +97,6 @@ The following optional property is added to each request type named above:
 additionalDirectories?: string[]
 ```
 
-The following optional property is also added to `ListSessionsRequest`:
-
-```ts
-additionalDirectories?: string[]
-```
-
 The following optional property is also added to `SessionInfo`:
 
 ```ts
@@ -117,9 +111,9 @@ additionalDirectories?: {}
 
 Clients MUST send `additionalDirectories` only when `sessionCapabilities.additionalDirectories` is present.
 
-If an agent advertises `sessionCapabilities.additionalDirectories` and also supports `session/list`, any `SessionInfo.additionalDirectories` value it returns is the authoritative ordered additional-root list for that session. Agents MAY omit the field when there are no additional roots, and clients MUST treat an omitted field the same as `[]`.
+If an Agent advertises `sessionCapabilities.additionalDirectories` and also supports `session/list`, it MAY include `SessionInfo.additionalDirectories` for sessions whose additional-root state it tracks. When present, the value is the complete ordered additional-root list known to the Agent for that session. Agents MAY omit the field when they do not track or choose not to surface additional-root state. Clients MUST NOT treat an omitted field as proof that the session has no additional roots; an explicit empty array means the Agent is reporting no additional roots for that session.
 
-If an agent advertises `sessionCapabilities.additionalDirectories` and also supports `session/list`, `ListSessionsRequest.additionalDirectories` filters sessions by exact match on the authoritative ordered additional-root list when the field is present and non-empty. When both `cwd` and a non-empty `additionalDirectories` are present on `session/list`, both filters apply. Omitting the field or supplying an empty array means no additional-root filter is applied.
+`ListSessionsRequest` is not extended with `additionalDirectories`. `session/list` filtering remains defined around existing list parameters such as `cwd`; Clients that need to find sessions by additional-root state can filter locally when Agents return `SessionInfo.additionalDirectories`.
 
 If adopted, the session-setup, session-list, and filesystem documentation will need corresponding updates so they describe the effective root set rather than `cwd` alone as the session filesystem context or boundary.
 
@@ -142,7 +136,7 @@ If adopted, the session-setup, session-list, and filesystem documentation will n
 
 ### `session/list` example
 
-When an agent supports both `sessionCapabilities.additionalDirectories` and `session/list`, clients may filter by `cwd`, `additionalDirectories`, or both. Each returned `SessionInfo` includes the authoritative additional-root list for that session:
+When an Agent supports both `sessionCapabilities.additionalDirectories` and `session/list`, Clients may still filter by `cwd`. Agents that track additional-root state may include the complete additional-root list on each returned `SessionInfo`:
 
 ```json
 {
@@ -150,11 +144,7 @@ When an agent supports both `sessionCapabilities.additionalDirectories` and `ses
   "id": 5,
   "method": "session/list",
   "params": {
-    "cwd": "/home/user/project",
-    "additionalDirectories": [
-      "/home/user/shared-lib",
-      "/home/user/product-docs"
-    ]
+    "cwd": "/home/user/project"
   }
 }
 ```
@@ -192,7 +182,7 @@ ACP does not define a wire-level lexical normalization algorithm for `cwd` or `a
 
 Clients SHOULD remove exact duplicate path strings before sending the request. Clients SHOULD also avoid entries whose path string exactly matches `cwd`. Overlapping or nested roots are not semantically redundant for ACP purposes: because discovery across the effective ordered root list is ordered and implementation-defined, such entries MAY affect behavior even when they do not change the union of accessible paths. Agents MAY remove exact duplicate path strings, including entries identical to `cwd`, provided doing so preserves the first occurrence order of the remaining entries and does not expand scope.
 
-For `session/list` filtering, matching is against the session's authoritative ordered additional-root list as surfaced in `SessionInfo.additionalDirectories`. Implementations that normalize or canonicalize path strings for comparison SHOULD apply the same platform-appropriate rule consistently to stored session state, `SessionInfo.additionalDirectories`, and `ListSessionsRequest.additionalDirectories`.
+When returning `SessionInfo.additionalDirectories`, implementations that normalize or canonicalize path strings SHOULD apply the same platform-appropriate rule consistently to stored session state and the returned `SessionInfo.additionalDirectories`.
 
 ### Semantics
 
@@ -228,10 +218,10 @@ For `NewSessionRequest`, the resulting additional root list is:
 
 For `LoadSessionRequest` and `ResumeSessionRequest`:
 
-- when `additionalDirectories` is present with a non-empty array value, it is the complete resulting list of additional roots for the active session, even if that list differs from the session's previously stored additional roots;
+- when `additionalDirectories` is present with a non-empty array value, it is the complete resulting list of additional roots for the active session, even if that list differs from the session's previously stored or reported additional roots, provided the request `cwd` matches the session's `cwd`;
 - when omitted or present as an empty array, the resulting additional root list is `[]`.
 
-Agents MUST NOT implicitly reactivate stored additional roots that were not supplied on the `session/load` or `session/resume` request. Supplying `additionalDirectories` on `session/load` or `session/resume` is always allowed when the capability is advertised, and doing so may preserve, replace, reduce, or expand the session's previously stored additional-root list for the resulting active session, subject to validation and policy checks. Clients that need to preserve a session's additional roots across restarts or across client instances MUST obtain, persist, or reconstruct the full list and resend it on load or resume. When `session/list` is available, `SessionInfo.additionalDirectories` provides the authoritative current additional-root list for that purpose.
+Agents MUST NOT implicitly reactivate stored additional roots that were not supplied on the `session/load` or `session/resume` request. Supplying `additionalDirectories` on `session/load` or `session/resume` is allowed when the capability is advertised and `cwd` matches the session being loaded or resumed, and doing so may preserve, replace, reduce, or expand the session's previously stored or reported additional-root list for the resulting active session, subject to validation and policy checks. Clients that need to preserve a session's additional roots across restarts or across client instances MUST obtain, persist, or reconstruct the full list and resend it on load or resume. When `session/list` includes `SessionInfo.additionalDirectories`, that value can help with this purpose, but Clients MUST NOT assume it is always returned.
 
 For `ForkSessionRequest`:
 
@@ -291,7 +281,7 @@ A client that sends `additionalDirectories`:
 - SHOULD remove exact duplicate path strings and entries identical to `cwd` before sending; and
 - MUST NOT assume an agent will infer extra roots from project metadata, directory conventions, or prior session state.
 
-If a client mediates filesystem access through ACP client capabilities such as `fs/read_text_file` and `fs/write_text_file`, it MUST enforce the effective root set for that session when authorizing path-based access. ACP's filesystem methods are client-mediated and operate on absolute paths, so the client remains responsible for boundary enforcement in those flows. When the client learns about an existing session through `session/list`, it SHOULD use `SessionInfo.additionalDirectories` together with `cwd` as the authoritative current root set for those checks until a subsequent lifecycle request establishes a different one.
+If a client mediates filesystem access through ACP client capabilities such as `fs/read_text_file` and `fs/write_text_file`, it MUST enforce the effective root set for that session when authorizing path-based access. ACP's filesystem methods are client-mediated and operate on absolute paths, so the client remains responsible for boundary enforcement in those flows. When the client learns about an existing session through `session/list`, it SHOULD use `SessionInfo.additionalDirectories` together with `cwd` as the current root set for those checks when the field is present. If the field is omitted, the Client should rely on roots it obtained, persisted, or reconstructed itself, and any subsequent lifecycle request establishes the resulting active root set explicitly.
 
 If a client launches an agent with direct filesystem access, `additionalDirectories` is not, by itself, a sandbox. Clients that need root boundaries to be enforced in that deployment model SHOULD apply operating-system or runtime sandboxing consistent with the declared root set.
 
@@ -392,9 +382,9 @@ Updated agents MUST continue to accept requests that do not include the field.
 
 Older implementations may validate request objects strictly against older schemas and MAY reject unknown fields. Clients therefore MUST gate usage on `sessionCapabilities.additionalDirectories`.
 
-This proposal intentionally does not extend the responses to `session/new`, `session/load`, `session/resume`, or `session/fork` to surface authoritative additional-root state directly. That remains consistent with existing ACP response shapes, which also do not return `cwd`. Instead, when `session/list` is supported, `SessionInfo.additionalDirectories` exposes the authoritative ordered additional-root list for listed sessions. `SessionInfoUpdate` remains unchanged because this RFD does not define mid-session mutation of `additionalDirectories`. Clients that need multi-root continuity across `session/load` or `session/resume` MUST still send the full intended list explicitly.
+This proposal intentionally does not extend the responses to `session/new`, `session/load`, `session/resume`, or `session/fork` to surface additional-root state directly. That remains consistent with existing ACP response shapes, which also do not return `cwd`. Instead, when `session/list` is supported, Agents MAY expose the complete ordered additional-root list for listed sessions through `SessionInfo.additionalDirectories` when they track that state. `SessionInfoUpdate` remains unchanged because this RFD does not define mid-session mutation of `additionalDirectories`. Clients that need multi-root continuity across `session/load` or `session/resume` MUST still send the full intended list explicitly, and MAY change that list from a previously used or reported list as long as the request `cwd` matches the session's `cwd`.
 
-`session/list` filtering no longer remains `cwd`-only: sessions may be filtered by `cwd`, by `additionalDirectories`, or by both together. Sessions that differ by `additionalDirectories` are therefore both distinguishable and filterable through `SessionInfo.additionalDirectories` and `ListSessionsRequest.additionalDirectories`.
+`session/list` filtering remains independent of `additionalDirectories`. Sessions that differ by `additionalDirectories` are distinguishable only when the Agent surfaces that state through `SessionInfo.additionalDirectories`; Clients that need additional-root matching can filter those returned sessions locally.
 
 This RFD does not add a new RPC method. It also does not change the meaning of `cwd`, `sessionId`, or `mcpServers`.
 
@@ -429,7 +419,7 @@ Clients MUST gate `additionalDirectories` on `sessionCapabilities.additionalDire
 
 ### Why not restore stored roots on `session/load` or `session/resume` when the field is omitted?
 
-Even with `SessionInfo.additionalDirectories` available through `session/list`, implicit restoration would still let an agent reactivate filesystem scope that the current request did not state explicitly. That is undesirable for clients that do not use `session/list`, for clients resuming a session by ID without first listing it, and for clients that want request-time control over the active root set. This proposal therefore keeps load and resume explicit-list only for additional roots: omitting the field or supplying an empty array activates none, while supplying a non-empty array is explicitly allowed and sets the complete resulting additional-root list for that request.
+Even when `SessionInfo.additionalDirectories` is available through `session/list`, implicit restoration would still let an Agent reactivate filesystem scope that the current request did not state explicitly. Some Agents also do not persist or surface this state at all. That is undesirable for Clients that do not use `session/list`, for Clients resuming a session by ID without first listing it, and for Clients that want request-time control over the active root set. This proposal therefore keeps load and resume explicit-list only for additional roots: omitting the field or supplying an empty array activates none, while supplying a non-empty array is explicitly allowed and sets the complete resulting additional-root list for that request. That list may differ from any previously used or reported list, as long as the request `cwd` matches the session's `cwd` and the Agent accepts the requested roots.
 
 ### What alternative approaches did you consider, and why did you settle on this one?
 

--- a/schema/schema.unstable.json
+++ b/schema/schema.unstable.json
@@ -3316,13 +3316,6 @@
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": ["object", "null"]
         },
-        "additionalDirectories": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nFilter sessions by the exact ordered additional workspace roots. Each path must be absolute.\n\nThis filter applies only when the field is present and non-empty. When\nomitted or empty, no additional-root filter is applied.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "cursor": {
           "description": "Opaque cursor token from a previous response's nextCursor field for cursor-based pagination",
           "type": ["string", "null"]
@@ -3405,7 +3398,7 @@
           "type": ["object", "null"]
         },
         "additionalDirectories": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the loaded\nsession.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the loaded\nsession. It may differ from any previously used or reported list as long as\nthe request `cwd` matches the session's `cwd`.",
           "items": {
             "type": "string"
           },
@@ -5566,7 +5559,7 @@
           "type": ["object", "null"]
         },
         "additionalDirectories": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the resumed\nsession.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the resumed\nsession. It may differ from any previously used or reported list as long as\nthe request `cwd` matches the session's `cwd`.",
           "items": {
             "type": "string"
           },
@@ -5665,7 +5658,7 @@
       "type": "object"
     },
     "SessionAdditionalDirectoriesCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for additional session directories support.\n\nBy supplying `{}` it means that the agent supports the `additionalDirectories` field on\nsupported session lifecycle requests and `session/list`.",
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for additional session directories support.\n\nBy supplying `{}` it means that the agent supports the `additionalDirectories`\nfield on supported session lifecycle requests. Agents that also support\n`session/list` may return `SessionInfo.additionalDirectories` when they track\nthat state.",
       "properties": {
         "_meta": {
           "additionalProperties": true,
@@ -5692,7 +5685,7 @@
               "type": "null"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `additionalDirectories` on supported session lifecycle requests and `session/list`."
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nAgents that also support `session/list` may return\n`SessionInfo.additionalDirectories` when they track that state."
         },
         "close": {
           "anyOf": [
@@ -6025,7 +6018,7 @@
           "type": ["object", "null"]
         },
         "additionalDirectories": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAuthoritative ordered additional workspace roots for this session. Each path must be absolute.\n\nWhen omitted or empty, there are no additional roots for the session.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots for this session, if the Agent reports them. Each path must be absolute.\n\nAgents may omit this field when they do not track or surface additional-root\nstate. When present, this is the complete additional-root list known to\nthe Agent for the session.",
           "items": {
             "type": "string"
           },

--- a/schema/schema.v2.unstable.json
+++ b/schema/schema.v2.unstable.json
@@ -3316,13 +3316,6 @@
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": ["object", "null"]
         },
-        "additionalDirectories": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nFilter sessions by the exact ordered additional workspace roots. Each path must be absolute.\n\nThis filter applies only when the field is present and non-empty. When\nomitted or empty, no additional-root filter is applied.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "cursor": {
           "description": "Opaque cursor token from a previous response's nextCursor field for cursor-based pagination",
           "type": ["string", "null"]
@@ -3405,7 +3398,7 @@
           "type": ["object", "null"]
         },
         "additionalDirectories": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the loaded\nsession.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the loaded\nsession. It may differ from any previously used or reported list as long as\nthe request `cwd` matches the session's `cwd`.",
           "items": {
             "type": "string"
           },
@@ -5566,7 +5559,7 @@
           "type": ["object", "null"]
         },
         "additionalDirectories": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the resumed\nsession.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the resumed\nsession. It may differ from any previously used or reported list as long as\nthe request `cwd` matches the session's `cwd`.",
           "items": {
             "type": "string"
           },
@@ -5665,7 +5658,7 @@
       "type": "object"
     },
     "SessionAdditionalDirectoriesCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for additional session directories support.\n\nBy supplying `{}` it means that the agent supports the `additionalDirectories` field on\nsupported session lifecycle requests and `session/list`.",
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for additional session directories support.\n\nBy supplying `{}` it means that the agent supports the `additionalDirectories`\nfield on supported session lifecycle requests. Agents that also support\n`session/list` may return `SessionInfo.additionalDirectories` when they track\nthat state.",
       "properties": {
         "_meta": {
           "additionalProperties": true,
@@ -5692,7 +5685,7 @@
               "type": "null"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `additionalDirectories` on supported session lifecycle requests and `session/list`."
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nAgents that also support `session/list` may return\n`SessionInfo.additionalDirectories` when they track that state."
         },
         "close": {
           "anyOf": [
@@ -6025,7 +6018,7 @@
           "type": ["object", "null"]
         },
         "additionalDirectories": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAuthoritative ordered additional workspace roots for this session. Each path must be absolute.\n\nWhen omitted or empty, there are no additional roots for the session.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAdditional workspace roots for this session, if the Agent reports them. Each path must be absolute.\n\nAgents may omit this field when they do not track or surface additional-root\nstate. When present, this is the complete additional-root list known to\nthe Agent for the session.",
           "items": {
             "type": "string"
           },

--- a/src/v1/agent.rs
+++ b/src/v1/agent.rs
@@ -1120,7 +1120,8 @@ pub struct LoadSessionRequest {
     ///
     /// When omitted or empty, no additional roots are activated. When non-empty,
     /// this is the complete resulting additional-root list for the loaded
-    /// session.
+    /// session. It may differ from any previously used or reported list as long as
+    /// the request `cwd` matches the session's `cwd`.
     #[cfg(feature = "unstable_session_additional_directories")]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_directories: Vec<PathBuf>,
@@ -1482,7 +1483,8 @@ pub struct ResumeSessionRequest {
     ///
     /// When omitted or empty, no additional roots are activated. When non-empty,
     /// this is the complete resulting additional-root list for the resumed
-    /// session.
+    /// session. It may differ from any previously used or reported list as long as
+    /// the request `cwd` matches the session's `cwd`.
     #[cfg(feature = "unstable_session_additional_directories")]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_directories: Vec<PathBuf>,
@@ -1721,17 +1723,6 @@ impl CloseSessionResponse {
 pub struct ListSessionsRequest {
     /// Filter sessions by working directory. Must be an absolute path.
     pub cwd: Option<PathBuf>,
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// Filter sessions by the exact ordered additional workspace roots. Each path must be absolute.
-    ///
-    /// This filter applies only when the field is present and non-empty. When
-    /// omitted or empty, no additional-root filter is applied.
-    #[cfg(feature = "unstable_session_additional_directories")]
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub additional_directories: Vec<PathBuf>,
     /// Opaque cursor token from a previous response's nextCursor field for cursor-based pagination
     pub cursor: Option<String>,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -1753,18 +1744,6 @@ impl ListSessionsRequest {
     #[must_use]
     pub fn cwd(mut self, cwd: impl IntoOption<PathBuf>) -> Self {
         self.cwd = cwd.into_option();
-        self
-    }
-
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// Filter sessions by the exact ordered additional workspace roots. Each path must be absolute.
-    #[cfg(feature = "unstable_session_additional_directories")]
-    #[must_use]
-    pub fn additional_directories(mut self, additional_directories: Vec<PathBuf>) -> Self {
-        self.additional_directories = additional_directories;
         self
     }
 
@@ -1942,9 +1921,11 @@ pub struct SessionInfo {
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
-    /// Authoritative ordered additional workspace roots for this session. Each path must be absolute.
+    /// Additional workspace roots for this session, if the Agent reports them. Each path must be absolute.
     ///
-    /// When omitted or empty, there are no additional roots for the session.
+    /// Agents may omit this field when they do not track or surface additional-root
+    /// state. When present, this is the complete additional-root list known to
+    /// the Agent for the session.
     #[cfg(feature = "unstable_session_additional_directories")]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_directories: Vec<PathBuf>,
@@ -1984,7 +1965,7 @@ impl SessionInfo {
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
-    /// Authoritative ordered additional workspace roots for this session. Each path must be absolute.
+    /// Additional workspace roots for this session, if the Agent reports them. Each path must be absolute.
     #[cfg(feature = "unstable_session_additional_directories")]
     #[must_use]
     pub fn additional_directories(mut self, additional_directories: Vec<PathBuf>) -> Self {
@@ -4252,7 +4233,10 @@ pub struct SessionCapabilities {
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
-    /// Whether the agent supports `additionalDirectories` on supported session lifecycle requests and `session/list`.
+    /// Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
+    ///
+    /// Agents that also support `session/list` may return
+    /// `SessionInfo.additionalDirectories` when they track that state.
     #[cfg(feature = "unstable_session_additional_directories")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[serde(default)]
@@ -4315,7 +4299,10 @@ impl SessionCapabilities {
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
-    /// Whether the agent supports `additionalDirectories` on supported session lifecycle requests and `session/list`.
+    /// Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
+    ///
+    /// Agents that also support `session/list` may return
+    /// `SessionInfo.additionalDirectories` when they track that state.
     #[cfg(feature = "unstable_session_additional_directories")]
     #[must_use]
     pub fn additional_directories(
@@ -4440,8 +4427,10 @@ impl SessionDeleteCapabilities {
 ///
 /// Capabilities for additional session directories support.
 ///
-/// By supplying `{}` it means that the agent supports the `additionalDirectories` field on
-/// supported session lifecycle requests and `session/list`.
+/// By supplying `{}` it means that the agent supports the `additionalDirectories`
+/// field on supported session lifecycle requests. Agents that also support
+/// `session/list` may return `SessionInfo.additionalDirectories` when they track
+/// that state.
 #[cfg(feature = "unstable_session_additional_directories")]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -5756,13 +5745,6 @@ mod test_serialization {
             })
         );
         assert_eq!(
-            serde_json::to_value(
-                ListSessionsRequest::new().additional_directories(Vec::<PathBuf>::new())
-            )
-            .unwrap(),
-            json!({})
-        );
-        assert_eq!(
             serde_json::to_value(SessionInfo::new("sess_abc123", "/home/user/project")).unwrap(),
             json!({
                 "sessionId": "sess_abc123",
@@ -5790,22 +5772,6 @@ mod test_serialization {
             serde_json::from_value::<SessionInfo>(json!({
                 "sessionId": "sess_abc123",
                 "cwd": "/home/user/project"
-            }))
-            .unwrap()
-            .additional_directories,
-            Vec::<PathBuf>::new()
-        );
-
-        assert_eq!(
-            serde_json::from_value::<ListSessionsRequest>(json!({}))
-                .unwrap()
-                .additional_directories,
-            Vec::<PathBuf>::new()
-        );
-
-        assert_eq!(
-            serde_json::from_value::<ListSessionsRequest>(json!({
-                "additionalDirectories": []
             }))
             .unwrap()
             .additional_directories,

--- a/src/v2/agent.rs
+++ b/src/v2/agent.rs
@@ -1120,7 +1120,8 @@ pub struct LoadSessionRequest {
     ///
     /// When omitted or empty, no additional roots are activated. When non-empty,
     /// this is the complete resulting additional-root list for the loaded
-    /// session.
+    /// session. It may differ from any previously used or reported list as long as
+    /// the request `cwd` matches the session's `cwd`.
     #[cfg(feature = "unstable_session_additional_directories")]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_directories: Vec<PathBuf>,
@@ -1482,7 +1483,8 @@ pub struct ResumeSessionRequest {
     ///
     /// When omitted or empty, no additional roots are activated. When non-empty,
     /// this is the complete resulting additional-root list for the resumed
-    /// session.
+    /// session. It may differ from any previously used or reported list as long as
+    /// the request `cwd` matches the session's `cwd`.
     #[cfg(feature = "unstable_session_additional_directories")]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_directories: Vec<PathBuf>,
@@ -1721,17 +1723,6 @@ impl CloseSessionResponse {
 pub struct ListSessionsRequest {
     /// Filter sessions by working directory. Must be an absolute path.
     pub cwd: Option<PathBuf>,
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// Filter sessions by the exact ordered additional workspace roots. Each path must be absolute.
-    ///
-    /// This filter applies only when the field is present and non-empty. When
-    /// omitted or empty, no additional-root filter is applied.
-    #[cfg(feature = "unstable_session_additional_directories")]
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub additional_directories: Vec<PathBuf>,
     /// Opaque cursor token from a previous response's nextCursor field for cursor-based pagination
     pub cursor: Option<String>,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -1753,18 +1744,6 @@ impl ListSessionsRequest {
     #[must_use]
     pub fn cwd(mut self, cwd: impl IntoOption<PathBuf>) -> Self {
         self.cwd = cwd.into_option();
-        self
-    }
-
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// Filter sessions by the exact ordered additional workspace roots. Each path must be absolute.
-    #[cfg(feature = "unstable_session_additional_directories")]
-    #[must_use]
-    pub fn additional_directories(mut self, additional_directories: Vec<PathBuf>) -> Self {
-        self.additional_directories = additional_directories;
         self
     }
 
@@ -1942,9 +1921,11 @@ pub struct SessionInfo {
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
-    /// Authoritative ordered additional workspace roots for this session. Each path must be absolute.
+    /// Additional workspace roots for this session, if the Agent reports them. Each path must be absolute.
     ///
-    /// When omitted or empty, there are no additional roots for the session.
+    /// Agents may omit this field when they do not track or surface additional-root
+    /// state. When present, this is the complete additional-root list known to
+    /// the Agent for the session.
     #[cfg(feature = "unstable_session_additional_directories")]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_directories: Vec<PathBuf>,
@@ -1984,7 +1965,7 @@ impl SessionInfo {
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
-    /// Authoritative ordered additional workspace roots for this session. Each path must be absolute.
+    /// Additional workspace roots for this session, if the Agent reports them. Each path must be absolute.
     #[cfg(feature = "unstable_session_additional_directories")]
     #[must_use]
     pub fn additional_directories(mut self, additional_directories: Vec<PathBuf>) -> Self {
@@ -4252,7 +4233,10 @@ pub struct SessionCapabilities {
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
-    /// Whether the agent supports `additionalDirectories` on supported session lifecycle requests and `session/list`.
+    /// Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
+    ///
+    /// Agents that also support `session/list` may return
+    /// `SessionInfo.additionalDirectories` when they track that state.
     #[cfg(feature = "unstable_session_additional_directories")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[serde(default)]
@@ -4315,7 +4299,10 @@ impl SessionCapabilities {
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
-    /// Whether the agent supports `additionalDirectories` on supported session lifecycle requests and `session/list`.
+    /// Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
+    ///
+    /// Agents that also support `session/list` may return
+    /// `SessionInfo.additionalDirectories` when they track that state.
     #[cfg(feature = "unstable_session_additional_directories")]
     #[must_use]
     pub fn additional_directories(
@@ -4440,8 +4427,10 @@ impl SessionDeleteCapabilities {
 ///
 /// Capabilities for additional session directories support.
 ///
-/// By supplying `{}` it means that the agent supports the `additionalDirectories` field on
-/// supported session lifecycle requests and `session/list`.
+/// By supplying `{}` it means that the agent supports the `additionalDirectories`
+/// field on supported session lifecycle requests. Agents that also support
+/// `session/list` may return `SessionInfo.additionalDirectories` when they track
+/// that state.
 #[cfg(feature = "unstable_session_additional_directories")]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -5678,13 +5667,6 @@ mod test_serialization {
             })
         );
         assert_eq!(
-            serde_json::to_value(
-                ListSessionsRequest::new().additional_directories(Vec::<PathBuf>::new())
-            )
-            .unwrap(),
-            json!({})
-        );
-        assert_eq!(
             serde_json::to_value(SessionInfo::new("sess_abc123", "/home/user/project")).unwrap(),
             json!({
                 "sessionId": "sess_abc123",
@@ -5712,22 +5694,6 @@ mod test_serialization {
             serde_json::from_value::<SessionInfo>(json!({
                 "sessionId": "sess_abc123",
                 "cwd": "/home/user/project"
-            }))
-            .unwrap()
-            .additional_directories,
-            Vec::<PathBuf>::new()
-        );
-
-        assert_eq!(
-            serde_json::from_value::<ListSessionsRequest>(json!({}))
-                .unwrap()
-                .additional_directories,
-            Vec::<PathBuf>::new()
-        );
-
-        assert_eq!(
-            serde_json::from_value::<ListSessionsRequest>(json!({
-                "additionalDirectories": []
             }))
             .unwrap()
             .additional_directories,

--- a/src/v2/conversion.rs
+++ b/src/v2/conversion.rs
@@ -3698,17 +3698,9 @@ impl IntoV1 for super::ListSessionsRequest {
     type Output = crate::v1::ListSessionsRequest;
 
     fn into_v1(self) -> Result<Self::Output> {
-        let Self {
-            cwd,
-            #[cfg(feature = "unstable_session_additional_directories")]
-            additional_directories,
-            cursor,
-            meta,
-        } = self;
+        let Self { cwd, cursor, meta } = self;
         Ok(crate::v1::ListSessionsRequest {
             cwd: cwd.into_v1()?,
-            #[cfg(feature = "unstable_session_additional_directories")]
-            additional_directories: additional_directories.into_v1()?,
             cursor: cursor.into_v1()?,
             meta: meta.into_v1()?,
         })
@@ -3719,17 +3711,9 @@ impl IntoV2 for crate::v1::ListSessionsRequest {
     type Output = super::ListSessionsRequest;
 
     fn into_v2(self) -> Result<Self::Output> {
-        let Self {
-            cwd,
-            #[cfg(feature = "unstable_session_additional_directories")]
-            additional_directories,
-            cursor,
-            meta,
-        } = self;
+        let Self { cwd, cursor, meta } = self;
         Ok(super::ListSessionsRequest {
             cwd: cwd.into_v2()?,
-            #[cfg(feature = "unstable_session_additional_directories")]
-            additional_directories: additional_directories.into_v2()?,
             cursor: cursor.into_v2()?,
             meta: meta.into_v2()?,
         })


### PR DESCRIPTION
In the implementation phase it has become clear most agents treat this
as optional data in their persistence, and it is ok to change on
resume/load. Given this, loosening the requirements of the RFD.

Remove additional-root filter from session list as well, since it is
best-effort anyway, and probably more of a footgun than not.
