### PR TITLE
docs: add ACP to AG-UI connector to clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -91,6 +91,7 @@ These frameworks add ACP support through dedicated integrations or adapters:
 
 These connectors bridge ACP into other environments and transport layers:
 
+- [ACP to AG-UI](https://github.com/namanrajpal/acp-to-agui) — bridges any ACP agent to web frontends via [AG-UI](https://docs.ag-ui.com) events over SSE; works with CopilotKit, AG-UI HttpAgent, or custom UIs (Web)
 - [AgentRQ](https://github.com/agentrq/acp-gateway) — bridges stdio-based ACP agents to the AgentRQ - Human-in-the-loop task collaboration service using MCP server.
 - [Aptove Bridge](https://github.com/aptove/bridge) — bridges stdio-based ACP agents to the Aptove mobile client over WebSocket
 - [OpenClaw](https://docs.openclaw.ai/cli/acp) — through the [`openclaw acp`](https://docs.openclaw.ai/cli/acp) bridge to an OpenClaw Gateway


### PR DESCRIPTION
## Summary

  Adds [ACP to AG-UI](https://github.com/namanrajpal/acp-to-agui) to the Connectors section of the clients page.
  This is a protocol bridge (Python/FastAPI) that connects any ACP-compatible agent to web frontends via [AG-UI](https://docs.ag-ui.com) events over SSE. It translates ACP JSON-RPC
  notifications into standard AG-UI event types (TEXT_MESSAGE_*, TOOL_CALL_*, STATE_UPDATE, RUN_FINISHED, etc.).
  
  Tested end-to-end with:
  - Kiro CLI (v2.3.0), 13 modes, extension notifications
  - Claude Agent ACP (v0.36.1), 5 modes, prompt queueing

  Supports three frontend integration patterns:
  - CopilotKit (framework-level, ~20 lines)
  - AG-UI HttpAgent (@ag-ui/client library, ~50 lines)
  - Custom workspace UI (direct REST + SSE, full control)