### PR TITLE
docs: add lark/feishu connector in get-started/clients chapter

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -75,6 +75,7 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 - [Telegram-ACP](https://github.com/SuperKenVery/Telegram-ACP/) (Telegram) — Supports multi-thread chat and message streaming
 - [WeChat ACP](https://github.com/formulahendry/wechat-acp) (WeChat)
 - [Sniptail](https://github.com/Justkog/sniptail) (Discord, Slack) - self-hosted chat bridge for running coding agents across your team’s repositories
+- [Lark ACP](https://github.com/4t145/lark-acp) (Lark/飞书)
 
 ## Frameworks
 


### PR DESCRIPTION
Lark/飞书 is a regional enterprise collaboration platform being wildly used in China. This connector bridge lark as an acp client.