### PR TITLE
Add ACPKit packages to docs

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -74,9 +74,9 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 - [OpenACP](https://github.com/Open-ACP/OpenACP) (Telegram, Discord, Slack) — self-hosted bridge for ACP agents; streams tool calls and responses in real time
 - [Telegram ACP Bot](https://github.com/mgaitan/telegram-acp-bot) (Telegram) — through the [`telegram-acp-bot`](https://github.com/mgaitan/telegram-acp-bot) connector
 - [Telegram-ACP](https://github.com/SuperKenVery/Telegram-ACP/) (Telegram) — Supports multi-thread chat and message streaming
+- [ACP Router](https://github.com/vcoderun/acprouter) (Telegram) - an ACP client surface for driving ACP agents from Telegram, with rich diffs, approvals and many more.
 - [WeChat ACP](https://github.com/formulahendry/wechat-acp) (WeChat)
 - [Sniptail](https://github.com/Justkog/sniptail) (Discord, Slack) - self-hosted chat bridge for running coding agents across your team’s repositories
-- [ACP Router](https://github.com/vcoderun/acprouter) (Telegram) - An ACP client surface for driving ACP agents from Telegram, with rich diffs, approvals and many more.
 
 
 
@@ -86,7 +86,7 @@ These frameworks add ACP support through dedicated integrations or adapters:
 
 - [AgentPool](https://phil65.github.io/agentpool/) — with built-in ACP integration for IDEs and external ACP agents
 - [fast-agent](https://fast-agent.ai/acp/) — through [`fast-agent-acp`](https://fast-agent.ai/acp/)
-- [ACP Kit](https://github.com/vcoderun/acpkit/) - Adapter toolkit for exposing existing Pydantic AI / LangChain agent runtimes through ACP.
+- [ACP Kit](https://github.com/vcoderun/acpkit/) - adapter toolkit for exposing existing [Pydantic AI](https://pypi.org/project/pydantic-acp/) / [LangChain](https://pypi.org/project/langchain-acp/) agent runtimes through ACP.
 - [Koog](https://docs.koog.ai/agent-client-protocol/) — through the [`agents-features-acp`](https://github.com/JetBrains/koog/tree/develop/examples/notebooks/acp) integration
 - [LangChain / LangGraph](https://docs.langchain.com/oss/python/deepagents/acp) — through [Deep Agents ACP](https://docs.langchain.com/oss/python/deepagents/acp)
 - [LlamaIndex](https://github.com/AstraBert/workflows-acp) — through the [`workflows-acp`](https://github.com/AstraBert/workflows-acp) adapter for Agent Workflows
@@ -99,6 +99,6 @@ These connectors bridge ACP into other environments and transport layers:
 - [ACP to AG-UI](https://github.com/namanrajpal/acp-to-agui) — bridges any ACP agent to web frontends via [AG-UI](https://docs.ag-ui.com) events over SSE; works with CopilotKit, AG-UI HttpAgent, or custom UIs (Web)
 - [AgentRQ](https://github.com/agentrq/acp-gateway) — bridges stdio-based ACP agents to the AgentRQ - Human-in-the-loop task collaboration service using MCP server.
 - [Aptove Bridge](https://github.com/aptove/bridge) — bridges stdio-based ACP agents to the Aptove mobile client over WebSocket
-- [ACP Remote](https://github.com/vcoderun/acpkit/tree/main/packages/transports/acpremote) - Remote WebSocket transport for ACP agents and clients.
+- [ACP Remote](https://github.com/vcoderun/acpkit/tree/main/packages/transports/acpremote) - remote WebSocket transport for ACP agents and clients.
 - [OpenClaw](https://docs.openclaw.ai/cli/acp) — through the [`openclaw acp`](https://docs.openclaw.ai/cli/acp) bridge to an OpenClaw Gateway
 - [stdio Bus](https://stdiobus.com) – deterministic stdio-based kernel providing transport-level routing for ACP/MCP-style agent protocols.

--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -67,6 +67,7 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 
 ## Messaging
 
+
 - [ACP Discord](https://github.com/broven/acp-discord) (Discord)
 - [duckdb-claude-slack](https://github.com/sidequery/duckdb-claude-slack) (Slack)
 - [Juan](https://github.com/DiscreteTom/juan) (Slack)
@@ -75,6 +76,9 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 - [Telegram-ACP](https://github.com/SuperKenVery/Telegram-ACP/) (Telegram) — Supports multi-thread chat and message streaming
 - [WeChat ACP](https://github.com/formulahendry/wechat-acp) (WeChat)
 - [Sniptail](https://github.com/Justkog/sniptail) (Discord, Slack) - self-hosted chat bridge for running coding agents across your team’s repositories
+- [ACP Router](https://github.com/vcoderun/acprouter) (Telegram) - An ACP client surface for driving ACP agents from Telegram, with rich diffs, approvals and many more.
+
+
 
 ## Frameworks
 
@@ -82,6 +86,7 @@ These frameworks add ACP support through dedicated integrations or adapters:
 
 - [AgentPool](https://phil65.github.io/agentpool/) — with built-in ACP integration for IDEs and external ACP agents
 - [fast-agent](https://fast-agent.ai/acp/) — through [`fast-agent-acp`](https://fast-agent.ai/acp/)
+- [ACP Kit](https://github.com/vcoderun/acpkit/) - Adapter toolkit for exposing existing Pydantic AI / LangChain agent runtimes through ACP.
 - [Koog](https://docs.koog.ai/agent-client-protocol/) — through the [`agents-features-acp`](https://github.com/JetBrains/koog/tree/develop/examples/notebooks/acp) integration
 - [LangChain / LangGraph](https://docs.langchain.com/oss/python/deepagents/acp) — through [Deep Agents ACP](https://docs.langchain.com/oss/python/deepagents/acp)
 - [LlamaIndex](https://github.com/AstraBert/workflows-acp) — through the [`workflows-acp`](https://github.com/AstraBert/workflows-acp) adapter for Agent Workflows
@@ -94,5 +99,6 @@ These connectors bridge ACP into other environments and transport layers:
 - [ACP to AG-UI](https://github.com/namanrajpal/acp-to-agui) — bridges any ACP agent to web frontends via [AG-UI](https://docs.ag-ui.com) events over SSE; works with CopilotKit, AG-UI HttpAgent, or custom UIs (Web)
 - [AgentRQ](https://github.com/agentrq/acp-gateway) — bridges stdio-based ACP agents to the AgentRQ - Human-in-the-loop task collaboration service using MCP server.
 - [Aptove Bridge](https://github.com/aptove/bridge) — bridges stdio-based ACP agents to the Aptove mobile client over WebSocket
+- [ACP Remote](https://github.com/vcoderun/acpkit/tree/main/packages/transports/acpremote) - Remote WebSocket transport for ACP agents and clients.
 - [OpenClaw](https://docs.openclaw.ai/cli/acp) — through the [`openclaw acp`](https://docs.openclaw.ai/cli/acp) bridge to an OpenClaw Gateway
 - [stdio Bus](https://stdiobus.com) – deterministic stdio-based kernel providing transport-level routing for ACP/MCP-style agent protocols.

--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -77,8 +77,6 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 - [WeChat ACP](https://github.com/formulahendry/wechat-acp) (WeChat)
 - [Sniptail](https://github.com/Justkog/sniptail) (Discord, Slack) - self-hosted chat bridge for running coding agents across your team’s repositories
 
-
-
 ## Frameworks
 
 These frameworks add ACP support through dedicated integrations or adapters:

--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -67,7 +67,6 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 
 ## Messaging
 
-
 - [ACP Discord](https://github.com/broven/acp-discord) (Discord)
 - [duckdb-claude-slack](https://github.com/sidequery/duckdb-claude-slack) (Slack)
 - [Juan](https://github.com/DiscreteTom/juan) (Slack)


### PR DESCRIPTION
Add main entry for `acpkit` exposing agents as ACP servers
Add sub entry for `acpremote` using ACP servers remotely
Add sub entry for `acprouter` using ACP servers in Telegram

More details in https://github.com/agentclientprotocol/registry/issues/290