### PR TITLE
feat(unstable): Add v2 enum extension RFD and fallbacks

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -149,6 +149,7 @@
                 "root": "rfds/v2/overview",
                 "pages": [
                   "rfds/v2/prompt",
+                  "rfds/v2/enum-variant-extension",
                   "rfds/message-id",
                   "rfds/streamable-http-websocket-transport"
                 ]

--- a/docs/protocol/draft/schema-v2.mdx
+++ b/docs/protocol/draft/schema-v2.mdx
@@ -3063,6 +3063,48 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
+<ResponseField name="unknown" type="object">
+Custom or future authentication method.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+Clients that do not understand this method type should preserve the raw
+payload when storing, replaying, proxying, or forwarding initialization
+data, and otherwise ignore the method or display it generically.
+
+<Expandable title="Properties">
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+
+</ResponseField>
+<ResponseField name="description" type={"string | null"} >
+  Optional description providing more details about this authentication method.
+</ResponseField>
+<ResponseField name="id" type={"string"} required>
+  Unique identifier for this authentication method.
+</ResponseField>
+<ResponseField name="name" type={"string"} required>
+  Human-readable name of the authentication method.
+</ResponseField>
+<ResponseField name="type" type={"string"} required>
+  Custom or future authentication method type.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+</ResponseField>
+
+</Expandable>
+</ResponseField>
+
 <ResponseField name="agent">
 Agent handles authentication itself.
 
@@ -3225,11 +3267,12 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 
 The input specification for a command.
 
+**Type:** Union
+
+<ResponseField name="unstructured">
 All text that was typed after the command name is provided as input.
 
-**Type:** Object
-
-**Properties:**
+<Expandable title="Properties">
 
 <ResponseField name="_meta" type={"object | null"} >
   The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -3241,6 +3284,35 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </ResponseField>
 <ResponseField name="hint" type={"string"} required>
   A hint to display when the input hasn't been provided yet
+</ResponseField>
+
+</Expandable>
+</ResponseField>
+
+<ResponseField name="unknown" type="object">
+Custom or future command input specification.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+Clients that do not understand this input type should preserve the raw
+payload when storing, replaying, proxying, or forwarding command
+metadata, and otherwise ignore the input specification or display the
+command without structured input.
+
+<Expandable title="Properties">
+
+<ResponseField name="type" type={"string"} required>
+  Custom or future command input type.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+</ResponseField>
+
+</Expandable>
 </ResponseField>
 
 ## <span class="font-mono">AvailableCommandsUpdate</span>
@@ -3617,6 +3689,31 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </ResponseField>
 <ResponseField name="type" type={"string"} required>
   The discriminator value. Must be `"resource"`.
+</ResponseField>
+
+</Expandable>
+</ResponseField>
+
+<ResponseField name="unknown" type="object">
+Custom or future content block.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+Receivers that do not understand this content block type should preserve
+the raw payload when storing, replaying, proxying, or forwarding content,
+and otherwise ignore it or display it generically.
+
+<Expandable title="Properties">
+
+<ResponseField name="type" type={"string"} required>
+  Custom or future content block type.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
 </ResponseField>
 
 </Expandable>
@@ -4658,7 +4755,12 @@ Protocol names that do not begin with `_` are reserved for the ACP spec.
 </ResponseField>
 
 <ResponseField name="other" type="string">
-  Unknown or custom protocol.
+Custom or future protocol.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
 </ResponseField>
 
 ## <span class="font-mono">LogoutCapabilities</span>
@@ -5227,6 +5329,15 @@ Severity of a diagnostic.
   A hint.
 </ResponseField>
 
+<ResponseField name="Other" type="string">
+Custom or future diagnostic severity.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+</ResponseField>
+
 ## <span class="font-mono">NesDiagnosticsCapabilities</span>
 
 Capabilities for diagnostics context.
@@ -5620,6 +5731,15 @@ The reason a suggestion was rejected.
   The request was cancelled before the agent returned a response.
 </ResponseField>
 
+<ResponseField name="Other" type="string">
+Custom or future rejection reason.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+</ResponseField>
+
 ## <span class="font-mono">NesRelatedSnippet</span>
 
 A related code snippet from a file.
@@ -5904,6 +6024,31 @@ A search-and-replace suggestion.
 </Expandable>
 </ResponseField>
 
+<ResponseField name="unknown" type="object">
+Custom or future NES suggestion.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+Receivers that do not understand this suggestion kind should preserve
+the raw payload when storing, replaying, proxying, or forwarding
+suggestions, and otherwise ignore it or display it generically.
+
+<Expandable title="Properties">
+
+<ResponseField name="kind" type={"string"} required>
+  Custom or future NES suggestion kind.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+</ResponseField>
+
+</Expandable>
+</ResponseField>
+
 ## <span class="font-mono">NesTextEdit</span>
 
 A text edit within a suggestion.
@@ -5935,6 +6080,15 @@ What triggered the suggestion request.
 
 <ResponseField name="manual" type="string">
   Triggered by an explicit user action (keyboard shortcut).
+</ResponseField>
+
+<ResponseField name="Other" type="string">
+Custom or future suggestion trigger kind.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
 </ResponseField>
 
 ## <span class="font-mono">NesUserAction</span>
@@ -6064,6 +6218,15 @@ Helps clients choose appropriate icons and UI treatment.
   Reject this operation and remember the choice.
 </ResponseField>
 
+<ResponseField name="other" type="string">
+Custom or future permission option kind.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+</ResponseField>
+
 ## <span class="font-mono">Plan</span>
 
 An execution plan for accomplishing complex tasks.
@@ -6168,6 +6331,15 @@ See protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/agent
   Low priority task - nice to have but not essential.
 </ResponseField>
 
+<ResponseField name="other" type="string">
+Custom or future plan entry priority.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+</ResponseField>
+
 ## <span class="font-mono">PlanEntryStatus</span>
 
 Status of a plan entry in the execution flow.
@@ -6187,6 +6359,15 @@ See protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/agent
 
 <ResponseField name="completed" type="string">
   The task has been successfully completed.
+</ResponseField>
+
+<ResponseField name="other" type="string">
+Custom or future plan entry status.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
 </ResponseField>
 
 ## <span class="font-mono">PlanFile</span>
@@ -6419,6 +6600,31 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </ResponseField>
 <ResponseField name="type" type={"string"} required>
   The discriminator value. Must be `"markdown"`.
+</ResponseField>
+
+</Expandable>
+</ResponseField>
+
+<ResponseField name="unknown" type="object">
+Custom or future plan update content.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+Receivers that do not understand this content type should preserve the
+raw payload when storing, replaying, proxying, or forwarding plans, and
+otherwise ignore it or display it generically.
+
+<Expandable title="Properties">
+
+<ResponseField name="type" type={"string"} required>
+  Custom or future plan update content type.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
 </ResponseField>
 
 </Expandable>
@@ -6734,12 +6940,20 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 
 The sender or recipient of messages and data in a conversation.
 
-**Type:** Enumeration
+**Type:** Union
 
-| Value         |
-| ------------- |
-| `"assistant"` |
-| `"user"`      |
+<ResponseField name="assistant | user" type="enum">
+  **Values:** `"assistant"`, `"user"`
+</ResponseField>
+
+<ResponseField name="other" type="string">
+Custom or future role.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+</ResponseField>
 
 ## <span class="font-mono">SelectedPermissionOutcome</span>
 
@@ -6975,6 +7189,31 @@ Boolean on/off toggle.
 </Expandable>
 </ResponseField>
 
+<ResponseField name="unknown" type="object">
+Custom or future session configuration option payload.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+Clients that do not understand this option type should preserve the raw
+payload when storing, replaying, proxying, or forwarding configuration
+data, and otherwise ignore the option or display it generically.
+
+<Expandable title="Properties">
+
+<ResponseField name="type" type={"string"} required>
+  Custom or future session configuration option type.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+</ResponseField>
+
+</Expandable>
+</ResponseField>
+
 ## <span class="font-mono">SessionConfigOptionCategory</span>
 
 Semantic category for a session configuration option.
@@ -7002,7 +7241,12 @@ Category names that do not begin with `_` are reserved for the ACP spec.
 </ResponseField>
 
 <ResponseField name="other" type="string">
-  Unknown / uncategorized selector.
+Custom or future category.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
 </ResponseField>
 
 ## <span class="font-mono">SessionConfigSelect</span>
@@ -7766,6 +8010,31 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
+<ResponseField name="unknown" type="object">
+Custom or future session update.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+Receivers that do not understand this update type should preserve the
+raw payload when storing, replaying, proxying, or forwarding session
+history, and otherwise ignore it or display it generically.
+
+<Expandable title="Properties">
+
+<ResponseField name="sessionUpdate" type={"string"} required>
+  Custom or future session update type.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+</ResponseField>
+
+</Expandable>
+</ResponseField>
+
 ## <span class="font-mono">StopReason</span>
 
 Reasons why an agent stops processing a prompt turn.
@@ -7803,6 +8072,15 @@ response to confirm successful cancellation.
 
 </ResponseField>
 
+<ResponseField name="other" type="string">
+Custom or future stop reason.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+</ResponseField>
+
 ## <span class="font-mono">StringFormat</span>
 
 String format types for string properties in elicitation schemas.
@@ -7823,6 +8101,14 @@ String format types for string properties in elicitation schemas.
 
 <ResponseField name="date-time" type="string">
   Date-time format (ISO 8601).
+</ResponseField>
+
+<ResponseField name="other" type="string">
+Custom or future string format.
+
+Unknown formats are preserved. Implementations that do not understand a
+format should treat it as an annotation rather than rejecting the schema.
+
 </ResponseField>
 
 ## <span class="font-mono">StringPropertySchema</span>
@@ -8159,6 +8445,31 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
+<ResponseField name="unknown" type="object">
+Custom or future tool call content.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+Receivers that do not understand this content type should preserve the
+raw payload when storing, replaying, proxying, or forwarding tool call
+output, and otherwise ignore it or display it generically.
+
+<Expandable title="Properties">
+
+<ResponseField name="type" type={"string"} required>
+  Custom or future tool call content type.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
+</ResponseField>
+
+</Expandable>
+</ResponseField>
+
 ## <span class="font-mono">ToolCallId</span>
 
 Unique identifier for a tool call within a session.
@@ -8221,6 +8532,15 @@ See protocol docs: [Status](https://agentclientprotocol.com/protocol/tool-calls#
 
 <ResponseField name="failed" type="string">
   The tool call failed with an error.
+</ResponseField>
+
+<ResponseField name="other" type="string">
+Custom or future tool call status.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
 </ResponseField>
 
 ## <span class="font-mono">ToolCallUpdate</span>
@@ -8318,6 +8638,15 @@ See protocol docs: [Creating](https://agentclientprotocol.com/protocol/tool-call
 
 <ResponseField name="other" type="string">
   Other tool types (default).
+</ResponseField>
+
+<ResponseField name="unknown" type="string">
+Custom or future tool kind.
+
+Values beginning with `_` are reserved for implementation-specific
+extensions. Unknown values that do not begin with `_` are reserved for
+future ACP variants.
+
 </ResponseField>
 
 ## <span class="font-mono">UnstructuredCommandInput</span>

--- a/docs/protocol/draft/schema-v2.mdx
+++ b/docs/protocol/draft/schema-v2.mdx
@@ -3063,7 +3063,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="unknown" type="object">
+<ResponseField name="other" type="object">
 Custom or future authentication method.
 
 Values beginning with `_` are reserved for implementation-specific
@@ -3289,7 +3289,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="unknown" type="object">
+<ResponseField name="other" type="object">
 Custom or future command input specification.
 
 Values beginning with `_` are reserved for implementation-specific
@@ -3694,7 +3694,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="unknown" type="object">
+<ResponseField name="other" type="object">
 Custom or future content block.
 
 Values beginning with `_` are reserved for implementation-specific
@@ -6024,7 +6024,7 @@ A search-and-replace suggestion.
 </Expandable>
 </ResponseField>
 
-<ResponseField name="unknown" type="object">
+<ResponseField name="other" type="object">
 Custom or future NES suggestion.
 
 Values beginning with `_` are reserved for implementation-specific
@@ -6605,7 +6605,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="unknown" type="object">
+<ResponseField name="other" type="object">
 Custom or future plan update content.
 
 Values beginning with `_` are reserved for implementation-specific
@@ -7189,7 +7189,7 @@ Boolean on/off toggle.
 </Expandable>
 </ResponseField>
 
-<ResponseField name="unknown" type="object">
+<ResponseField name="other" type="object">
 Custom or future session configuration option payload.
 
 Values beginning with `_` are reserved for implementation-specific
@@ -8010,7 +8010,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="unknown" type="object">
+<ResponseField name="other" type="object">
 Custom or future session update.
 
 Values beginning with `_` are reserved for implementation-specific
@@ -8445,7 +8445,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </Expandable>
 </ResponseField>
 
-<ResponseField name="unknown" type="object">
+<ResponseField name="other" type="object">
 Custom or future tool call content.
 
 Values beginning with `_` are reserved for implementation-specific

--- a/docs/rfds/updates.mdx
+++ b/docs/rfds/updates.mdx
@@ -7,6 +7,10 @@ rss: true
 This page tracks lifecycle changes for ACP Requests for Dialog. For broader ACP announcements, see [Updates](/updates).
 
 <Update label="May 27, 2026" tags={["Draft"]}>
+## v2 Enum Variant Extension RFD moves to Draft stage
+
+The RFD for reserving `_`-prefixed enum variants for extensions while preserving non-underscore variants for future ACP versions has been moved to Draft stage. Please review the [RFD](/rfds/v2/enum-variant-extension) for more information on the current proposal and provide feedback as work on v2 continues.
+
 ## Plan Operations Support RFD moves to Draft stage
 
 The RFD for adding `plan_update` and `plan_removed` session update types has been moved to Draft stage. Please review the [RFD](/rfds/plan-operations) for more information on the current proposal and provide feedback as work on the implementation begins.

--- a/docs/rfds/v2/enum-variant-extension.mdx
+++ b/docs/rfds/v2/enum-variant-extension.mdx
@@ -65,7 +65,6 @@ The v2 Rust schema types should encode this convention directly where fallback b
 - Core control-flow discriminators may remain closed when there is no safe fallback behavior.
 - SDKs should expose fallback variants that carry unknown values rather than silently discarding them.
 - Conversion from v2 to v1 should fail when an unknown v2 value cannot be represented in v1 without data loss.
-- v2-to-v1 conversion errors for unknown v2 variants should be structured so compatibility bridges can explicitly decide to drop unsupported informational notifications while continuing to fail requests, responses, and required fields that cannot be represented correctly.
 - v1 schemas remain unchanged.
 
 The fallback variant's Rust doc comment should document the `_` extension rule and the future-ACP reservation rule, so generated docs and schemas follow the type source of truth.

--- a/docs/rfds/v2/enum-variant-extension.mdx
+++ b/docs/rfds/v2/enum-variant-extension.mdx
@@ -1,0 +1,97 @@
+---
+title: "v2 Enum Variant Extension"
+---
+
+Author(s): [@benbrandt](https://github.com/benbrandt)
+
+## Elevator pitch
+
+> What are you proposing to change?
+
+ACP v2 should make enum-like protocol values forward-compatible when a receiver has a safe fallback. Values beginning with `_` are reserved for implementation-specific extensions. Values that do not begin with `_` are reserved for ACP itself, including future ACP variants.
+
+This gives extensions a dedicated namespace without making older clients and agents reject additive informational protocol changes.
+
+## Status quo
+
+> How do things work today and what problems does this cause? Why would we change things?
+
+ACP already uses `_` as the extension namespace for custom methods and session config categories. Session config categories also preserve unknown category strings, so older clients can handle newer categories gracefully.
+
+Most other string enum protocol fields are closed in the generated schema. Examples include roles, status values, stop reasons, and permission option kinds. SDKs and validators generated from those schemas can reject a message only because a newer ACP version added a variant the older implementation does not understand.
+
+That strictness is useful when the value controls whether a request can be fulfilled correctly. It is unnecessarily disruptive for notifications, display metadata, and other informational fields. A client can often ignore, preserve, forward, or display a generic fallback for an unknown session update, tool status, plan entry status, or UI hint.
+
+Without a shared namespace rule, extension authors also have no safe place to experiment with custom values without risking collisions with future ACP variants.
+
+## What we propose to do about it
+
+> What are you proposing to improve the situation?
+
+ACP v2 should define one enum extension rule for ACP-owned values when the receiving side has an acceptable fallback:
+
+- Values beginning with `_` are reserved for implementation-specific extensions.
+- Values that do not begin with `_` are reserved for ACP.
+- Future ACP versions may add non-underscore values without treating that as an extension collision.
+- Extensions MUST NOT define custom non-underscore values.
+- Implementations MUST NOT treat an unknown non-underscore value as a custom extension.
+- Implementations SHOULD preserve unknown values when storing, replaying, proxying, or forwarding protocol data.
+- Implementations that cannot act on an unknown value SHOULD degrade gracefully according to the field's semantics.
+
+This applies to ACP-owned enum-like values where fallback behavior is acceptable. It does not apply to JSON-RPC fixed constants such as `"2.0"`, numeric code spaces such as JSON-RPC error codes, user-supplied elicitation option values such as `enum` or `oneOf` constants, or discriminators that are core to fulfilling a request. Elicitation schema annotations such as string `format` values can still be open because an implementation can safely treat an unknown format as an annotation.
+
+Tagged unions use string discriminator fields too. When ACP v2 opens one of these unions, it must preserve both the discriminator and the unknown object payload. The same `_` namespace rule applies. Raw fallbacks are appropriate for notification-style and display-data payloads that can be stored, replayed, proxied, forwarded, ignored, or rendered with a generic UI. Tagged unions that are core to request handling, such as elicitation actions, permission outcomes, schema-shape discriminators, and transport selectors, may remain closed and produce a deserialization error for unknown variants.
+
+## Shiny future
+
+> How will things play out once this feature exists?
+
+Adding a new ACP variant for an informational or notification-like field will not automatically make older v2 validators reject otherwise well-formed messages. Older implementations can preserve and forward data they do not understand, or fall back to generic display behavior when that is enough.
+
+Extensions get a clear rule: use `_vendor_or_feature`-style values for custom variants, and leave every non-underscore spelling available for ACP.
+
+Capabilities are still available when a sender needs to know whether the receiver can act on a value. This proposal makes the wire format tolerant first; capabilities can still gate behavior when behavior matters.
+
+## Implementation details and plan
+
+> Tell me more about your implementation. What is your detailed implementation plan?
+
+The v2 Rust schema types should encode this convention directly where fallback behavior is safe:
+
+- String enum definitions list known values explicitly and include a fallback variant that captures the unknown string.
+- Notification-style and display-data tagged unions can add a raw fallback variant that captures the discriminator string and unknown payload object.
+- Raw tagged-union fallbacks must not hide malformed known variants. If a known discriminator is present but its payload is invalid, deserialization must still fail.
+- Untagged shape unions can add raw fallbacks only when there is a reliable discriminator field to distinguish a future/custom variant from a malformed known shape.
+- Core control-flow discriminators may remain closed when there is no safe fallback behavior.
+- SDKs should expose fallback variants that carry unknown values rather than silently discarding them.
+- Conversion from v2 to v1 should fail when an unknown v2 value cannot be represented in v1 without data loss.
+- v2-to-v1 conversion errors for unknown v2 variants should be structured so compatibility bridges can explicitly decide to drop unsupported informational notifications while continuing to fail requests, responses, and required fields that cannot be represented correctly.
+- v1 schemas remain unchanged.
+
+The fallback variant's Rust doc comment should document the `_` extension rule and the future-ACP reservation rule, so generated docs and schemas follow the type source of truth.
+
+This proposal does not require identical runtime behavior for every unknown value. Some fields can be ignored, some can be displayed generically, some can be preserved only for replay or proxying, and some should still fail because the receiver cannot safely continue. The cross-cutting rule is that `_` means extension-owned, non-underscore means ACP-owned, and parsers and validators should not fail solely because a value is unknown when that field has a defined fallback path.
+
+## Frequently asked questions
+
+> What questions have arisen over the course of authoring this document or during subsequent discussions?
+
+### Why not reserve all unknown values for custom extensions?
+
+That would block ACP from adding future standard variants without risking collisions with implementations that already claimed those names. Reserving non-underscore values for ACP gives the protocol room to grow while still giving extensions a predictable namespace.
+
+### Does this make every enum extensible?
+
+No. This proposal opens values only when the receiver has a safe fallback. If understanding the variant is required for correctness, the enum should remain closed or be gated by capability negotiation.
+
+### Why not use capabilities for every new variant?
+
+Capabilities are still useful when a sender needs to know whether the receiver can act on a variant. They do not solve parsing, validation, storage, replay, or proxying problems. The enum extension rule makes the wire format tolerant first; capabilities can still gate behavior when needed.
+
+### Does this mean implementations must understand every unknown variant?
+
+No. Implementations should preserve unknown values when practical and degrade gracefully according to the field's semantics. This proposal is about forward compatibility and namespace ownership, not requiring old software to implement future behavior.
+
+## Revision history
+
+2026-05-27: Initial draft

--- a/docs/rfds/v2/overview.mdx
+++ b/docs/rfds/v2/overview.mdx
@@ -29,6 +29,7 @@ We have had a fairly successful time adding new features via new capabilities an
 Current RFDs accepted as Drafts that are targeting v2 release
 
 - [New Prompt Lifecycle](./prompt.md)
+- [Enum Variant Extension](./enum-variant-extension.mdx)
 - [Message IDs](../message-id.md)
   - [Fork from specified IDs](../session-fork.mds)
 - [Remote Transports](../streamable-http-websocket-transport.mdx)
@@ -40,16 +41,16 @@ Other RFDs will progress separately and are not dependent on breaking changes (s
 Changes under consideration that still need to be drafted or moved to draft:
 
 - Capabilities: clean up naming and organization, as well as make some more capabilities required.
-- Enum variant extension: Same as session config categories: \_ for extension, preserve non-underscore for future variants
 - Streaming/Non-streaming consistency: Offer both options for both messages and tool calls
   - Also Terminal Output type for streaming terminal output from an agent
-  - Expand diff types
+  - Expand diff types (delete, move)
 - JSON-RPC Batch messages: clearer guidance on how SDK support should work for these
 - Truncate/Edit support
 - session/new changes:
   - Providing starting message history
   - Response can provide available commands
   - Potentially config options
+    - Get config options outside of a session (take a cwd?)
 - Remove session modes and (unstable) session models. These are replaces by session config options
 - [Plan variants](/rfds/plan-operations): Make this RFD the default and remove the old plan update
 - Subagent support

--- a/schema/schema.v2.unstable.json
+++ b/schema/schema.v2.unstable.json
@@ -682,6 +682,70 @@
           "type": "object"
         },
         {
+          "additionalProperties": true,
+          "description": "Custom or future authentication method.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nClients that do not understand this method type should preserve the raw\npayload when storing, replaying, proxying, or forwarding initialization\ndata, and otherwise ignore the method or display it generically.",
+          "not": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": {
+                    "const": "agent",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "env_var",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "terminal",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              }
+            ]
+          },
+          "properties": {
+            "_meta": {
+              "additionalProperties": true,
+              "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+              "type": ["object", "null"]
+            },
+            "description": {
+              "description": "Optional description providing more details about this authentication method.",
+              "type": ["string", "null"]
+            },
+            "id": {
+              "description": "Unique identifier for this authentication method.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Human-readable name of the authentication method.",
+              "type": "string"
+            },
+            "type": {
+              "description": "Custom or future authentication method type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["type", "id", "name"],
+          "title": "unknown",
+          "type": "object"
+        },
+        {
           "allOf": [
             {
               "$ref": "#/$defs/AuthMethodAgent"
@@ -695,6 +759,17 @@
     },
     "AuthMethodAgent": {
       "description": "Agent handles authentication itself.\n\nThis is the default authentication method type.",
+      "not": {
+        "properties": {
+          "type": {
+            "not": {
+              "const": "agent"
+            }
+          }
+        },
+        "required": ["type"],
+        "type": "object"
+      },
       "properties": {
         "_meta": {
           "additionalProperties": true,
@@ -862,6 +937,19 @@
           ],
           "description": "All text that was typed after the command name is provided as input.",
           "title": "unstructured"
+        },
+        {
+          "additionalProperties": true,
+          "description": "Custom or future command input specification.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nClients that do not understand this input type should preserve the raw\npayload when storing, replaying, proxying, or forwarding command\nmetadata, and otherwise ignore the input specification or display the\ncommand without structured input.",
+          "properties": {
+            "type": {
+              "description": "Custom or future command input type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["type"],
+          "title": "unknown",
+          "type": "object"
         }
       ],
       "description": "The input specification for a command."
@@ -1739,11 +1827,7 @@
       "type": "object"
     },
     "ContentBlock": {
-      "description": "Content blocks represent displayable information in the Agent Client Protocol.\n\nThey provide a structured way to handle various types of user-facing content—whether\nit's text from language models, images for analysis, or embedded resources for context.\n\nContent blocks appear in:\n- User prompts sent via `session/prompt`\n- Language model output streamed through `session/update` notifications\n- Progress updates and results from tool calls\n\nThis structure is compatible with the Model Context Protocol (MCP), enabling\nagents to seamlessly forward content from MCP tool outputs without transformation.\n\nSee protocol docs: [Content](https://agentclientprotocol.com/protocol/content)",
-      "discriminator": {
-        "propertyName": "type"
-      },
-      "oneOf": [
+      "anyOf": [
         {
           "allOf": [
             {
@@ -1823,8 +1907,79 @@
           },
           "required": ["type"],
           "type": "object"
+        },
+        {
+          "additionalProperties": true,
+          "description": "Custom or future content block.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nReceivers that do not understand this content block type should preserve\nthe raw payload when storing, replaying, proxying, or forwarding content,\nand otherwise ignore it or display it generically.",
+          "not": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": {
+                    "const": "text",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "image",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "audio",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "resource_link",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "resource",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              }
+            ]
+          },
+          "properties": {
+            "type": {
+              "description": "Custom or future content block type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["type"],
+          "title": "unknown",
+          "type": "object"
         }
-      ]
+      ],
+      "description": "Content blocks represent displayable information in the Agent Client Protocol.\n\nThey provide a structured way to handle various types of user-facing content—whether\nit's text from language models, images for analysis, or embedded resources for context.\n\nContent blocks appear in:\n- User prompts sent via `session/prompt`\n- Language model output streamed through `session/update` notifications\n- Progress updates and results from tool calls\n\nThis structure is compatible with the Model Context Protocol (MCP), enabling\nagents to seamlessly forward content from MCP tool outputs without transformation.\n\nSee protocol docs: [Content](https://agentclientprotocol.com/protocol/content)",
+      "discriminator": {
+        "propertyName": "type"
+      }
     },
     "ContentChunk": {
       "description": "A streamed item of content",
@@ -3393,7 +3548,7 @@
           "type": "string"
         },
         {
-          "description": "Unknown or custom protocol.",
+          "description": "Custom or future protocol.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
           "title": "other",
           "type": "string"
         }
@@ -4033,8 +4188,7 @@
       "type": "object"
     },
     "NesDiagnosticSeverity": {
-      "description": "Severity of a diagnostic.",
-      "oneOf": [
+      "anyOf": [
         {
           "const": "error",
           "description": "An error.",
@@ -4054,8 +4208,14 @@
           "const": "hint",
           "description": "A hint.",
           "type": "string"
+        },
+        {
+          "description": "Custom or future diagnostic severity.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "title": "Other",
+          "type": "string"
         }
-      ]
+      ],
+      "description": "Severity of a diagnostic."
     },
     "NesDiagnosticsCapabilities": {
       "description": "Capabilities for diagnostics context.",
@@ -4422,8 +4582,7 @@
       "type": "object"
     },
     "NesRejectReason": {
-      "description": "The reason a suggestion was rejected.",
-      "oneOf": [
+      "anyOf": [
         {
           "const": "rejected",
           "description": "The user explicitly dismissed the suggestion.",
@@ -4443,8 +4602,14 @@
           "const": "cancelled",
           "description": "The request was cancelled before the agent returned a response.",
           "type": "string"
+        },
+        {
+          "description": "Custom or future rejection reason.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "title": "Other",
+          "type": "string"
         }
-      ]
+      ],
+      "description": "The reason a suggestion was rejected."
     },
     "NesRelatedSnippet": {
       "description": "A related code snippet from a file.",
@@ -4624,11 +4789,7 @@
       "type": "object"
     },
     "NesSuggestion": {
-      "description": "A suggestion returned by the agent.",
-      "discriminator": {
-        "propertyName": "kind"
-      },
-      "oneOf": [
+      "anyOf": [
         {
           "allOf": [
             {
@@ -4692,8 +4853,69 @@
           },
           "required": ["kind"],
           "type": "object"
+        },
+        {
+          "additionalProperties": true,
+          "description": "Custom or future NES suggestion.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nReceivers that do not understand this suggestion kind should preserve\nthe raw payload when storing, replaying, proxying, or forwarding\nsuggestions, and otherwise ignore it or display it generically.",
+          "not": {
+            "anyOf": [
+              {
+                "properties": {
+                  "kind": {
+                    "const": "edit",
+                    "type": "string"
+                  }
+                },
+                "required": ["kind"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "const": "jump",
+                    "type": "string"
+                  }
+                },
+                "required": ["kind"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "const": "rename",
+                    "type": "string"
+                  }
+                },
+                "required": ["kind"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "const": "searchAndReplace",
+                    "type": "string"
+                  }
+                },
+                "required": ["kind"],
+                "type": "object"
+              }
+            ]
+          },
+          "properties": {
+            "kind": {
+              "description": "Custom or future NES suggestion kind.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["kind"],
+          "title": "unknown",
+          "type": "object"
         }
-      ]
+      ],
+      "description": "A suggestion returned by the agent.",
+      "discriminator": {
+        "propertyName": "kind"
+      }
     },
     "NesTextEdit": {
       "description": "A text edit within a suggestion.",
@@ -4715,8 +4937,7 @@
       "type": "object"
     },
     "NesTriggerKind": {
-      "description": "What triggered the suggestion request.",
-      "oneOf": [
+      "anyOf": [
         {
           "const": "automatic",
           "description": "Triggered by user typing or cursor movement.",
@@ -4731,8 +4952,14 @@
           "const": "manual",
           "description": "Triggered by an explicit user action (keyboard shortcut).",
           "type": "string"
+        },
+        {
+          "description": "Custom or future suggestion trigger kind.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "title": "Other",
+          "type": "string"
         }
-      ]
+      ],
+      "description": "What triggered the suggestion request."
     },
     "NesUserAction": {
       "description": "A user action (typing, cursor movement, etc.).",
@@ -4929,8 +5156,7 @@
       "type": "string"
     },
     "PermissionOptionKind": {
-      "description": "The type of permission option being presented to the user.\n\nHelps clients choose appropriate icons and UI treatment.",
-      "oneOf": [
+      "anyOf": [
         {
           "const": "allow_once",
           "description": "Allow this operation only this time.",
@@ -4950,8 +5176,14 @@
           "const": "reject_always",
           "description": "Reject this operation and remember the choice.",
           "type": "string"
+        },
+        {
+          "description": "Custom or future permission option kind.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "title": "other",
+          "type": "string"
         }
-      ]
+      ],
+      "description": "The type of permission option being presented to the user.\n\nHelps clients choose appropriate icons and UI treatment."
     },
     "Plan": {
       "description": "An execution plan for accomplishing complex tasks.\n\nPlans consist of multiple entries representing individual tasks or goals.\nAgents report plans to clients to provide visibility into their execution strategy.\nPlans can evolve during execution as the agent discovers new requirements or completes tasks.\n\nSee protocol docs: [Agent Plan](https://agentclientprotocol.com/protocol/agent-plan)",
@@ -5016,8 +5248,7 @@
       "type": "object"
     },
     "PlanEntryPriority": {
-      "description": "Priority levels for plan entries.\n\nUsed to indicate the relative importance or urgency of different\ntasks in the execution plan.\nSee protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/agent-plan#plan-entries)",
-      "oneOf": [
+      "anyOf": [
         {
           "const": "high",
           "description": "High priority task - critical to the overall goal.",
@@ -5032,12 +5263,17 @@
           "const": "low",
           "description": "Low priority task - nice to have but not essential.",
           "type": "string"
+        },
+        {
+          "description": "Custom or future plan entry priority.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "title": "other",
+          "type": "string"
         }
-      ]
+      ],
+      "description": "Priority levels for plan entries.\n\nUsed to indicate the relative importance or urgency of different\ntasks in the execution plan.\nSee protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/agent-plan#plan-entries)"
     },
     "PlanEntryStatus": {
-      "description": "Status of a plan entry in the execution flow.\n\nTracks the lifecycle of each task from planning through completion.\nSee protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/agent-plan#plan-entries)",
-      "oneOf": [
+      "anyOf": [
         {
           "const": "pending",
           "description": "The task has not started yet.",
@@ -5052,8 +5288,14 @@
           "const": "completed",
           "description": "The task has been successfully completed.",
           "type": "string"
+        },
+        {
+          "description": "Custom or future plan entry status.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "title": "other",
+          "type": "string"
         }
-      ]
+      ],
+      "description": "Status of a plan entry in the execution flow.\n\nTracks the lifecycle of each task from planning through completion.\nSee protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/agent-plan#plan-entries)"
     },
     "PlanFile": {
       "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nA plan represented by a file URI.",
@@ -5175,11 +5417,7 @@
       "type": "object"
     },
     "PlanUpdateContent": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nUpdated content for a plan.",
-      "discriminator": {
-        "propertyName": "type"
-      },
-      "oneOf": [
+      "anyOf": [
         {
           "allOf": [
             {
@@ -5227,8 +5465,59 @@
           },
           "required": ["type"],
           "type": "object"
+        },
+        {
+          "additionalProperties": true,
+          "description": "Custom or future plan update content.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nReceivers that do not understand this content type should preserve the\nraw payload when storing, replaying, proxying, or forwarding plans, and\notherwise ignore it or display it generically.",
+          "not": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": {
+                    "const": "items",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "file",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "markdown",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              }
+            ]
+          },
+          "properties": {
+            "type": {
+              "description": "Custom or future plan update content type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["type"],
+          "title": "unknown",
+          "type": "object"
         }
-      ]
+      ],
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nUpdated content for a plan.",
+      "discriminator": {
+        "propertyName": "type"
+      }
     },
     "Position": {
       "description": "A zero-based position in a text document.\n\nThe meaning of `character` depends on the negotiated position encoding.",
@@ -5830,9 +6119,18 @@
       "x-side": "agent"
     },
     "Role": {
-      "description": "The sender or recipient of messages and data in a conversation.",
-      "enum": ["assistant", "user"],
-      "type": "string"
+      "anyOf": [
+        {
+          "enum": ["assistant", "user"],
+          "type": "string"
+        },
+        {
+          "description": "Custom or future role.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "title": "other",
+          "type": "string"
+        }
+      ],
+      "description": "The sender or recipient of messages and data in a conversation."
     },
     "SelectedPermissionOutcome": {
       "description": "The user selected one of the provided options.",
@@ -5973,11 +6271,7 @@
       "type": "string"
     },
     "SessionConfigOption": {
-      "description": "A session configuration option selector and its current state.",
-      "discriminator": {
-        "propertyName": "type"
-      },
-      "oneOf": [
+      "anyOf": [
         {
           "allOf": [
             {
@@ -6009,8 +6303,49 @@
           },
           "required": ["type"],
           "type": "object"
+        },
+        {
+          "additionalProperties": true,
+          "description": "Custom or future session configuration option payload.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nClients that do not understand this option type should preserve the raw\npayload when storing, replaying, proxying, or forwarding configuration\ndata, and otherwise ignore the option or display it generically.",
+          "not": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": {
+                    "const": "select",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "boolean",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              }
+            ]
+          },
+          "properties": {
+            "type": {
+              "description": "Custom or future session configuration option type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["type"],
+          "title": "unknown",
+          "type": "object"
         }
       ],
+      "description": "A session configuration option selector and its current state.",
+      "discriminator": {
+        "propertyName": "type"
+      },
       "properties": {
         "_meta": {
           "additionalProperties": true,
@@ -6066,7 +6401,7 @@
           "type": "string"
         },
         {
-          "description": "Unknown / uncategorized selector.",
+          "description": "Custom or future category.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
           "title": "other",
           "type": "string"
         }
@@ -6396,11 +6731,7 @@
       "type": "object"
     },
     "SessionUpdate": {
-      "description": "Different types of updates that can be sent during session processing.\n\nThese updates provide real-time feedback about the agent's progress.\n\nSee protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protocol/prompt-turn#3-agent-reports-output)",
-      "discriminator": {
-        "propertyName": "sessionUpdate"
-      },
-      "oneOf": [
+      "anyOf": [
         {
           "allOf": [
             {
@@ -6608,8 +6939,159 @@
           },
           "required": ["sessionUpdate"],
           "type": "object"
+        },
+        {
+          "additionalProperties": true,
+          "description": "Custom or future session update.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nReceivers that do not understand this update type should preserve the\nraw payload when storing, replaying, proxying, or forwarding session\nhistory, and otherwise ignore it or display it generically.",
+          "not": {
+            "anyOf": [
+              {
+                "properties": {
+                  "sessionUpdate": {
+                    "const": "user_message_chunk",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionUpdate"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "sessionUpdate": {
+                    "const": "agent_message_chunk",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionUpdate"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "sessionUpdate": {
+                    "const": "agent_thought_chunk",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionUpdate"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "sessionUpdate": {
+                    "const": "tool_call",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionUpdate"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "sessionUpdate": {
+                    "const": "tool_call_update",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionUpdate"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "sessionUpdate": {
+                    "const": "plan",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionUpdate"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "sessionUpdate": {
+                    "const": "available_commands_update",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionUpdate"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "sessionUpdate": {
+                    "const": "current_mode_update",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionUpdate"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "sessionUpdate": {
+                    "const": "config_option_update",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionUpdate"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "sessionUpdate": {
+                    "const": "session_info_update",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionUpdate"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "sessionUpdate": {
+                    "const": "plan_update",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionUpdate"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "sessionUpdate": {
+                    "const": "plan_removed",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionUpdate"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "sessionUpdate": {
+                    "const": "usage_update",
+                    "type": "string"
+                  }
+                },
+                "required": ["sessionUpdate"],
+                "type": "object"
+              }
+            ]
+          },
+          "properties": {
+            "sessionUpdate": {
+              "description": "Custom or future session update type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "title": "unknown",
+          "type": "object"
         }
-      ]
+      ],
+      "description": "Different types of updates that can be sent during session processing.\n\nThese updates provide real-time feedback about the agent's progress.\n\nSee protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protocol/prompt-turn#3-agent-reports-output)",
+      "discriminator": {
+        "propertyName": "sessionUpdate"
+      }
     },
     "SetProviderRequest": {
       "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest parameters for `providers/set`.\n\nReplaces the full configuration for one provider id.",
@@ -6889,8 +7371,7 @@
       "x-side": "agent"
     },
     "StopReason": {
-      "description": "Reasons why an agent stops processing a prompt turn.\n\nSee protocol docs: [Stop Reasons](https://agentclientprotocol.com/protocol/prompt-turn#stop-reasons)",
-      "oneOf": [
+      "anyOf": [
         {
           "const": "end_turn",
           "description": "The turn ended successfully.",
@@ -6915,12 +7396,17 @@
           "const": "cancelled",
           "description": "The turn was cancelled by the client via `session/cancel`.\n\nThis stop reason MUST be returned when the client sends a `session/cancel`\nnotification, even if the cancellation causes exceptions in underlying operations.\nAgents should catch these exceptions and return this semantically meaningful\nresponse to confirm successful cancellation.",
           "type": "string"
+        },
+        {
+          "description": "Custom or future stop reason.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "title": "other",
+          "type": "string"
         }
-      ]
+      ],
+      "description": "Reasons why an agent stops processing a prompt turn.\n\nSee protocol docs: [Stop Reasons](https://agentclientprotocol.com/protocol/prompt-turn#stop-reasons)"
     },
     "StringFormat": {
-      "description": "String format types for string properties in elicitation schemas.",
-      "oneOf": [
+      "anyOf": [
         {
           "const": "email",
           "description": "Email address format.",
@@ -6940,8 +7426,14 @@
           "const": "date-time",
           "description": "Date-time format (ISO 8601).",
           "type": "string"
+        },
+        {
+          "description": "Custom or future string format.\n\nUnknown formats are preserved. Implementations that do not understand a\nformat should treat it as an annotation rather than rejecting the schema.",
+          "title": "other",
+          "type": "string"
         }
-      ]
+      ],
+      "description": "String format types for string properties in elicitation schemas."
     },
     "StringPropertySchema": {
       "description": "Schema for string properties in an elicitation form.\n\nWhen `enum` or `oneOf` is set, this represents a single-select enum\nwith `\"type\": \"string\"`.",
@@ -7345,11 +7837,7 @@
       "type": "object"
     },
     "ToolCallContent": {
-      "description": "Content produced by a tool call.\n\nTool calls can produce different types of content including\nstandard content blocks (text, images) or file diffs.\n\nSee protocol docs: [Content](https://agentclientprotocol.com/protocol/tool-calls#content)",
-      "discriminator": {
-        "propertyName": "type"
-      },
-      "oneOf": [
+      "anyOf": [
         {
           "allOf": [
             {
@@ -7397,8 +7885,59 @@
           },
           "required": ["type"],
           "type": "object"
+        },
+        {
+          "additionalProperties": true,
+          "description": "Custom or future tool call content.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nReceivers that do not understand this content type should preserve the\nraw payload when storing, replaying, proxying, or forwarding tool call\noutput, and otherwise ignore it or display it generically.",
+          "not": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": {
+                    "const": "content",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "diff",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "terminal",
+                    "type": "string"
+                  }
+                },
+                "required": ["type"],
+                "type": "object"
+              }
+            ]
+          },
+          "properties": {
+            "type": {
+              "description": "Custom or future tool call content type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["type"],
+          "title": "unknown",
+          "type": "object"
         }
-      ]
+      ],
+      "description": "Content produced by a tool call.\n\nTool calls can produce different types of content including\nstandard content blocks (text, images) or file diffs.\n\nSee protocol docs: [Content](https://agentclientprotocol.com/protocol/tool-calls#content)",
+      "discriminator": {
+        "propertyName": "type"
+      }
     },
     "ToolCallId": {
       "description": "Unique identifier for a tool call within a session.",
@@ -7427,8 +7966,7 @@
       "type": "object"
     },
     "ToolCallStatus": {
-      "description": "Execution status of a tool call.\n\nTool calls progress through different statuses during their lifecycle.\n\nSee protocol docs: [Status](https://agentclientprotocol.com/protocol/tool-calls#status)",
-      "oneOf": [
+      "anyOf": [
         {
           "const": "pending",
           "description": "The tool call hasn't started running yet because the input is either\nstreaming or we're awaiting approval.",
@@ -7448,8 +7986,14 @@
           "const": "failed",
           "description": "The tool call failed with an error.",
           "type": "string"
+        },
+        {
+          "description": "Custom or future tool call status.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "title": "other",
+          "type": "string"
         }
-      ]
+      ],
+      "description": "Execution status of a tool call.\n\nTool calls progress through different statuses during their lifecycle.\n\nSee protocol docs: [Status](https://agentclientprotocol.com/protocol/tool-calls#status)"
     },
     "ToolCallUpdate": {
       "description": "An update to an existing tool call.\n\nUsed to report progress and results as tools execute. All fields except\nthe tool call ID are optional - only changed fields need to be included.\n\nSee protocol docs: [Updating](https://agentclientprotocol.com/protocol/tool-calls#updating)",
@@ -7518,8 +8062,7 @@
       "type": "object"
     },
     "ToolKind": {
-      "description": "Categories of tools that can be invoked.\n\nTool kinds help clients choose appropriate icons and optimize how they\ndisplay tool execution progress.\n\nSee protocol docs: [Creating](https://agentclientprotocol.com/protocol/tool-calls#creating)",
-      "oneOf": [
+      "anyOf": [
         {
           "const": "read",
           "description": "Reading files or data.",
@@ -7569,11 +8112,21 @@
           "const": "other",
           "description": "Other tool types (default).",
           "type": "string"
+        },
+        {
+          "description": "Custom or future tool kind.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "title": "unknown",
+          "type": "string"
         }
-      ]
+      ],
+      "description": "Categories of tools that can be invoked.\n\nTool kinds help clients choose appropriate icons and optimize how they\ndisplay tool execution progress.\n\nSee protocol docs: [Creating](https://agentclientprotocol.com/protocol/tool-calls#creating)"
     },
     "UnstructuredCommandInput": {
       "description": "All text that was typed after the command name is provided as input.",
+      "not": {
+        "required": ["type"],
+        "type": "object"
+      },
       "properties": {
         "_meta": {
           "additionalProperties": true,

--- a/schema/schema.v2.unstable.json
+++ b/schema/schema.v2.unstable.json
@@ -742,7 +742,7 @@
             }
           },
           "required": ["type", "id", "name"],
-          "title": "unknown",
+          "title": "other",
           "type": "object"
         },
         {
@@ -948,7 +948,7 @@
             }
           },
           "required": ["type"],
-          "title": "unknown",
+          "title": "other",
           "type": "object"
         }
       ],
@@ -1972,7 +1972,7 @@
             }
           },
           "required": ["type"],
-          "title": "unknown",
+          "title": "other",
           "type": "object"
         }
       ],
@@ -4908,7 +4908,7 @@
             }
           },
           "required": ["kind"],
-          "title": "unknown",
+          "title": "other",
           "type": "object"
         }
       ],
@@ -5510,7 +5510,7 @@
             }
           },
           "required": ["type"],
-          "title": "unknown",
+          "title": "other",
           "type": "object"
         }
       ],
@@ -6338,7 +6338,7 @@
             }
           },
           "required": ["type"],
-          "title": "unknown",
+          "title": "other",
           "type": "object"
         }
       ],
@@ -7084,7 +7084,7 @@
             }
           },
           "required": ["sessionUpdate"],
-          "title": "unknown",
+          "title": "other",
           "type": "object"
         }
       ],
@@ -7930,7 +7930,7 @@
             }
           },
           "required": ["type"],
-          "title": "unknown",
+          "title": "other",
           "type": "object"
         }
       ],

--- a/src/bin/generate.rs
+++ b/src/bin/generate.rs
@@ -502,12 +502,16 @@ starting with '$/' it is free to ignore the notification."
 
         #[expect(clippy::too_many_lines)]
         fn document_variant_table_row(&mut self, variant: &Value) {
+            let enum_values = variant.get("enum").and_then(|v| v.as_array());
+
             write!(&mut self.output, "<ResponseField name=\"").unwrap();
 
             // Get variant name
             if let Some(ref_val) = variant.get("$ref").and_then(|v| v.as_str()) {
                 let type_name = ref_val.strip_prefix("#/$defs/").unwrap_or(ref_val);
                 write!(&mut self.output, "{type_name}").unwrap();
+            } else if let Some(enum_values) = enum_values {
+                write!(&mut self.output, "{}", Self::enum_values_label(enum_values)).unwrap();
             } else if let Some(const_val) = variant.get("const") {
                 if let Some(s) = const_val.as_str() {
                     write!(&mut self.output, "{s}").unwrap();
@@ -546,7 +550,9 @@ starting with '$/' it is free to ignore the notification."
                 write!(&mut self.output, "Variant").unwrap();
             }
 
-            if let Some(format) = variant.get("format") {
+            if enum_values.is_some() {
+                write!(&mut self.output, "\" type=\"enum").unwrap();
+            } else if let Some(format) = variant.get("format") {
                 if let Some(s) = format.as_str() {
                     write!(&mut self.output, "\" type=\"{s}").unwrap();
                 } else {
@@ -565,7 +571,19 @@ starting with '$/' it is free to ignore the notification."
             // Get description
             if let Some(desc) = Self::get_def_description(variant) {
                 writeln!(&mut self.output, "{desc}").unwrap();
-            } else {
+            }
+
+            if let Some(enum_values) = enum_values {
+                if Self::get_def_description(variant).is_some() {
+                    writeln!(&mut self.output).unwrap();
+                }
+                writeln!(
+                    &mut self.output,
+                    "**Values:** {}",
+                    Self::format_enum_values(enum_values)
+                )
+                .unwrap();
+            } else if Self::get_def_description(variant).is_none() {
                 writeln!(&mut self.output, "{{\"\"}}").unwrap();
             }
 
@@ -655,6 +673,32 @@ starting with '$/' it is free to ignore the notification."
                 }
                 writeln!(&mut self.output).unwrap();
             }
+        }
+
+        fn enum_values_label(values: &[Value]) -> String {
+            values
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .map_or_else(|| value.to_string(), str::to_string)
+                })
+                .collect::<Vec<_>>()
+                .join(" | ")
+        }
+
+        fn format_enum_values(values: &[Value]) -> String {
+            values
+                .iter()
+                .map(|value| {
+                    if let Some(value) = value.as_str() {
+                        format!("`\"{}\"`", Self::escape_mdx(value))
+                    } else {
+                        format!("`{value}`")
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
         }
 
         fn document_object(&mut self, definition: &Value) {
@@ -1506,6 +1550,39 @@ starting with '$/' it is free to ignore the notification."
             let form_pos = generator.output.find("\"form\"").unwrap();
             assert!(variants_pos < session_pos);
             assert!(session_pos < form_pos);
+        }
+
+        #[test]
+        fn document_union_renders_enum_variant_values() {
+            let mut generator = MarkdownGenerator::new();
+            let definition = json!({
+                "description": "The sender or recipient.",
+                "anyOf": [
+                    {
+                        "enum": ["assistant", "user"],
+                        "type": "string"
+                    },
+                    {
+                        "description": "Custom or future role.",
+                        "title": "other",
+                        "type": "string"
+                    }
+                ]
+            });
+
+            generator.document_type(4, "Role", &definition);
+
+            assert!(
+                generator
+                    .output
+                    .contains("<ResponseField name=\"assistant | user\" type=\"enum\">")
+            );
+            assert!(
+                generator
+                    .output
+                    .contains("**Values:** `\"assistant\"`, `\"user\"`")
+            );
+            assert!(!generator.output.contains("<ResponseField name=\"string\""));
         }
     }
 }

--- a/src/v2/agent.rs
+++ b/src/v2/agent.rs
@@ -3,20 +3,20 @@
 //! This module defines the Agent trait and all associated types for implementing
 //! an AI coding agent that follows the Agent Client Protocol (ACP).
 
-use std::{path::PathBuf, sync::Arc};
+use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 
 #[cfg(any(feature = "unstable_auth_methods", feature = "unstable_llm_providers"))]
 use std::collections::HashMap;
 
 use derive_more::{Display, From};
-use schemars::JsonSchema;
+use schemars::{JsonSchema, Schema};
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnError, VecSkipError, serde_as, skip_serializing_none};
 
 use super::{
     ClientCapabilities, ContentBlock, ExtNotification, ExtRequest, ExtResponse, Meta, SessionId,
 };
-use crate::{IntoOption, ProtocolVersion, SkipListener};
+use crate::{IntoOption, MaybeUndefined, ProtocolVersion, SkipListener};
 
 #[cfg(feature = "unstable_mcp_over_acp")]
 use super::mcp::{
@@ -521,6 +521,17 @@ pub enum AuthMethod {
     /// Client runs an interactive terminal for the user to authenticate via a TUI.
     #[cfg(feature = "unstable_auth_methods")]
     Terminal(AuthMethodTerminal),
+    /// Custom or future authentication method.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    ///
+    /// Clients that do not understand this method type should preserve the raw
+    /// payload when storing, replaying, proxying, or forwarding initialization
+    /// data, and otherwise ignore the method or display it generically.
+    #[serde(untagged)]
+    Unknown(UnknownAuthMethod),
     /// Agent handles authentication itself.
     ///
     /// This is the default when no `type` is specified.
@@ -534,6 +545,7 @@ impl AuthMethod {
     pub fn id(&self) -> &AuthMethodId {
         match self {
             Self::Agent(a) => &a.id,
+            Self::Unknown(a) => &a.id,
             #[cfg(feature = "unstable_auth_methods")]
             Self::EnvVar(e) => &e.id,
             #[cfg(feature = "unstable_auth_methods")]
@@ -546,6 +558,7 @@ impl AuthMethod {
     pub fn name(&self) -> &str {
         match self {
             Self::Agent(a) => &a.name,
+            Self::Unknown(a) => &a.name,
             #[cfg(feature = "unstable_auth_methods")]
             Self::EnvVar(e) => &e.name,
             #[cfg(feature = "unstable_auth_methods")]
@@ -558,6 +571,7 @@ impl AuthMethod {
     pub fn description(&self) -> Option<&str> {
         match self {
             Self::Agent(a) => a.description.as_deref(),
+            Self::Unknown(a) => a.description.as_deref(),
             #[cfg(feature = "unstable_auth_methods")]
             Self::EnvVar(e) => e.description.as_deref(),
             #[cfg(feature = "unstable_auth_methods")]
@@ -574,6 +588,7 @@ impl AuthMethod {
     pub fn meta(&self) -> Option<&Meta> {
         match self {
             Self::Agent(a) => a.meta.as_ref(),
+            Self::Unknown(a) => a.meta.as_ref(),
             #[cfg(feature = "unstable_auth_methods")]
             Self::EnvVar(e) => e.meta.as_ref(),
             #[cfg(feature = "unstable_auth_methods")]
@@ -582,11 +597,148 @@ impl AuthMethod {
     }
 }
 
+/// Custom or future authentication method payload.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[schemars(inline)]
+#[schemars(transform = unknown_auth_method_schema)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct UnknownAuthMethod {
+    /// Custom or future authentication method type.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// Unique identifier for this authentication method.
+    pub id: AuthMethodId,
+    /// Human-readable name of the authentication method.
+    pub name: String,
+    /// Optional description providing more details about this authentication method.
+    pub description: Option<String>,
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+    /// Additional fields from the unknown authentication method payload.
+    #[serde(flatten)]
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl UnknownAuthMethod {
+    #[must_use]
+    pub fn new(
+        type_: impl Into<String>,
+        id: impl Into<AuthMethodId>,
+        name: impl Into<String>,
+        mut fields: BTreeMap<String, serde_json::Value>,
+    ) -> Self {
+        fields.remove("type");
+        fields.remove("id");
+        fields.remove("name");
+        fields.remove("description");
+        fields.remove("_meta");
+        Self {
+            type_: type_.into(),
+            id: id.into(),
+            name: name.into(),
+            description: None,
+            meta: None,
+            fields,
+        }
+    }
+
+    /// Optional description providing more details about this authentication method.
+    #[must_use]
+    pub fn description(mut self, description: impl IntoOption<String>) -> Self {
+        self.description = description.into_option();
+        self
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+impl<'de> Deserialize<'de> for UnknownAuthMethod {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct RawUnknownAuthMethod {
+            #[serde(rename = "type")]
+            type_: String,
+            id: AuthMethodId,
+            name: String,
+            description: Option<String>,
+            #[serde(rename = "_meta")]
+            meta: Option<Meta>,
+            #[serde(flatten)]
+            fields: BTreeMap<String, serde_json::Value>,
+        }
+
+        let raw = RawUnknownAuthMethod::deserialize(deserializer)?;
+        if is_known_auth_method_type(&raw.type_) {
+            return Err(serde::de::Error::custom(format!(
+                "known authentication method `{}` did not match its schema",
+                raw.type_
+            )));
+        }
+
+        Ok(Self {
+            type_: raw.type_,
+            id: raw.id,
+            name: raw.name,
+            description: raw.description,
+            meta: raw.meta,
+            fields: raw.fields,
+        })
+    }
+}
+
+fn is_known_auth_method_type(type_: &str) -> bool {
+    match type_ {
+        "agent" => true,
+        #[cfg(feature = "unstable_auth_methods")]
+        "env_var" | "terminal" => true,
+        _ => false,
+    }
+}
+
+fn unknown_auth_method_schema(schema: &mut Schema) {
+    super::schema_util::reject_known_string_discriminators(
+        schema,
+        "type",
+        &[
+            "agent",
+            #[cfg(feature = "unstable_auth_methods")]
+            "env_var",
+            #[cfg(feature = "unstable_auth_methods")]
+            "terminal",
+        ],
+    );
+}
+
 /// Agent handles authentication itself.
 ///
 /// This is the default authentication method type.
 #[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[schemars(transform = auth_method_agent_schema)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AuthMethodAgent {
@@ -633,6 +785,52 @@ impl AuthMethodAgent {
         self.meta = meta.into_option();
         self
     }
+}
+
+impl<'de> Deserialize<'de> for AuthMethodAgent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct RawAuthMethodAgent {
+            id: AuthMethodId,
+            name: String,
+            description: Option<String>,
+            #[serde(rename = "_meta")]
+            meta: Option<Meta>,
+            #[serde(rename = "type")]
+            #[serde(default)]
+            type_: MaybeUndefined<String>,
+        }
+
+        let raw = RawAuthMethodAgent::deserialize(deserializer)?;
+        match raw.type_.as_opt_deref() {
+            None | Some(Some("agent")) => {}
+            Some(None) => {
+                return Err(serde::de::Error::custom(
+                    "default authentication method `type` must be omitted or `agent`",
+                ));
+            }
+            Some(Some(_)) => {
+                return Err(serde::de::Error::custom(
+                    "default authentication method cannot include a non-agent `type`",
+                ));
+            }
+        }
+
+        Ok(Self {
+            id: raw.id,
+            name: raw.name,
+            description: raw.description,
+            meta: raw.meta,
+        })
+    }
+}
+
+fn auth_method_agent_schema(schema: &mut Schema) {
+    super::schema_util::reject_string_property_except(schema, "type", "agent");
 }
 
 /// **UNSTABLE**
@@ -2389,7 +2587,11 @@ pub enum SessionConfigOptionCategory {
     Model,
     /// Thought/reasoning level selector.
     ThoughtLevel,
-    /// Unknown / uncategorized selector.
+    /// Custom or future category.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
     #[serde(untagged)]
     Other(String),
 }
@@ -2409,6 +2611,91 @@ pub enum SessionConfigKind {
     /// Boolean on/off toggle.
     #[cfg(feature = "unstable_boolean_config")]
     Boolean(SessionConfigBoolean),
+    /// Custom or future session configuration option payload.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    ///
+    /// Clients that do not understand this option type should preserve the raw
+    /// payload when storing, replaying, proxying, or forwarding configuration
+    /// data, and otherwise ignore the option or display it generically.
+    #[serde(untagged)]
+    Unknown(UnknownSessionConfigKind),
+}
+
+/// Custom or future session configuration option payload.
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[schemars(inline)]
+#[schemars(transform = unknown_session_config_kind_schema)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct UnknownSessionConfigKind {
+    /// Custom or future session configuration option type.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// Additional fields from the unknown session configuration option payload.
+    #[serde(flatten)]
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl UnknownSessionConfigKind {
+    #[must_use]
+    pub fn new(type_: impl Into<String>, mut fields: BTreeMap<String, serde_json::Value>) -> Self {
+        fields.remove("type");
+        Self {
+            type_: type_.into(),
+            fields,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for UnknownSessionConfigKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut fields = BTreeMap::<String, serde_json::Value>::deserialize(deserializer)?;
+        let type_ = fields
+            .remove("type")
+            .ok_or_else(|| serde::de::Error::missing_field("type"))?;
+        let serde_json::Value::String(type_) = type_ else {
+            return Err(serde::de::Error::custom("`type` must be a string"));
+        };
+
+        if is_known_session_config_kind_type(&type_) {
+            return Err(serde::de::Error::custom(format!(
+                "known session configuration option `{type_}` did not match its schema"
+            )));
+        }
+
+        Ok(Self { type_, fields })
+    }
+}
+
+fn is_known_session_config_kind_type(type_: &str) -> bool {
+    match type_ {
+        "select" => true,
+        #[cfg(feature = "unstable_boolean_config")]
+        "boolean" => true,
+        _ => false,
+    }
+}
+
+fn unknown_session_config_kind_schema(schema: &mut Schema) {
+    super::schema_util::reject_known_string_discriminators(
+        schema,
+        "type",
+        &[
+            "select",
+            #[cfg(feature = "unstable_boolean_config")]
+            "boolean",
+        ],
+    );
 }
 
 /// A session configuration option selector and its current state.
@@ -3265,7 +3552,7 @@ impl PromptResponse {
 /// Reasons why an agent stops processing a prompt turn.
 ///
 /// See protocol docs: [Stop Reasons](https://agentclientprotocol.com/protocol/prompt-turn#stop-reasons)
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum StopReason {
@@ -3287,6 +3574,13 @@ pub enum StopReason {
     /// Agents should catch these exceptions and return this semantically meaningful
     /// response to confirm successful cancellation.
     Cancelled,
+    /// Custom or future stop reason.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(untagged)]
+    Other(String),
 }
 
 /// **UNSTABLE**
@@ -3596,7 +3890,11 @@ pub enum LlmProtocol {
     Vertex,
     /// AWS Bedrock API protocol.
     Bedrock,
-    /// Unknown or custom protocol.
+    /// Custom or future protocol.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
     #[serde(untagged)]
     Other(String),
 }
@@ -5550,7 +5848,6 @@ mod test_serialization {
                 assert_eq!(id.0.as_ref(), "default-auth");
                 assert_eq!(name, "Default Auth");
             }
-            #[cfg(feature = "unstable_auth_methods")]
             _ => panic!("Expected Agent variant"),
         }
     }
@@ -5566,6 +5863,63 @@ mod test_serialization {
 
         let deserialized: AuthMethod = serde_json::from_value(json).unwrap();
         assert!(matches!(deserialized, AuthMethod::Agent(_)));
+    }
+
+    #[test]
+    fn test_auth_method_agent_rejects_null_type() {
+        assert!(
+            serde_json::from_value::<AuthMethod>(json!({
+                "id": "agent-auth",
+                "name": "Agent Auth",
+                "type": null
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_auth_method_unknown_variant_roundtrip() {
+        let method: AuthMethod = serde_json::from_value(json!({
+            "id": "oauth",
+            "name": "OAuth",
+            "type": "_oauth",
+            "authorizationUrl": "https://example.com/auth"
+        }))
+        .unwrap();
+
+        assert_eq!(method.id().0.as_ref(), "oauth");
+        assert_eq!(method.name(), "OAuth");
+        let AuthMethod::Unknown(unknown) = method else {
+            panic!("expected unknown auth method");
+        };
+        assert_eq!(unknown.type_, "_oauth");
+        assert_eq!(
+            unknown.fields.get("authorizationUrl"),
+            Some(&json!("https://example.com/auth"))
+        );
+
+        assert_eq!(
+            serde_json::to_value(AuthMethod::Unknown(unknown)).unwrap(),
+            json!({
+                "id": "oauth",
+                "name": "OAuth",
+                "type": "_oauth",
+                "authorizationUrl": "https://example.com/auth"
+            })
+        );
+    }
+
+    #[cfg(feature = "unstable_auth_methods")]
+    #[test]
+    fn test_auth_method_unknown_does_not_hide_malformed_known_variant() {
+        assert!(
+            serde_json::from_value::<AuthMethod>(json!({
+                "id": "api-key",
+                "name": "API Key",
+                "type": "env_var"
+            }))
+            .is_err()
+        );
     }
 
     #[cfg(feature = "unstable_session_delete")]
@@ -6115,6 +6469,44 @@ mod test_serialization {
             }
             _ => panic!("Expected Select kind"),
         }
+    }
+
+    #[test]
+    fn test_session_config_option_unknown_kind_roundtrip() {
+        let option: SessionConfigOption = serde_json::from_value(json!({
+            "id": "verbosity",
+            "name": "Verbosity",
+            "type": "_slider",
+            "currentValue": 3,
+            "min": 0,
+            "max": 5
+        }))
+        .unwrap();
+
+        assert_eq!(option.id.to_string(), "verbosity");
+        let SessionConfigKind::Unknown(unknown) = &option.kind else {
+            panic!("expected unknown config kind");
+        };
+        assert_eq!(unknown.type_, "_slider");
+        assert_eq!(unknown.fields.get("currentValue"), Some(&json!(3)));
+
+        let json = serde_json::to_value(&option).unwrap();
+        assert_eq!(json["type"], "_slider");
+        assert_eq!(json["currentValue"], 3);
+        assert_eq!(json["min"], 0);
+        assert_eq!(json["max"], 5);
+    }
+
+    #[test]
+    fn test_session_config_option_unknown_does_not_hide_malformed_known_kind() {
+        assert!(
+            serde_json::from_value::<SessionConfigOption>(json!({
+                "id": "model",
+                "name": "Model",
+                "type": "select"
+            }))
+            .is_err()
+        );
     }
 
     #[cfg(feature = "unstable_llm_providers")]

--- a/src/v2/agent.rs
+++ b/src/v2/agent.rs
@@ -531,7 +531,7 @@ pub enum AuthMethod {
     /// payload when storing, replaying, proxying, or forwarding initialization
     /// data, and otherwise ignore the method or display it generically.
     #[serde(untagged)]
-    Unknown(UnknownAuthMethod),
+    Other(OtherAuthMethod),
     /// Agent handles authentication itself.
     ///
     /// This is the default when no `type` is specified.
@@ -545,7 +545,7 @@ impl AuthMethod {
     pub fn id(&self) -> &AuthMethodId {
         match self {
             Self::Agent(a) => &a.id,
-            Self::Unknown(a) => &a.id,
+            Self::Other(a) => &a.id,
             #[cfg(feature = "unstable_auth_methods")]
             Self::EnvVar(e) => &e.id,
             #[cfg(feature = "unstable_auth_methods")]
@@ -558,7 +558,7 @@ impl AuthMethod {
     pub fn name(&self) -> &str {
         match self {
             Self::Agent(a) => &a.name,
-            Self::Unknown(a) => &a.name,
+            Self::Other(a) => &a.name,
             #[cfg(feature = "unstable_auth_methods")]
             Self::EnvVar(e) => &e.name,
             #[cfg(feature = "unstable_auth_methods")]
@@ -571,7 +571,7 @@ impl AuthMethod {
     pub fn description(&self) -> Option<&str> {
         match self {
             Self::Agent(a) => a.description.as_deref(),
-            Self::Unknown(a) => a.description.as_deref(),
+            Self::Other(a) => a.description.as_deref(),
             #[cfg(feature = "unstable_auth_methods")]
             Self::EnvVar(e) => e.description.as_deref(),
             #[cfg(feature = "unstable_auth_methods")]
@@ -588,7 +588,7 @@ impl AuthMethod {
     pub fn meta(&self) -> Option<&Meta> {
         match self {
             Self::Agent(a) => a.meta.as_ref(),
-            Self::Unknown(a) => a.meta.as_ref(),
+            Self::Other(a) => a.meta.as_ref(),
             #[cfg(feature = "unstable_auth_methods")]
             Self::EnvVar(e) => e.meta.as_ref(),
             #[cfg(feature = "unstable_auth_methods")]
@@ -601,10 +601,10 @@ impl AuthMethod {
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
 #[schemars(inline)]
-#[schemars(transform = unknown_auth_method_schema)]
+#[schemars(transform = other_auth_method_schema)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct UnknownAuthMethod {
+pub struct OtherAuthMethod {
     /// Custom or future authentication method type.
     ///
     /// Values beginning with `_` are reserved for implementation-specific
@@ -630,7 +630,7 @@ pub struct UnknownAuthMethod {
     pub fields: BTreeMap<String, serde_json::Value>,
 }
 
-impl UnknownAuthMethod {
+impl OtherAuthMethod {
     #[must_use]
     pub fn new(
         type_: impl Into<String>,
@@ -672,14 +672,14 @@ impl UnknownAuthMethod {
     }
 }
 
-impl<'de> Deserialize<'de> for UnknownAuthMethod {
+impl<'de> Deserialize<'de> for OtherAuthMethod {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase")]
-        struct RawUnknownAuthMethod {
+        struct RawOtherAuthMethod {
             #[serde(rename = "type")]
             type_: String,
             id: AuthMethodId,
@@ -691,7 +691,7 @@ impl<'de> Deserialize<'de> for UnknownAuthMethod {
             fields: BTreeMap<String, serde_json::Value>,
         }
 
-        let raw = RawUnknownAuthMethod::deserialize(deserializer)?;
+        let raw = RawOtherAuthMethod::deserialize(deserializer)?;
         if is_known_auth_method_type(&raw.type_) {
             return Err(serde::de::Error::custom(format!(
                 "known authentication method `{}` did not match its schema",
@@ -719,7 +719,7 @@ fn is_known_auth_method_type(type_: &str) -> bool {
     }
 }
 
-fn unknown_auth_method_schema(schema: &mut Schema) {
+fn other_auth_method_schema(schema: &mut Schema) {
     super::schema_util::reject_known_string_discriminators(
         schema,
         "type",
@@ -2621,16 +2621,16 @@ pub enum SessionConfigKind {
     /// payload when storing, replaying, proxying, or forwarding configuration
     /// data, and otherwise ignore the option or display it generically.
     #[serde(untagged)]
-    Unknown(UnknownSessionConfigKind),
+    Other(OtherSessionConfigKind),
 }
 
 /// Custom or future session configuration option payload.
 #[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
 #[schemars(inline)]
-#[schemars(transform = unknown_session_config_kind_schema)]
+#[schemars(transform = other_session_config_kind_schema)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct UnknownSessionConfigKind {
+pub struct OtherSessionConfigKind {
     /// Custom or future session configuration option type.
     ///
     /// Values beginning with `_` are reserved for implementation-specific
@@ -2643,7 +2643,7 @@ pub struct UnknownSessionConfigKind {
     pub fields: BTreeMap<String, serde_json::Value>,
 }
 
-impl UnknownSessionConfigKind {
+impl OtherSessionConfigKind {
     #[must_use]
     pub fn new(type_: impl Into<String>, mut fields: BTreeMap<String, serde_json::Value>) -> Self {
         fields.remove("type");
@@ -2654,7 +2654,7 @@ impl UnknownSessionConfigKind {
     }
 }
 
-impl<'de> Deserialize<'de> for UnknownSessionConfigKind {
+impl<'de> Deserialize<'de> for OtherSessionConfigKind {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -2686,7 +2686,7 @@ fn is_known_session_config_kind_type(type_: &str) -> bool {
     }
 }
 
-fn unknown_session_config_kind_schema(schema: &mut Schema) {
+fn other_session_config_kind_schema(schema: &mut Schema) {
     super::schema_util::reject_known_string_discriminators(
         schema,
         "type",
@@ -5889,7 +5889,7 @@ mod test_serialization {
 
         assert_eq!(method.id().0.as_ref(), "oauth");
         assert_eq!(method.name(), "OAuth");
-        let AuthMethod::Unknown(unknown) = method else {
+        let AuthMethod::Other(unknown) = method else {
             panic!("expected unknown auth method");
         };
         assert_eq!(unknown.type_, "_oauth");
@@ -5899,7 +5899,7 @@ mod test_serialization {
         );
 
         assert_eq!(
-            serde_json::to_value(AuthMethod::Unknown(unknown)).unwrap(),
+            serde_json::to_value(AuthMethod::Other(unknown)).unwrap(),
             json!({
                 "id": "oauth",
                 "name": "OAuth",
@@ -6484,7 +6484,7 @@ mod test_serialization {
         .unwrap();
 
         assert_eq!(option.id.to_string(), "verbosity");
-        let SessionConfigKind::Unknown(unknown) = &option.kind else {
+        let SessionConfigKind::Other(unknown) = &option.kind else {
             panic!("expected unknown config kind");
         };
         assert_eq!(unknown.type_, "_slider");

--- a/src/v2/client.rs
+++ b/src/v2/client.rs
@@ -145,7 +145,7 @@ pub enum SessionUpdate {
     /// raw payload when storing, replaying, proxying, or forwarding session
     /// history, and otherwise ignore it or display it generically.
     #[serde(untagged)]
-    Unknown(UnknownSessionUpdate),
+    Other(OtherSessionUpdate),
 }
 
 /// Custom or future session update payload.
@@ -155,10 +155,10 @@ pub enum SessionUpdate {
 /// history.
 #[derive(Debug, Clone, Serialize, JsonSchema, PartialEq)]
 #[schemars(inline)]
-#[schemars(transform = unknown_session_update_schema)]
+#[schemars(transform = other_session_update_schema)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct UnknownSessionUpdate {
+pub struct OtherSessionUpdate {
     /// Custom or future session update type.
     ///
     /// Values beginning with `_` are reserved for implementation-specific
@@ -171,7 +171,7 @@ pub struct UnknownSessionUpdate {
     pub fields: BTreeMap<String, serde_json::Value>,
 }
 
-impl UnknownSessionUpdate {
+impl OtherSessionUpdate {
     #[must_use]
     pub fn new(
         session_update: impl Into<String>,
@@ -185,7 +185,7 @@ impl UnknownSessionUpdate {
     }
 }
 
-impl<'de> Deserialize<'de> for UnknownSessionUpdate {
+impl<'de> Deserialize<'de> for OtherSessionUpdate {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -231,7 +231,7 @@ fn is_known_session_update(session_update: &str) -> bool {
     }
 }
 
-fn unknown_session_update_schema(schema: &mut Schema) {
+fn other_session_update_schema(schema: &mut Schema) {
     super::schema_util::reject_known_string_discriminators(
         schema,
         "sessionUpdate",
@@ -657,7 +657,7 @@ pub enum AvailableCommandInput {
     /// payload when storing, replaying, proxying, or forwarding command
     /// metadata, and otherwise ignore the input specification or display the
     /// command without structured input.
-    Unknown(UnknownAvailableCommandInput),
+    Other(OtherAvailableCommandInput),
 }
 
 /// Custom or future command input specification.
@@ -665,7 +665,7 @@ pub enum AvailableCommandInput {
 #[schemars(inline)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct UnknownAvailableCommandInput {
+pub struct OtherAvailableCommandInput {
     /// Custom or future command input type.
     ///
     /// Values beginning with `_` are reserved for implementation-specific
@@ -678,7 +678,7 @@ pub struct UnknownAvailableCommandInput {
     pub fields: BTreeMap<String, serde_json::Value>,
 }
 
-impl UnknownAvailableCommandInput {
+impl OtherAvailableCommandInput {
     #[must_use]
     pub fn new(type_: impl Into<String>, mut fields: BTreeMap<String, serde_json::Value>) -> Self {
         fields.remove("type");
@@ -689,7 +689,7 @@ impl UnknownAvailableCommandInput {
     }
 }
 
-impl<'de> Deserialize<'de> for UnknownAvailableCommandInput {
+impl<'de> Deserialize<'de> for OtherAvailableCommandInput {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -2437,7 +2437,7 @@ mod tests {
         }))
         .unwrap();
 
-        let SessionUpdate::Unknown(unknown) = update else {
+        let SessionUpdate::Other(unknown) = update else {
             panic!("expected unknown session update");
         };
 
@@ -2446,7 +2446,7 @@ mod tests {
         assert_eq!(unknown.fields.get("progress"), Some(&json!(0.5)));
 
         assert_eq!(
-            serde_json::to_value(SessionUpdate::Unknown(unknown)).unwrap(),
+            serde_json::to_value(SessionUpdate::Other(unknown)).unwrap(),
             json!({
                 "sessionUpdate": "_status_badge",
                 "label": "Indexing",
@@ -2478,7 +2478,7 @@ mod tests {
         }))
         .unwrap();
 
-        let AvailableCommandInput::Unknown(unknown) = input else {
+        let AvailableCommandInput::Other(unknown) = input else {
             panic!("expected unknown command input");
         };
 
@@ -2489,7 +2489,7 @@ mod tests {
             Some(&json!(["fast", "careful"]))
         );
         assert_eq!(
-            serde_json::to_value(AvailableCommandInput::Unknown(unknown)).unwrap(),
+            serde_json::to_value(AvailableCommandInput::Other(unknown)).unwrap(),
             json!({
                 "type": "_choices",
                 "hint": "Pick one",

--- a/src/v2/client.rs
+++ b/src/v2/client.rs
@@ -3,10 +3,10 @@
 //! This module defines the Client trait and all associated types for implementing
 //! a client that interacts with AI coding agents via the Agent Client Protocol (ACP).
 
-use std::{path::PathBuf, sync::Arc};
+use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 
 use derive_more::{Display, From};
-use schemars::JsonSchema;
+use schemars::{JsonSchema, Schema};
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnError, VecSkipError, serde_as, skip_serializing_none};
 
@@ -135,6 +135,125 @@ pub enum SessionUpdate {
     /// Context window and cost update for the session.
     #[cfg(feature = "unstable_session_usage")]
     UsageUpdate(UsageUpdate),
+    /// Custom or future session update.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    ///
+    /// Receivers that do not understand this update type should preserve the
+    /// raw payload when storing, replaying, proxying, or forwarding session
+    /// history, and otherwise ignore it or display it generically.
+    #[serde(untagged)]
+    Unknown(UnknownSessionUpdate),
+}
+
+/// Custom or future session update payload.
+///
+/// This preserves the unknown `sessionUpdate` discriminator and the rest of the
+/// update object for clients that store, replay, proxy, or forward session
+/// history.
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq)]
+#[schemars(inline)]
+#[schemars(transform = unknown_session_update_schema)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct UnknownSessionUpdate {
+    /// Custom or future session update type.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(rename = "sessionUpdate")]
+    pub session_update: String,
+    /// Additional fields from the unknown update payload.
+    #[serde(flatten)]
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl UnknownSessionUpdate {
+    #[must_use]
+    pub fn new(
+        session_update: impl Into<String>,
+        mut fields: BTreeMap<String, serde_json::Value>,
+    ) -> Self {
+        fields.remove("sessionUpdate");
+        Self {
+            session_update: session_update.into(),
+            fields,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for UnknownSessionUpdate {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut fields = BTreeMap::<String, serde_json::Value>::deserialize(deserializer)?;
+        let session_update = fields
+            .remove("sessionUpdate")
+            .ok_or_else(|| serde::de::Error::missing_field("sessionUpdate"))?;
+        let serde_json::Value::String(session_update) = session_update else {
+            return Err(serde::de::Error::custom("`sessionUpdate` must be a string"));
+        };
+
+        if is_known_session_update(&session_update) {
+            return Err(serde::de::Error::custom(format!(
+                "known session update `{session_update}` did not match its schema"
+            )));
+        }
+
+        Ok(Self {
+            session_update,
+            fields,
+        })
+    }
+}
+
+fn is_known_session_update(session_update: &str) -> bool {
+    match session_update {
+        "user_message_chunk"
+        | "agent_message_chunk"
+        | "agent_thought_chunk"
+        | "tool_call"
+        | "tool_call_update"
+        | "plan"
+        | "available_commands_update"
+        | "current_mode_update"
+        | "config_option_update"
+        | "session_info_update" => true,
+        #[cfg(feature = "unstable_plan_operations")]
+        "plan_update" | "plan_removed" => true,
+        #[cfg(feature = "unstable_session_usage")]
+        "usage_update" => true,
+        _ => false,
+    }
+}
+
+fn unknown_session_update_schema(schema: &mut Schema) {
+    super::schema_util::reject_known_string_discriminators(
+        schema,
+        "sessionUpdate",
+        &[
+            "user_message_chunk",
+            "agent_message_chunk",
+            "agent_thought_chunk",
+            "tool_call",
+            "tool_call_update",
+            "plan",
+            "available_commands_update",
+            "current_mode_update",
+            "config_option_update",
+            "session_info_update",
+            #[cfg(feature = "unstable_plan_operations")]
+            "plan_update",
+            #[cfg(feature = "unstable_plan_operations")]
+            "plan_removed",
+            #[cfg(feature = "unstable_session_usage")]
+            "usage_update",
+        ],
+    );
 }
 
 /// The current mode of the session has changed
@@ -528,11 +647,69 @@ impl AvailableCommand {
 pub enum AvailableCommandInput {
     /// All text that was typed after the command name is provided as input.
     Unstructured(UnstructuredCommandInput),
+    /// Custom or future command input specification.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    ///
+    /// Clients that do not understand this input type should preserve the raw
+    /// payload when storing, replaying, proxying, or forwarding command
+    /// metadata, and otherwise ignore the input specification or display the
+    /// command without structured input.
+    Unknown(UnknownAvailableCommandInput),
+}
+
+/// Custom or future command input specification.
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[schemars(inline)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct UnknownAvailableCommandInput {
+    /// Custom or future command input type.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// Additional fields from the unknown command input payload.
+    #[serde(flatten)]
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl UnknownAvailableCommandInput {
+    #[must_use]
+    pub fn new(type_: impl Into<String>, mut fields: BTreeMap<String, serde_json::Value>) -> Self {
+        fields.remove("type");
+        Self {
+            type_: type_.into(),
+            fields,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for UnknownAvailableCommandInput {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut fields = BTreeMap::<String, serde_json::Value>::deserialize(deserializer)?;
+        let type_ = fields
+            .remove("type")
+            .ok_or_else(|| serde::de::Error::missing_field("type"))?;
+        let serde_json::Value::String(type_) = type_ else {
+            return Err(serde::de::Error::custom("`type` must be a string"));
+        };
+
+        Ok(Self { type_, fields })
+    }
 }
 
 /// All text that was typed after the command name is provided as input.
 #[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[schemars(transform = unstructured_command_input_schema)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct UnstructuredCommandInput {
@@ -566,6 +743,39 @@ impl UnstructuredCommandInput {
         self.meta = meta.into_option();
         self
     }
+}
+
+impl<'de> Deserialize<'de> for UnstructuredCommandInput {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct RawUnstructuredCommandInput {
+            hint: String,
+            #[serde(rename = "_meta")]
+            meta: Option<Meta>,
+            #[serde(flatten)]
+            fields: BTreeMap<String, serde_json::Value>,
+        }
+
+        let raw = RawUnstructuredCommandInput::deserialize(deserializer)?;
+        if raw.fields.contains_key("type") {
+            return Err(serde::de::Error::custom(
+                "unstructured command input cannot include a `type` field",
+            ));
+        }
+
+        Ok(Self {
+            hint: raw.hint,
+            meta: raw.meta,
+        })
+    }
+}
+
+fn unstructured_command_input_schema(schema: &mut Schema) {
+    super::schema_util::reject_property(schema, "type");
 }
 
 // Permission
@@ -688,7 +898,7 @@ impl PermissionOptionId {
 /// The type of permission option being presented to the user.
 ///
 /// Helps clients choose appropriate icons and UI treatment.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum PermissionOptionKind {
@@ -700,6 +910,13 @@ pub enum PermissionOptionKind {
     RejectOnce,
     /// Reject this operation and remember the choice.
     RejectAlways,
+    /// Custom or future permission option kind.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(untagged)]
+    Other(String),
 }
 
 /// Response to a permission request.
@@ -2206,6 +2423,92 @@ mod tests {
             )
             .unwrap(),
             json!({})
+        );
+    }
+
+    #[test]
+    fn session_update_preserves_unknown_variant() {
+        use serde_json::json;
+
+        let update: SessionUpdate = serde_json::from_value(json!({
+            "sessionUpdate": "_status_badge",
+            "label": "Indexing",
+            "progress": 0.5
+        }))
+        .unwrap();
+
+        let SessionUpdate::Unknown(unknown) = update else {
+            panic!("expected unknown session update");
+        };
+
+        assert_eq!(unknown.session_update, "_status_badge");
+        assert_eq!(unknown.fields.get("label"), Some(&json!("Indexing")));
+        assert_eq!(unknown.fields.get("progress"), Some(&json!(0.5)));
+
+        assert_eq!(
+            serde_json::to_value(SessionUpdate::Unknown(unknown)).unwrap(),
+            json!({
+                "sessionUpdate": "_status_badge",
+                "label": "Indexing",
+                "progress": 0.5
+            })
+        );
+    }
+
+    #[test]
+    fn session_update_does_not_hide_malformed_known_variant() {
+        use serde_json::json;
+
+        assert!(
+            serde_json::from_value::<SessionUpdate>(json!({
+                "sessionUpdate": "agent_message_chunk"
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn available_command_input_preserves_unknown_typed_variant() {
+        use serde_json::json;
+
+        let input: AvailableCommandInput = serde_json::from_value(json!({
+            "type": "_choices",
+            "hint": "Pick one",
+            "options": ["fast", "careful"]
+        }))
+        .unwrap();
+
+        let AvailableCommandInput::Unknown(unknown) = input else {
+            panic!("expected unknown command input");
+        };
+
+        assert_eq!(unknown.type_, "_choices");
+        assert_eq!(unknown.fields.get("hint"), Some(&json!("Pick one")));
+        assert_eq!(
+            unknown.fields.get("options"),
+            Some(&json!(["fast", "careful"]))
+        );
+        assert_eq!(
+            serde_json::to_value(AvailableCommandInput::Unknown(unknown)).unwrap(),
+            json!({
+                "type": "_choices",
+                "hint": "Pick one",
+                "options": ["fast", "careful"]
+            })
+        );
+    }
+
+    #[test]
+    fn available_command_input_unknown_does_not_hide_malformed_unstructured_variant() {
+        use serde_json::json;
+
+        assert!(serde_json::from_value::<AvailableCommandInput>(json!({})).is_err());
+        assert!(
+            serde_json::from_value::<AvailableCommandInput>(json!({
+                "type": 1,
+                "hint": "Pick one"
+            }))
+            .is_err()
         );
     }
 

--- a/src/v2/content.rs
+++ b/src/v2/content.rs
@@ -70,16 +70,16 @@ pub enum ContentBlock {
     /// the raw payload when storing, replaying, proxying, or forwarding content,
     /// and otherwise ignore it or display it generically.
     #[serde(untagged)]
-    Unknown(UnknownContentBlock),
+    Other(OtherContentBlock),
 }
 
 /// Custom or future content block payload.
 #[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
 #[schemars(inline)]
-#[schemars(transform = unknown_content_block_schema)]
+#[schemars(transform = other_content_block_schema)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct UnknownContentBlock {
+pub struct OtherContentBlock {
     /// Custom or future content block type.
     ///
     /// Values beginning with `_` are reserved for implementation-specific
@@ -92,7 +92,7 @@ pub struct UnknownContentBlock {
     pub fields: BTreeMap<String, serde_json::Value>,
 }
 
-impl UnknownContentBlock {
+impl OtherContentBlock {
     #[must_use]
     pub fn new(type_: impl Into<String>, mut fields: BTreeMap<String, serde_json::Value>) -> Self {
         fields.remove("type");
@@ -103,7 +103,7 @@ impl UnknownContentBlock {
     }
 }
 
-impl<'de> Deserialize<'de> for UnknownContentBlock {
+impl<'de> Deserialize<'de> for OtherContentBlock {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -133,7 +133,7 @@ fn is_known_content_block_type(type_: &str) -> bool {
     )
 }
 
-fn unknown_content_block_schema(schema: &mut Schema) {
+fn other_content_block_schema(schema: &mut Schema) {
     super::schema_util::reject_known_string_discriminators(
         schema,
         "type",
@@ -652,7 +652,7 @@ mod tests {
         }))
         .unwrap();
 
-        let ContentBlock::Unknown(unknown) = block else {
+        let ContentBlock::Other(unknown) = block else {
             panic!("expected unknown content block");
         };
 
@@ -662,7 +662,7 @@ mod tests {
             Some(&serde_json::json!("Status"))
         );
         assert_eq!(
-            serde_json::to_value(ContentBlock::Unknown(unknown)).unwrap(),
+            serde_json::to_value(ContentBlock::Other(unknown)).unwrap(),
             serde_json::json!({
                 "type": "_widget",
                 "title": "Status",

--- a/src/v2/content.rs
+++ b/src/v2/content.rs
@@ -9,7 +9,9 @@
 //!
 //! See: [Content](https://agentclientprotocol.com/protocol/content)
 
-use schemars::JsonSchema;
+use std::collections::BTreeMap;
+
+use schemars::{JsonSchema, Schema};
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnError, VecSkipError, serde_as, skip_serializing_none};
 
@@ -58,6 +60,85 @@ pub enum ContentBlock {
     ///
     /// Requires the `embeddedContext` prompt capability when included in prompts.
     Resource(EmbeddedResource),
+    /// Custom or future content block.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    ///
+    /// Receivers that do not understand this content block type should preserve
+    /// the raw payload when storing, replaying, proxying, or forwarding content,
+    /// and otherwise ignore it or display it generically.
+    #[serde(untagged)]
+    Unknown(UnknownContentBlock),
+}
+
+/// Custom or future content block payload.
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+#[schemars(inline)]
+#[schemars(transform = unknown_content_block_schema)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct UnknownContentBlock {
+    /// Custom or future content block type.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// Additional fields from the unknown content block payload.
+    #[serde(flatten)]
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl UnknownContentBlock {
+    #[must_use]
+    pub fn new(type_: impl Into<String>, mut fields: BTreeMap<String, serde_json::Value>) -> Self {
+        fields.remove("type");
+        Self {
+            type_: type_.into(),
+            fields,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for UnknownContentBlock {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut fields = BTreeMap::<String, serde_json::Value>::deserialize(deserializer)?;
+        let type_ = fields
+            .remove("type")
+            .ok_or_else(|| serde::de::Error::missing_field("type"))?;
+        let serde_json::Value::String(type_) = type_ else {
+            return Err(serde::de::Error::custom("`type` must be a string"));
+        };
+
+        if is_known_content_block_type(&type_) {
+            return Err(serde::de::Error::custom(format!(
+                "known content block `{type_}` did not match its schema"
+            )));
+        }
+
+        Ok(Self { type_, fields })
+    }
+}
+
+fn is_known_content_block_type(type_: &str) -> bool {
+    matches!(
+        type_,
+        "text" | "image" | "audio" | "resource_link" | "resource"
+    )
+}
+
+fn unknown_content_block_schema(schema: &mut Schema) {
+    super::schema_util::reject_known_string_discriminators(
+        schema,
+        "type",
+        &["text", "image", "audio", "resource_link", "resource"],
+    );
 }
 
 /// Text provided to or from an LLM.
@@ -517,6 +598,13 @@ impl Annotations {
 pub enum Role {
     Assistant,
     User,
+    /// Custom or future role.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(untagged)]
+    Other(String),
 }
 
 #[cfg(test)]
@@ -546,6 +634,51 @@ mod tests {
             ContentBlock::Text(c) => assert_eq!(c.text, "hello"),
             _ => panic!("Expected Text variant"),
         }
+    }
+
+    #[test]
+    fn role_preserves_unknown_variant() {
+        let role: Role = serde_json::from_str("\"critic\"").unwrap();
+        assert_eq!(role, Role::Other("critic".to_string()));
+        assert_eq!(serde_json::to_value(&role).unwrap(), "critic");
+    }
+
+    #[test]
+    fn content_block_preserves_unknown_variant() {
+        let block: ContentBlock = serde_json::from_value(serde_json::json!({
+            "type": "_widget",
+            "title": "Status",
+            "state": {"ok": true}
+        }))
+        .unwrap();
+
+        let ContentBlock::Unknown(unknown) = block else {
+            panic!("expected unknown content block");
+        };
+
+        assert_eq!(unknown.type_, "_widget");
+        assert_eq!(
+            unknown.fields.get("title"),
+            Some(&serde_json::json!("Status"))
+        );
+        assert_eq!(
+            serde_json::to_value(ContentBlock::Unknown(unknown)).unwrap(),
+            serde_json::json!({
+                "type": "_widget",
+                "title": "Status",
+                "state": {"ok": true}
+            })
+        );
+    }
+
+    #[test]
+    fn content_block_does_not_hide_malformed_known_variant() {
+        assert!(
+            serde_json::from_value::<ContentBlock>(serde_json::json!({
+                "type": "text"
+            }))
+            .is_err()
+        );
     }
 
     #[test]

--- a/src/v2/conversion.rs
+++ b/src/v2/conversion.rs
@@ -24,29 +24,6 @@ pub type Result<T> = std::result::Result<T, ProtocolConversionError>;
 #[non_exhaustive]
 pub struct ProtocolConversionError {
     message: String,
-    unsupported_v2_variant: Option<UnsupportedV2Variant>,
-}
-
-/// A v2 enum-like variant that cannot be represented in the v1 type namespace.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct UnsupportedV2Variant {
-    type_name: String,
-    value: String,
-}
-
-impl UnsupportedV2Variant {
-    /// Returns the v2 enum-like type name that contained the unsupported variant.
-    #[must_use]
-    pub fn type_name(&self) -> &str {
-        &self.type_name
-    }
-
-    /// Returns the unsupported v2 variant value.
-    #[must_use]
-    pub fn value(&self) -> &str {
-        &self.value
-    }
 }
 
 impl ProtocolConversionError {
@@ -55,7 +32,6 @@ impl ProtocolConversionError {
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
-            unsupported_v2_variant: None,
         }
     }
 
@@ -63,20 +39,6 @@ impl ProtocolConversionError {
     #[must_use]
     pub fn message(&self) -> &str {
         &self.message
-    }
-
-    /// Returns the unsupported v2 variant details when this conversion failed
-    /// because a v2 enum-like value has no v1 representation.
-    #[must_use]
-    pub fn unsupported_v2_variant(&self) -> Option<&UnsupportedV2Variant> {
-        self.unsupported_v2_variant.as_ref()
-    }
-
-    /// Returns true when this conversion failed because a v2 enum-like value
-    /// has no v1 representation.
-    #[must_use]
-    pub fn is_unsupported_v2_variant(&self) -> bool {
-        self.unsupported_v2_variant.is_some()
     }
 }
 
@@ -89,13 +51,9 @@ impl fmt::Display for ProtocolConversionError {
 impl std::error::Error for ProtocolConversionError {}
 
 fn unknown_v2_enum_variant(type_name: &str, value: &str) -> ProtocolConversionError {
-    ProtocolConversionError {
-        message: format!("v2 {type_name} variant `{value}` cannot be represented in v1"),
-        unsupported_v2_variant: Some(UnsupportedV2Variant {
-            type_name: type_name.to_string(),
-            value: value.to_string(),
-        }),
-    }
+    ProtocolConversionError::new(format!(
+        "v2 {type_name} variant `{value}` cannot be represented in v1"
+    ))
 }
 
 /// Converts a [`ProtocolConversionError`] into a v1 [`Error`](crate::v1::Error)
@@ -549,7 +507,7 @@ impl IntoV1 for super::PlanUpdateContent {
             Self::Items(value) => crate::v1::PlanUpdateContent::Items(value.into_v1()?),
             Self::File(value) => crate::v1::PlanUpdateContent::File(value.into_v1()?),
             Self::Markdown(value) => crate::v1::PlanUpdateContent::Markdown(value.into_v1()?),
-            Self::Unknown(value) => {
+            Self::Other(value) => {
                 return Err(unknown_v2_enum_variant("PlanUpdateContent", &value.type_));
             }
         })
@@ -916,7 +874,7 @@ impl IntoV1 for super::SessionUpdate {
             }
             #[cfg(feature = "unstable_session_usage")]
             Self::UsageUpdate(value) => crate::v1::SessionUpdate::UsageUpdate(value.into_v1()?),
-            Self::Unknown(value) => {
+            Self::Other(value) => {
                 return Err(unknown_v2_enum_variant(
                     "SessionUpdate",
                     &value.session_update,
@@ -1239,7 +1197,7 @@ impl IntoV1 for super::AvailableCommandInput {
             Self::Unstructured(value) => {
                 crate::v1::AvailableCommandInput::Unstructured(value.into_v1()?)
             }
-            Self::Unknown(value) => {
+            Self::Other(value) => {
                 return Err(unknown_v2_enum_variant(
                     "AvailableCommandInput",
                     &value.type_,
@@ -2918,7 +2876,7 @@ impl IntoV1 for super::ToolCallContent {
             Self::Content(value) => crate::v1::ToolCallContent::Content(value.into_v1()?),
             Self::Diff(value) => crate::v1::ToolCallContent::Diff(value.into_v1()?),
             Self::Terminal(value) => crate::v1::ToolCallContent::Terminal(value.into_v1()?),
-            Self::Unknown(value) => {
+            Self::Other(value) => {
                 return Err(unknown_v2_enum_variant("ToolCallContent", &value.type_));
             }
         })
@@ -3328,7 +3286,7 @@ impl IntoV1 for super::AuthMethod {
             Self::EnvVar(value) => crate::v1::AuthMethod::EnvVar(value.into_v1()?),
             #[cfg(feature = "unstable_auth_methods")]
             Self::Terminal(value) => crate::v1::AuthMethod::Terminal(value.into_v1()?),
-            Self::Unknown(value) => {
+            Self::Other(value) => {
                 return Err(unknown_v2_enum_variant("AuthMethod", &value.type_));
             }
             Self::Agent(value) => crate::v1::AuthMethod::Agent(value.into_v1()?),
@@ -4478,7 +4436,7 @@ impl IntoV1 for super::SessionConfigKind {
             Self::Select(value) => crate::v1::SessionConfigKind::Select(value.into_v1()?),
             #[cfg(feature = "unstable_boolean_config")]
             Self::Boolean(value) => crate::v1::SessionConfigKind::Boolean(value.into_v1()?),
-            Self::Unknown(value) => {
+            Self::Other(value) => {
                 return Err(unknown_v2_enum_variant("SessionConfigKind", &value.type_));
             }
         })
@@ -7822,7 +7780,7 @@ impl IntoV1 for super::NesSuggestion {
             Self::SearchAndReplace(value) => {
                 crate::v1::NesSuggestion::SearchAndReplace(value.into_v1()?)
             }
-            Self::Unknown(value) => {
+            Self::Other(value) => {
                 return Err(unknown_v2_enum_variant("NesSuggestion", &value.kind));
             }
         })
@@ -9147,7 +9105,7 @@ impl IntoV1 for super::ContentBlock {
             Self::Audio(value) => crate::v1::ContentBlock::Audio(value.into_v1()?),
             Self::ResourceLink(value) => crate::v1::ContentBlock::ResourceLink(value.into_v1()?),
             Self::Resource(value) => crate::v1::ContentBlock::Resource(value.into_v1()?),
-            Self::Unknown(value) => {
+            Self::Other(value) => {
                 return Err(unknown_v2_enum_variant("ContentBlock", &value.type_));
             }
         })
@@ -9770,7 +9728,7 @@ mod tests {
 
     #[test]
     fn unknown_v2_session_update_does_not_convert_to_v1() {
-        let update = v2::SessionUpdate::Unknown(v2::UnknownSessionUpdate::new(
+        let update = v2::SessionUpdate::Other(v2::OtherSessionUpdate::new(
             "_status_badge",
             std::collections::BTreeMap::new(),
         ));
@@ -9782,51 +9740,37 @@ mod tests {
     }
 
     #[test]
-    fn unknown_v2_variant_conversion_error_is_structured() {
-        let error = v2_to_v1(v2::Role::Other("_critic".to_string())).unwrap_err();
-
-        assert_eq!(
-            error.message(),
-            "v2 Role variant `_critic` cannot be represented in v1"
-        );
-        assert!(error.is_unsupported_v2_variant());
-        let unsupported = error.unsupported_v2_variant().unwrap();
-        assert_eq!(unsupported.type_name(), "Role");
-        assert_eq!(unsupported.value(), "_critic");
-    }
-
-    #[test]
     fn unknown_v2_raw_fallbacks_do_not_convert_to_v1() {
         assert_v2_to_v1_error(
-            v2::ContentBlock::Unknown(v2::UnknownContentBlock::new(
+            v2::ContentBlock::Other(v2::OtherContentBlock::new(
                 "_widget",
                 std::collections::BTreeMap::new(),
             )),
             "v2 ContentBlock variant `_widget` cannot be represented in v1",
         );
         assert_v2_to_v1_error(
-            v2::ToolCallContent::Unknown(v2::UnknownToolCallContent::new(
+            v2::ToolCallContent::Other(v2::OtherToolCallContent::new(
                 "_chart",
                 std::collections::BTreeMap::new(),
             )),
             "v2 ToolCallContent variant `_chart` cannot be represented in v1",
         );
         assert_v2_to_v1_error(
-            v2::AvailableCommandInput::Unknown(v2::UnknownAvailableCommandInput::new(
+            v2::AvailableCommandInput::Other(v2::OtherAvailableCommandInput::new(
                 "_choices",
                 std::collections::BTreeMap::new(),
             )),
             "v2 AvailableCommandInput variant `_choices` cannot be represented in v1",
         );
         assert_v2_to_v1_error(
-            v2::SessionConfigKind::Unknown(v2::UnknownSessionConfigKind::new(
+            v2::SessionConfigKind::Other(v2::OtherSessionConfigKind::new(
                 "_slider",
                 std::collections::BTreeMap::new(),
             )),
             "v2 SessionConfigKind variant `_slider` cannot be represented in v1",
         );
         assert_v2_to_v1_error(
-            v2::AuthMethod::Unknown(v2::UnknownAuthMethod::new(
+            v2::AuthMethod::Other(v2::OtherAuthMethod::new(
                 "_oauth",
                 "oauth",
                 "OAuth",
@@ -9836,7 +9780,7 @@ mod tests {
         );
         #[cfg(feature = "unstable_plan_operations")]
         assert_v2_to_v1_error(
-            v2::PlanUpdateContent::Unknown(v2::UnknownPlanUpdateContent::new(
+            v2::PlanUpdateContent::Other(v2::OtherPlanUpdateContent::new(
                 "_timeline",
                 std::collections::BTreeMap::new(),
             )),
@@ -9844,7 +9788,7 @@ mod tests {
         );
         #[cfg(feature = "unstable_nes")]
         assert_v2_to_v1_error(
-            v2::NesSuggestion::Unknown(v2::UnknownNesSuggestion::new(
+            v2::NesSuggestion::Other(v2::OtherNesSuggestion::new(
                 "_preview",
                 std::collections::BTreeMap::new(),
             )),

--- a/src/v2/conversion.rs
+++ b/src/v2/conversion.rs
@@ -24,6 +24,29 @@ pub type Result<T> = std::result::Result<T, ProtocolConversionError>;
 #[non_exhaustive]
 pub struct ProtocolConversionError {
     message: String,
+    unsupported_v2_variant: Option<UnsupportedV2Variant>,
+}
+
+/// A v2 enum-like variant that cannot be represented in the v1 type namespace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UnsupportedV2Variant {
+    type_name: String,
+    value: String,
+}
+
+impl UnsupportedV2Variant {
+    /// Returns the v2 enum-like type name that contained the unsupported variant.
+    #[must_use]
+    pub fn type_name(&self) -> &str {
+        &self.type_name
+    }
+
+    /// Returns the unsupported v2 variant value.
+    #[must_use]
+    pub fn value(&self) -> &str {
+        &self.value
+    }
 }
 
 impl ProtocolConversionError {
@@ -32,6 +55,7 @@ impl ProtocolConversionError {
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            unsupported_v2_variant: None,
         }
     }
 
@@ -39,6 +63,20 @@ impl ProtocolConversionError {
     #[must_use]
     pub fn message(&self) -> &str {
         &self.message
+    }
+
+    /// Returns the unsupported v2 variant details when this conversion failed
+    /// because a v2 enum-like value has no v1 representation.
+    #[must_use]
+    pub fn unsupported_v2_variant(&self) -> Option<&UnsupportedV2Variant> {
+        self.unsupported_v2_variant.as_ref()
+    }
+
+    /// Returns true when this conversion failed because a v2 enum-like value
+    /// has no v1 representation.
+    #[must_use]
+    pub fn is_unsupported_v2_variant(&self) -> bool {
+        self.unsupported_v2_variant.is_some()
     }
 }
 
@@ -49,6 +87,16 @@ impl fmt::Display for ProtocolConversionError {
 }
 
 impl std::error::Error for ProtocolConversionError {}
+
+fn unknown_v2_enum_variant(type_name: &str, value: &str) -> ProtocolConversionError {
+    ProtocolConversionError {
+        message: format!("v2 {type_name} variant `{value}` cannot be represented in v1"),
+        unsupported_v2_variant: Some(UnsupportedV2Variant {
+            type_name: type_name.to_string(),
+            value: value.to_string(),
+        }),
+    }
+}
 
 /// Converts a [`ProtocolConversionError`] into a v1 [`Error`](crate::v1::Error)
 /// so callers can use `?` to bubble conversion failures through APIs that
@@ -501,6 +549,9 @@ impl IntoV1 for super::PlanUpdateContent {
             Self::Items(value) => crate::v1::PlanUpdateContent::Items(value.into_v1()?),
             Self::File(value) => crate::v1::PlanUpdateContent::File(value.into_v1()?),
             Self::Markdown(value) => crate::v1::PlanUpdateContent::Markdown(value.into_v1()?),
+            Self::Unknown(value) => {
+                return Err(unknown_v2_enum_variant("PlanUpdateContent", &value.type_));
+            }
         })
     }
 }
@@ -698,6 +749,9 @@ impl IntoV1 for super::PlanEntryPriority {
             Self::High => crate::v1::PlanEntryPriority::High,
             Self::Medium => crate::v1::PlanEntryPriority::Medium,
             Self::Low => crate::v1::PlanEntryPriority::Low,
+            Self::Other(value) => {
+                return Err(unknown_v2_enum_variant("PlanEntryPriority", &value));
+            }
         })
     }
 }
@@ -722,6 +776,7 @@ impl IntoV1 for super::PlanEntryStatus {
             Self::Pending => crate::v1::PlanEntryStatus::Pending,
             Self::InProgress => crate::v1::PlanEntryStatus::InProgress,
             Self::Completed => crate::v1::PlanEntryStatus::Completed,
+            Self::Other(value) => return Err(unknown_v2_enum_variant("PlanEntryStatus", &value)),
         })
     }
 }
@@ -861,6 +916,12 @@ impl IntoV1 for super::SessionUpdate {
             }
             #[cfg(feature = "unstable_session_usage")]
             Self::UsageUpdate(value) => crate::v1::SessionUpdate::UsageUpdate(value.into_v1()?),
+            Self::Unknown(value) => {
+                return Err(unknown_v2_enum_variant(
+                    "SessionUpdate",
+                    &value.session_update,
+                ));
+            }
         })
     }
 }
@@ -1178,6 +1239,12 @@ impl IntoV1 for super::AvailableCommandInput {
             Self::Unstructured(value) => {
                 crate::v1::AvailableCommandInput::Unstructured(value.into_v1()?)
             }
+            Self::Unknown(value) => {
+                return Err(unknown_v2_enum_variant(
+                    "AvailableCommandInput",
+                    &value.type_,
+                ));
+            }
         })
     }
 }
@@ -1319,6 +1386,9 @@ impl IntoV1 for super::PermissionOptionKind {
             Self::AllowAlways => crate::v1::PermissionOptionKind::AllowAlways,
             Self::RejectOnce => crate::v1::PermissionOptionKind::RejectOnce,
             Self::RejectAlways => crate::v1::PermissionOptionKind::RejectAlways,
+            Self::Other(value) => {
+                return Err(unknown_v2_enum_variant("PermissionOptionKind", &value));
+            }
         })
     }
 }
@@ -2789,6 +2859,7 @@ impl IntoV1 for super::ToolKind {
             Self::Fetch => crate::v1::ToolKind::Fetch,
             Self::SwitchMode => crate::v1::ToolKind::SwitchMode,
             Self::Other => crate::v1::ToolKind::Other,
+            Self::Unknown(value) => return Err(unknown_v2_enum_variant("ToolKind", &value)),
         })
     }
 }
@@ -2821,6 +2892,7 @@ impl IntoV1 for super::ToolCallStatus {
             Self::InProgress => crate::v1::ToolCallStatus::InProgress,
             Self::Completed => crate::v1::ToolCallStatus::Completed,
             Self::Failed => crate::v1::ToolCallStatus::Failed,
+            Self::Other(value) => return Err(unknown_v2_enum_variant("ToolCallStatus", &value)),
         })
     }
 }
@@ -2846,6 +2918,9 @@ impl IntoV1 for super::ToolCallContent {
             Self::Content(value) => crate::v1::ToolCallContent::Content(value.into_v1()?),
             Self::Diff(value) => crate::v1::ToolCallContent::Diff(value.into_v1()?),
             Self::Terminal(value) => crate::v1::ToolCallContent::Terminal(value.into_v1()?),
+            Self::Unknown(value) => {
+                return Err(unknown_v2_enum_variant("ToolCallContent", &value.type_));
+            }
         })
     }
 }
@@ -3253,6 +3328,9 @@ impl IntoV1 for super::AuthMethod {
             Self::EnvVar(value) => crate::v1::AuthMethod::EnvVar(value.into_v1()?),
             #[cfg(feature = "unstable_auth_methods")]
             Self::Terminal(value) => crate::v1::AuthMethod::Terminal(value.into_v1()?),
+            Self::Unknown(value) => {
+                return Err(unknown_v2_enum_variant("AuthMethod", &value.type_));
+            }
             Self::Agent(value) => crate::v1::AuthMethod::Agent(value.into_v1()?),
         })
     }
@@ -4400,6 +4478,9 @@ impl IntoV1 for super::SessionConfigKind {
             Self::Select(value) => crate::v1::SessionConfigKind::Select(value.into_v1()?),
             #[cfg(feature = "unstable_boolean_config")]
             Self::Boolean(value) => crate::v1::SessionConfigKind::Boolean(value.into_v1()?),
+            Self::Unknown(value) => {
+                return Err(unknown_v2_enum_variant("SessionConfigKind", &value.type_));
+            }
         })
     }
 }
@@ -4922,6 +5003,7 @@ impl IntoV1 for super::StopReason {
             Self::MaxTurnRequests => crate::v1::StopReason::MaxTurnRequests,
             Self::Refusal => crate::v1::StopReason::Refusal,
             Self::Cancelled => crate::v1::StopReason::Cancelled,
+            Self::Other(value) => return Err(unknown_v2_enum_variant("StopReason", &value)),
         })
     }
 }
@@ -7301,6 +7383,7 @@ impl IntoV1 for super::NesTriggerKind {
             Self::Automatic => crate::v1::NesTriggerKind::Automatic,
             Self::Diagnostic => crate::v1::NesTriggerKind::Diagnostic,
             Self::Manual => crate::v1::NesTriggerKind::Manual,
+            Self::Other(value) => return Err(unknown_v2_enum_variant("NesTriggerKind", &value)),
         })
     }
 }
@@ -7680,6 +7763,9 @@ impl IntoV1 for super::NesDiagnosticSeverity {
             Self::Warning => crate::v1::NesDiagnosticSeverity::Warning,
             Self::Information => crate::v1::NesDiagnosticSeverity::Information,
             Self::Hint => crate::v1::NesDiagnosticSeverity::Hint,
+            Self::Other(value) => {
+                return Err(unknown_v2_enum_variant("NesDiagnosticSeverity", &value));
+            }
         })
     }
 }
@@ -7735,6 +7821,9 @@ impl IntoV1 for super::NesSuggestion {
             Self::Rename(value) => crate::v1::NesSuggestion::Rename(value.into_v1()?),
             Self::SearchAndReplace(value) => {
                 crate::v1::NesSuggestion::SearchAndReplace(value.into_v1()?)
+            }
+            Self::Unknown(value) => {
+                return Err(unknown_v2_enum_variant("NesSuggestion", &value.kind));
             }
         })
     }
@@ -8020,6 +8109,7 @@ impl IntoV1 for super::NesRejectReason {
             Self::Ignored => crate::v1::NesRejectReason::Ignored,
             Self::Replaced => crate::v1::NesRejectReason::Replaced,
             Self::Cancelled => crate::v1::NesRejectReason::Cancelled,
+            Self::Other(value) => return Err(unknown_v2_enum_variant("NesRejectReason", &value)),
         })
     }
 }
@@ -8066,6 +8156,7 @@ impl IntoV1 for super::StringFormat {
             Self::Uri => crate::v1::StringFormat::Uri,
             Self::Date => crate::v1::StringFormat::Date,
             Self::DateTime => crate::v1::StringFormat::DateTime,
+            Self::Other(value) => return Err(unknown_v2_enum_variant("StringFormat", &value)),
         })
     }
 }
@@ -9056,6 +9147,9 @@ impl IntoV1 for super::ContentBlock {
             Self::Audio(value) => crate::v1::ContentBlock::Audio(value.into_v1()?),
             Self::ResourceLink(value) => crate::v1::ContentBlock::ResourceLink(value.into_v1()?),
             Self::Resource(value) => crate::v1::ContentBlock::Resource(value.into_v1()?),
+            Self::Unknown(value) => {
+                return Err(unknown_v2_enum_variant("ContentBlock", &value.type_));
+            }
         })
     }
 }
@@ -9427,6 +9521,7 @@ impl IntoV1 for super::Role {
         Ok(match self {
             Self::Assistant => crate::v1::Role::Assistant,
             Self::User => crate::v1::Role::User,
+            Self::Other(value) => return Err(unknown_v2_enum_variant("Role", &value)),
         })
     }
 }
@@ -9535,6 +9630,15 @@ mod tests {
         );
     }
 
+    fn assert_v2_to_v1_error<T>(value: T, expected: &str)
+    where
+        T: IntoV1,
+        T::Output: std::fmt::Debug,
+    {
+        let error = v2_to_v1(value).unwrap_err();
+        assert_eq!(error.message(), expected);
+    }
+
     #[test]
     fn converts_v2_initialize_request_to_v1_without_serde() {
         let request = v2::InitializeRequest::new(ProtocolVersion::V2);
@@ -9555,7 +9659,7 @@ mod tests {
 
     #[test]
     fn round_trips_initialize_request() {
-        let mut client_capabilities =
+        let client_capabilities =
             v1::ClientCapabilities::new()
                 .terminal(true)
                 .fs(v1::FileSystemCapabilities::new()
@@ -9563,10 +9667,8 @@ mod tests {
                     .write_text_file(true));
 
         #[cfg(feature = "unstable_plan_operations")]
-        {
-            client_capabilities =
-                client_capabilities.plan_capabilities(v1::PlanCapabilities::new());
-        }
+        let client_capabilities =
+            client_capabilities.plan_capabilities(v1::PlanCapabilities::new());
 
         let request = v1::InitializeRequest::new(ProtocolVersion::V1)
             .client_capabilities(client_capabilities)
@@ -9664,6 +9766,90 @@ mod tests {
                 notification,
             );
         }
+    }
+
+    #[test]
+    fn unknown_v2_session_update_does_not_convert_to_v1() {
+        let update = v2::SessionUpdate::Unknown(v2::UnknownSessionUpdate::new(
+            "_status_badge",
+            std::collections::BTreeMap::new(),
+        ));
+
+        assert_v2_to_v1_error(
+            update,
+            "v2 SessionUpdate variant `_status_badge` cannot be represented in v1",
+        );
+    }
+
+    #[test]
+    fn unknown_v2_variant_conversion_error_is_structured() {
+        let error = v2_to_v1(v2::Role::Other("_critic".to_string())).unwrap_err();
+
+        assert_eq!(
+            error.message(),
+            "v2 Role variant `_critic` cannot be represented in v1"
+        );
+        assert!(error.is_unsupported_v2_variant());
+        let unsupported = error.unsupported_v2_variant().unwrap();
+        assert_eq!(unsupported.type_name(), "Role");
+        assert_eq!(unsupported.value(), "_critic");
+    }
+
+    #[test]
+    fn unknown_v2_raw_fallbacks_do_not_convert_to_v1() {
+        assert_v2_to_v1_error(
+            v2::ContentBlock::Unknown(v2::UnknownContentBlock::new(
+                "_widget",
+                std::collections::BTreeMap::new(),
+            )),
+            "v2 ContentBlock variant `_widget` cannot be represented in v1",
+        );
+        assert_v2_to_v1_error(
+            v2::ToolCallContent::Unknown(v2::UnknownToolCallContent::new(
+                "_chart",
+                std::collections::BTreeMap::new(),
+            )),
+            "v2 ToolCallContent variant `_chart` cannot be represented in v1",
+        );
+        assert_v2_to_v1_error(
+            v2::AvailableCommandInput::Unknown(v2::UnknownAvailableCommandInput::new(
+                "_choices",
+                std::collections::BTreeMap::new(),
+            )),
+            "v2 AvailableCommandInput variant `_choices` cannot be represented in v1",
+        );
+        assert_v2_to_v1_error(
+            v2::SessionConfigKind::Unknown(v2::UnknownSessionConfigKind::new(
+                "_slider",
+                std::collections::BTreeMap::new(),
+            )),
+            "v2 SessionConfigKind variant `_slider` cannot be represented in v1",
+        );
+        assert_v2_to_v1_error(
+            v2::AuthMethod::Unknown(v2::UnknownAuthMethod::new(
+                "_oauth",
+                "oauth",
+                "OAuth",
+                std::collections::BTreeMap::new(),
+            )),
+            "v2 AuthMethod variant `_oauth` cannot be represented in v1",
+        );
+        #[cfg(feature = "unstable_plan_operations")]
+        assert_v2_to_v1_error(
+            v2::PlanUpdateContent::Unknown(v2::UnknownPlanUpdateContent::new(
+                "_timeline",
+                std::collections::BTreeMap::new(),
+            )),
+            "v2 PlanUpdateContent variant `_timeline` cannot be represented in v1",
+        );
+        #[cfg(feature = "unstable_nes")]
+        assert_v2_to_v1_error(
+            v2::NesSuggestion::Unknown(v2::UnknownNesSuggestion::new(
+                "_preview",
+                std::collections::BTreeMap::new(),
+            )),
+            "v2 NesSuggestion variant `_preview` cannot be represented in v1",
+        );
     }
 
     #[test]

--- a/src/v2/elicitation.rs
+++ b/src/v2/elicitation.rs
@@ -37,7 +37,7 @@ impl ElicitationId {
 }
 
 /// String format types for string properties in elicitation schemas.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum StringFormat {
@@ -49,6 +49,12 @@ pub enum StringFormat {
     Date,
     /// Date-time format (ISO 8601).
     DateTime,
+    /// Custom or future string format.
+    ///
+    /// Unknown formats are preserved. Implementations that do not understand a
+    /// format should treat it as an annotation rather than rejecting the schema.
+    #[serde(untagged)]
+    Other(String),
 }
 
 /// Type discriminator for elicitation schemas.

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -25,6 +25,7 @@ mod nes;
 mod plan;
 #[cfg(feature = "unstable_cancel_request")]
 mod protocol_level;
+pub(crate) mod schema_util;
 mod tool_call;
 
 pub use crate::rpc::{JsonRpcMessage, Notification, Request, RequestId};

--- a/src/v2/nes.rs
+++ b/src/v2/nes.rs
@@ -4,7 +4,9 @@
 //! document events, and a suggestion request/response flow. NES sessions are
 //! independent of chat sessions and have their own lifecycle.
 
-use schemars::JsonSchema;
+use std::collections::BTreeMap;
+
+use schemars::{JsonSchema, Schema};
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnError, VecSkipError, serde_as, skip_serializing_none};
 
@@ -1347,6 +1349,13 @@ pub enum NesTriggerKind {
     /// Triggered by an explicit user action (keyboard shortcut).
     #[serde(rename = "manual")]
     Manual,
+    /// Custom or future suggestion trigger kind.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(untagged)]
+    Other(String),
 }
 
 /// Request for a code suggestion.
@@ -1745,6 +1754,13 @@ pub enum NesDiagnosticSeverity {
     /// A hint.
     #[serde(rename = "hint")]
     Hint,
+    /// Custom or future diagnostic severity.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(untagged)]
+    Other(String),
 }
 
 // NES suggest response
@@ -1804,6 +1820,81 @@ pub enum NesSuggestion {
     Rename(NesRenameSuggestion),
     /// A search-and-replace suggestion.
     SearchAndReplace(NesSearchAndReplaceSuggestion),
+    /// Custom or future NES suggestion.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    ///
+    /// Receivers that do not understand this suggestion kind should preserve
+    /// the raw payload when storing, replaying, proxying, or forwarding
+    /// suggestions, and otherwise ignore it or display it generically.
+    #[serde(untagged)]
+    Unknown(UnknownNesSuggestion),
+}
+
+/// Custom or future NES suggestion payload.
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[schemars(inline)]
+#[schemars(transform = unknown_nes_suggestion_schema)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct UnknownNesSuggestion {
+    /// Custom or future NES suggestion kind.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    pub kind: String,
+    /// Additional fields from the unknown NES suggestion payload.
+    #[serde(flatten)]
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl UnknownNesSuggestion {
+    #[must_use]
+    pub fn new(kind: impl Into<String>, mut fields: BTreeMap<String, serde_json::Value>) -> Self {
+        fields.remove("kind");
+        Self {
+            kind: kind.into(),
+            fields,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for UnknownNesSuggestion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut fields = BTreeMap::<String, serde_json::Value>::deserialize(deserializer)?;
+        let kind = fields
+            .remove("kind")
+            .ok_or_else(|| serde::de::Error::missing_field("kind"))?;
+        let serde_json::Value::String(kind) = kind else {
+            return Err(serde::de::Error::custom("`kind` must be a string"));
+        };
+
+        if is_known_nes_suggestion_kind(&kind) {
+            return Err(serde::de::Error::custom(format!(
+                "known NES suggestion `{kind}` did not match its schema"
+            )));
+        }
+
+        Ok(Self { kind, fields })
+    }
+}
+
+fn is_known_nes_suggestion_kind(kind: &str) -> bool {
+    matches!(kind, "edit" | "jump" | "rename" | "searchAndReplace")
+}
+
+fn unknown_nes_suggestion_schema(schema: &mut Schema) {
+    super::schema_util::reject_known_string_discriminators(
+        schema,
+        "kind",
+        &["edit", "jump", "rename", "searchAndReplace"],
+    );
 }
 
 /// A text edit suggestion.
@@ -2076,6 +2167,13 @@ pub enum NesRejectReason {
     /// The request was cancelled before the agent returned a response.
     #[serde(rename = "cancelled")]
     Cancelled,
+    /// Custom or future rejection reason.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(untagged)]
+    Other(String),
 }
 
 #[cfg(test)]
@@ -2109,6 +2207,20 @@ mod tests {
         assert_eq!(
             serde_json::from_value::<PositionEncodingKind>(json!("utf-8")).unwrap(),
             PositionEncodingKind::Utf8
+        );
+        assert!(serde_json::from_value::<PositionEncodingKind>(json!("_future")).is_err());
+    }
+
+    #[test]
+    fn test_client_capabilities_skip_unknown_position_encodings() {
+        let caps: crate::v2::ClientCapabilities = serde_json::from_value(json!({
+            "positionEncodings": ["_future", "utf-8", "utf-16"]
+        }))
+        .unwrap();
+
+        assert_eq!(
+            caps.position_encodings,
+            vec![PositionEncodingKind::Utf8, PositionEncodingKind::Utf16]
         );
     }
 
@@ -2376,6 +2488,41 @@ mod tests {
     }
 
     #[test]
+    fn test_nes_suggestion_unknown_variant() {
+        let suggestion: NesSuggestion = serde_json::from_value(json!({
+            "kind": "_preview",
+            "id": "sugg_001",
+            "label": "Preview generated file"
+        }))
+        .unwrap();
+
+        let NesSuggestion::Unknown(unknown) = suggestion else {
+            panic!("expected unknown NES suggestion");
+        };
+
+        assert_eq!(unknown.kind, "_preview");
+        assert_eq!(unknown.fields.get("id"), Some(&json!("sugg_001")));
+        assert_eq!(
+            serde_json::to_value(NesSuggestion::Unknown(unknown)).unwrap(),
+            json!({
+                "kind": "_preview",
+                "id": "sugg_001",
+                "label": "Preview generated file"
+            })
+        );
+    }
+
+    #[test]
+    fn test_nes_suggestion_unknown_does_not_hide_malformed_known_variant() {
+        assert!(
+            serde_json::from_value::<NesSuggestion>(json!({
+                "kind": "edit"
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
     fn test_nes_suggestion_jump_serialization() {
         let suggestion = NesSuggestion::Jump(NesJumpSuggestion::new(
             "sugg_002",
@@ -2597,6 +2744,19 @@ mod tests {
             serde_json::to_value(&TextDocumentSyncKind::Incremental).unwrap(),
             json!("incremental")
         );
+        assert!(serde_json::from_value::<TextDocumentSyncKind>(json!("_future")).is_err());
+    }
+
+    #[test]
+    fn test_document_event_capabilities_drop_unknown_did_change_sync_kind() {
+        let caps: NesDocumentEventCapabilities = serde_json::from_value(json!({
+            "didChange": {
+                "syncKind": "_future"
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(caps.did_change, None);
     }
 
     #[test]

--- a/src/v2/nes.rs
+++ b/src/v2/nes.rs
@@ -1830,16 +1830,16 @@ pub enum NesSuggestion {
     /// the raw payload when storing, replaying, proxying, or forwarding
     /// suggestions, and otherwise ignore it or display it generically.
     #[serde(untagged)]
-    Unknown(UnknownNesSuggestion),
+    Other(OtherNesSuggestion),
 }
 
 /// Custom or future NES suggestion payload.
 #[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
 #[schemars(inline)]
-#[schemars(transform = unknown_nes_suggestion_schema)]
+#[schemars(transform = other_nes_suggestion_schema)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct UnknownNesSuggestion {
+pub struct OtherNesSuggestion {
     /// Custom or future NES suggestion kind.
     ///
     /// Values beginning with `_` are reserved for implementation-specific
@@ -1851,7 +1851,7 @@ pub struct UnknownNesSuggestion {
     pub fields: BTreeMap<String, serde_json::Value>,
 }
 
-impl UnknownNesSuggestion {
+impl OtherNesSuggestion {
     #[must_use]
     pub fn new(kind: impl Into<String>, mut fields: BTreeMap<String, serde_json::Value>) -> Self {
         fields.remove("kind");
@@ -1862,7 +1862,7 @@ impl UnknownNesSuggestion {
     }
 }
 
-impl<'de> Deserialize<'de> for UnknownNesSuggestion {
+impl<'de> Deserialize<'de> for OtherNesSuggestion {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -1889,7 +1889,7 @@ fn is_known_nes_suggestion_kind(kind: &str) -> bool {
     matches!(kind, "edit" | "jump" | "rename" | "searchAndReplace")
 }
 
-fn unknown_nes_suggestion_schema(schema: &mut Schema) {
+fn other_nes_suggestion_schema(schema: &mut Schema) {
     super::schema_util::reject_known_string_discriminators(
         schema,
         "kind",
@@ -2496,14 +2496,14 @@ mod tests {
         }))
         .unwrap();
 
-        let NesSuggestion::Unknown(unknown) = suggestion else {
+        let NesSuggestion::Other(unknown) = suggestion else {
             panic!("expected unknown NES suggestion");
         };
 
         assert_eq!(unknown.kind, "_preview");
         assert_eq!(unknown.fields.get("id"), Some(&json!("sugg_001")));
         assert_eq!(
-            serde_json::to_value(NesSuggestion::Unknown(unknown)).unwrap(),
+            serde_json::to_value(NesSuggestion::Other(unknown)).unwrap(),
             json!({
                 "kind": "_preview",
                 "id": "sugg_001",

--- a/src/v2/plan.rs
+++ b/src/v2/plan.rs
@@ -6,11 +6,13 @@
 //! See: [Agent Plan](https://agentclientprotocol.com/protocol/agent-plan)
 
 #[cfg(feature = "unstable_plan_operations")]
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 #[cfg(feature = "unstable_plan_operations")]
 use derive_more::{Display, From};
 use schemars::JsonSchema;
+#[cfg(feature = "unstable_plan_operations")]
+use schemars::Schema;
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnError, VecSkipError, serde_as, skip_serializing_none};
 
@@ -144,6 +146,87 @@ pub enum PlanUpdateContent {
     File(PlanFile),
     /// Raw markdown content for the plan.
     Markdown(PlanMarkdown),
+    /// Custom or future plan update content.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    ///
+    /// Receivers that do not understand this content type should preserve the
+    /// raw payload when storing, replaying, proxying, or forwarding plans, and
+    /// otherwise ignore it or display it generically.
+    #[serde(untagged)]
+    Unknown(UnknownPlanUpdateContent),
+}
+
+/// Custom or future plan update content payload.
+#[cfg(feature = "unstable_plan_operations")]
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[schemars(inline)]
+#[schemars(transform = unknown_plan_update_content_schema)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct UnknownPlanUpdateContent {
+    /// Custom or future plan update content type.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// Additional fields from the unknown plan update content payload.
+    #[serde(flatten)]
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+
+#[cfg(feature = "unstable_plan_operations")]
+impl UnknownPlanUpdateContent {
+    #[must_use]
+    pub fn new(type_: impl Into<String>, mut fields: BTreeMap<String, serde_json::Value>) -> Self {
+        fields.remove("type");
+        Self {
+            type_: type_.into(),
+            fields,
+        }
+    }
+}
+
+#[cfg(feature = "unstable_plan_operations")]
+impl<'de> Deserialize<'de> for UnknownPlanUpdateContent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut fields = BTreeMap::<String, serde_json::Value>::deserialize(deserializer)?;
+        let type_ = fields
+            .remove("type")
+            .ok_or_else(|| serde::de::Error::missing_field("type"))?;
+        let serde_json::Value::String(type_) = type_ else {
+            return Err(serde::de::Error::custom("`type` must be a string"));
+        };
+
+        if is_known_plan_update_content_type(&type_) {
+            return Err(serde::de::Error::custom(format!(
+                "known plan update content `{type_}` did not match its schema"
+            )));
+        }
+
+        Ok(Self { type_, fields })
+    }
+}
+
+#[cfg(feature = "unstable_plan_operations")]
+fn is_known_plan_update_content_type(type_: &str) -> bool {
+    matches!(type_, "items" | "file" | "markdown")
+}
+
+#[cfg(feature = "unstable_plan_operations")]
+fn unknown_plan_update_content_schema(schema: &mut Schema) {
+    super::schema_util::reject_known_string_discriminators(
+        schema,
+        "type",
+        &["items", "file", "markdown"],
+    );
 }
 
 #[cfg(feature = "unstable_plan_operations")]
@@ -461,6 +544,13 @@ pub enum PlanEntryPriority {
     Medium,
     /// Low priority task - nice to have but not essential.
     Low,
+    /// Custom or future plan entry priority.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(untagged)]
+    Other(String),
 }
 
 /// Status of a plan entry in the execution flow.
@@ -477,4 +567,65 @@ pub enum PlanEntryStatus {
     InProgress,
     /// The task has been successfully completed.
     Completed,
+    /// Custom or future plan entry status.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(untagged)]
+    Other(String),
+}
+
+#[cfg(all(test, feature = "unstable_plan_operations"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_entry_priority_preserves_unknown_variant() {
+        let priority: PlanEntryPriority = serde_json::from_str("\"urgent\"").unwrap();
+        assert_eq!(priority, PlanEntryPriority::Other("urgent".to_string()));
+        assert_eq!(serde_json::to_value(&priority).unwrap(), "urgent");
+    }
+
+    #[test]
+    fn plan_entry_status_preserves_unknown_variant() {
+        let status: PlanEntryStatus = serde_json::from_str("\"blocked\"").unwrap();
+        assert_eq!(status, PlanEntryStatus::Other("blocked".to_string()));
+        assert_eq!(serde_json::to_value(&status).unwrap(), "blocked");
+    }
+
+    #[test]
+    fn plan_update_content_preserves_unknown_variant() {
+        let content: PlanUpdateContent = serde_json::from_value(serde_json::json!({
+            "type": "_timeline",
+            "id": "plan-1",
+            "events": []
+        }))
+        .unwrap();
+
+        let PlanUpdateContent::Unknown(unknown) = content else {
+            panic!("expected unknown plan update content");
+        };
+
+        assert_eq!(unknown.type_, "_timeline");
+        assert_eq!(unknown.fields.get("id"), Some(&serde_json::json!("plan-1")));
+        assert_eq!(
+            serde_json::to_value(PlanUpdateContent::Unknown(unknown)).unwrap(),
+            serde_json::json!({
+                "type": "_timeline",
+                "id": "plan-1",
+                "events": []
+            })
+        );
+    }
+
+    #[test]
+    fn plan_update_content_does_not_hide_malformed_known_variant() {
+        assert!(
+            serde_json::from_value::<PlanUpdateContent>(serde_json::json!({
+                "type": "items"
+            }))
+            .is_err()
+        );
+    }
 }

--- a/src/v2/plan.rs
+++ b/src/v2/plan.rs
@@ -156,17 +156,17 @@ pub enum PlanUpdateContent {
     /// raw payload when storing, replaying, proxying, or forwarding plans, and
     /// otherwise ignore it or display it generically.
     #[serde(untagged)]
-    Unknown(UnknownPlanUpdateContent),
+    Other(OtherPlanUpdateContent),
 }
 
 /// Custom or future plan update content payload.
 #[cfg(feature = "unstable_plan_operations")]
 #[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
 #[schemars(inline)]
-#[schemars(transform = unknown_plan_update_content_schema)]
+#[schemars(transform = other_plan_update_content_schema)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct UnknownPlanUpdateContent {
+pub struct OtherPlanUpdateContent {
     /// Custom or future plan update content type.
     ///
     /// Values beginning with `_` are reserved for implementation-specific
@@ -180,7 +180,7 @@ pub struct UnknownPlanUpdateContent {
 }
 
 #[cfg(feature = "unstable_plan_operations")]
-impl UnknownPlanUpdateContent {
+impl OtherPlanUpdateContent {
     #[must_use]
     pub fn new(type_: impl Into<String>, mut fields: BTreeMap<String, serde_json::Value>) -> Self {
         fields.remove("type");
@@ -192,7 +192,7 @@ impl UnknownPlanUpdateContent {
 }
 
 #[cfg(feature = "unstable_plan_operations")]
-impl<'de> Deserialize<'de> for UnknownPlanUpdateContent {
+impl<'de> Deserialize<'de> for OtherPlanUpdateContent {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -221,7 +221,7 @@ fn is_known_plan_update_content_type(type_: &str) -> bool {
 }
 
 #[cfg(feature = "unstable_plan_operations")]
-fn unknown_plan_update_content_schema(schema: &mut Schema) {
+fn other_plan_update_content_schema(schema: &mut Schema) {
     super::schema_util::reject_known_string_discriminators(
         schema,
         "type",
@@ -603,14 +603,14 @@ mod tests {
         }))
         .unwrap();
 
-        let PlanUpdateContent::Unknown(unknown) = content else {
+        let PlanUpdateContent::Other(unknown) = content else {
             panic!("expected unknown plan update content");
         };
 
         assert_eq!(unknown.type_, "_timeline");
         assert_eq!(unknown.fields.get("id"), Some(&serde_json::json!("plan-1")));
         assert_eq!(
-            serde_json::to_value(PlanUpdateContent::Unknown(unknown)).unwrap(),
+            serde_json::to_value(PlanUpdateContent::Other(unknown)).unwrap(),
             serde_json::json!({
                 "type": "_timeline",
                 "id": "plan-1",

--- a/src/v2/schema_util.rs
+++ b/src/v2/schema_util.rs
@@ -1,0 +1,62 @@
+use schemars::Schema;
+use serde_json::json;
+
+pub(crate) fn reject_known_string_discriminators(
+    schema: &mut Schema,
+    property_name: &str,
+    known_values: &[&str],
+) {
+    let known_value_schemas: Vec<_> = known_values
+        .iter()
+        .map(|value| {
+            json!({
+                "properties": {
+                    property_name: {
+                        "const": value,
+                        "type": "string"
+                    }
+                },
+                "required": [property_name],
+                "type": "object"
+            })
+        })
+        .collect();
+
+    schema.insert(
+        "not".into(),
+        json!({
+            "anyOf": known_value_schemas
+        }),
+    );
+}
+
+pub(crate) fn reject_property(schema: &mut Schema, property_name: &str) {
+    schema.insert(
+        "not".into(),
+        json!({
+            "required": [property_name],
+            "type": "object"
+        }),
+    );
+}
+
+pub(crate) fn reject_string_property_except(
+    schema: &mut Schema,
+    property_name: &str,
+    allowed_value: &str,
+) {
+    schema.insert(
+        "not".into(),
+        json!({
+            "properties": {
+                property_name: {
+                    "not": {
+                        "const": allowed_value
+                    }
+                }
+            },
+            "required": [property_name],
+            "type": "object"
+        }),
+    );
+}

--- a/src/v2/tool_call.rs
+++ b/src/v2/tool_call.rs
@@ -493,16 +493,16 @@ pub enum ToolCallContent {
     /// raw payload when storing, replaying, proxying, or forwarding tool call
     /// output, and otherwise ignore it or display it generically.
     #[serde(untagged)]
-    Unknown(UnknownToolCallContent),
+    Other(OtherToolCallContent),
 }
 
 /// Custom or future tool call content payload.
 #[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
 #[schemars(inline)]
-#[schemars(transform = unknown_tool_call_content_schema)]
+#[schemars(transform = other_tool_call_content_schema)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct UnknownToolCallContent {
+pub struct OtherToolCallContent {
     /// Custom or future tool call content type.
     ///
     /// Values beginning with `_` are reserved for implementation-specific
@@ -515,7 +515,7 @@ pub struct UnknownToolCallContent {
     pub fields: BTreeMap<String, serde_json::Value>,
 }
 
-impl UnknownToolCallContent {
+impl OtherToolCallContent {
     #[must_use]
     pub fn new(type_: impl Into<String>, mut fields: BTreeMap<String, serde_json::Value>) -> Self {
         fields.remove("type");
@@ -526,7 +526,7 @@ impl UnknownToolCallContent {
     }
 }
 
-impl<'de> Deserialize<'de> for UnknownToolCallContent {
+impl<'de> Deserialize<'de> for OtherToolCallContent {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -553,7 +553,7 @@ fn is_known_tool_call_content_type(type_: &str) -> bool {
     matches!(type_, "content" | "diff" | "terminal")
 }
 
-fn unknown_tool_call_content_schema(schema: &mut Schema) {
+fn other_tool_call_content_schema(schema: &mut Schema) {
     super::schema_util::reject_known_string_discriminators(
         schema,
         "type",
@@ -788,7 +788,7 @@ mod tests {
         }))
         .unwrap();
 
-        let ToolCallContent::Unknown(unknown) = content else {
+        let ToolCallContent::Other(unknown) = content else {
             panic!("expected unknown tool call content");
         };
 
@@ -798,7 +798,7 @@ mod tests {
             Some(&serde_json::json!("Tests"))
         );
         assert_eq!(
-            serde_json::to_value(ToolCallContent::Unknown(unknown)).unwrap(),
+            serde_json::to_value(ToolCallContent::Other(unknown)).unwrap(),
             serde_json::json!({
                 "type": "_chart",
                 "title": "Tests",

--- a/src/v2/tool_call.rs
+++ b/src/v2/tool_call.rs
@@ -4,10 +4,10 @@
 //! running code, or fetching data—it generates tool calls that the agent executes on its behalf.
 //!
 /// See protocol docs: [Tool Calls](https://agentclientprotocol.com/protocol/tool-calls)
-use std::{path::PathBuf, sync::Arc};
+use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 
 use derive_more::{Display, From};
-use schemars::JsonSchema;
+use schemars::{JsonSchema, Schema};
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnError, VecSkipError, serde_as, skip_serializing_none};
 
@@ -388,7 +388,7 @@ impl IntoOption<ToolCallId> for &str {
 /// display tool execution progress.
 ///
 /// See protocol docs: [Creating](https://agentclientprotocol.com/protocol/tool-calls#creating)
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ToolKind {
@@ -412,12 +412,17 @@ pub enum ToolKind {
     SwitchMode,
     /// Other tool types (default).
     #[default]
-    #[serde(other)]
     Other,
+    /// Custom or future tool kind.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(untagged)]
+    Unknown(String),
 }
 
 impl ToolKind {
-    #[expect(clippy::trivially_copy_pass_by_ref, reason = "Required by serde")]
     fn is_default(&self) -> bool {
         matches!(self, ToolKind::Other)
     }
@@ -428,7 +433,7 @@ impl ToolKind {
 /// Tool calls progress through different statuses during their lifecycle.
 ///
 /// See protocol docs: [Status](https://agentclientprotocol.com/protocol/tool-calls#status)
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ToolCallStatus {
@@ -442,10 +447,16 @@ pub enum ToolCallStatus {
     Completed,
     /// The tool call failed with an error.
     Failed,
+    /// Custom or future tool call status.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(untagged)]
+    Other(String),
 }
 
 impl ToolCallStatus {
-    #[expect(clippy::trivially_copy_pass_by_ref, reason = "Required by serde")]
     fn is_default(&self) -> bool {
         matches!(self, ToolCallStatus::Pending)
     }
@@ -472,6 +483,82 @@ pub enum ToolCallContent {
     ///
     /// See protocol docs: [Terminal](https://agentclientprotocol.com/protocol/terminals)
     Terminal(Terminal),
+    /// Custom or future tool call content.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    ///
+    /// Receivers that do not understand this content type should preserve the
+    /// raw payload when storing, replaying, proxying, or forwarding tool call
+    /// output, and otherwise ignore it or display it generically.
+    #[serde(untagged)]
+    Unknown(UnknownToolCallContent),
+}
+
+/// Custom or future tool call content payload.
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+#[schemars(inline)]
+#[schemars(transform = unknown_tool_call_content_schema)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct UnknownToolCallContent {
+    /// Custom or future tool call content type.
+    ///
+    /// Values beginning with `_` are reserved for implementation-specific
+    /// extensions. Unknown values that do not begin with `_` are reserved for
+    /// future ACP variants.
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// Additional fields from the unknown tool call content payload.
+    #[serde(flatten)]
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl UnknownToolCallContent {
+    #[must_use]
+    pub fn new(type_: impl Into<String>, mut fields: BTreeMap<String, serde_json::Value>) -> Self {
+        fields.remove("type");
+        Self {
+            type_: type_.into(),
+            fields,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for UnknownToolCallContent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut fields = BTreeMap::<String, serde_json::Value>::deserialize(deserializer)?;
+        let type_ = fields
+            .remove("type")
+            .ok_or_else(|| serde::de::Error::missing_field("type"))?;
+        let serde_json::Value::String(type_) = type_ else {
+            return Err(serde::de::Error::custom("`type` must be a string"));
+        };
+
+        if is_known_tool_call_content_type(&type_) {
+            return Err(serde::de::Error::custom(format!(
+                "known tool call content `{type_}` did not match its schema"
+            )));
+        }
+
+        Ok(Self { type_, fields })
+    }
+}
+
+fn is_known_tool_call_content_type(type_: &str) -> bool {
+    matches!(type_, "content" | "diff" | "terminal")
+}
+
+fn unknown_tool_call_content_schema(schema: &mut Schema) {
+    super::schema_util::reject_known_string_discriminators(
+        schema,
+        "type",
+        &["content", "diff", "terminal"],
+    );
 }
 
 impl<T: Into<ContentBlock>> From<T> for ToolCallContent {
@@ -671,5 +758,62 @@ impl ToolCallLocation {
     pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
         self.meta = meta.into_option();
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_kind_preserves_unknown_variant() {
+        let kind: ToolKind = serde_json::from_str("\"review\"").unwrap();
+        assert_eq!(kind, ToolKind::Unknown("review".to_string()));
+        assert_eq!(serde_json::to_value(&kind).unwrap(), "review");
+    }
+
+    #[test]
+    fn tool_call_status_preserves_unknown_variant() {
+        let status: ToolCallStatus = serde_json::from_str("\"deferred\"").unwrap();
+        assert_eq!(status, ToolCallStatus::Other("deferred".to_string()));
+        assert_eq!(serde_json::to_value(&status).unwrap(), "deferred");
+    }
+
+    #[test]
+    fn tool_call_content_preserves_unknown_variant() {
+        let content: ToolCallContent = serde_json::from_value(serde_json::json!({
+            "type": "_chart",
+            "title": "Tests",
+            "data": [1, 2, 3]
+        }))
+        .unwrap();
+
+        let ToolCallContent::Unknown(unknown) = content else {
+            panic!("expected unknown tool call content");
+        };
+
+        assert_eq!(unknown.type_, "_chart");
+        assert_eq!(
+            unknown.fields.get("title"),
+            Some(&serde_json::json!("Tests"))
+        );
+        assert_eq!(
+            serde_json::to_value(ToolCallContent::Unknown(unknown)).unwrap(),
+            serde_json::json!({
+                "type": "_chart",
+                "title": "Tests",
+                "data": [1, 2, 3]
+            })
+        );
+    }
+
+    #[test]
+    fn tool_call_content_does_not_hide_malformed_known_variant() {
+        assert!(
+            serde_json::from_value::<ToolCallContent>(serde_json::json!({
+                "type": "diff"
+            }))
+            .is_err()
+        );
     }
 }


### PR DESCRIPTION
Makes the forward-compat enum setup consistent across the board
