### PR TITLE
docs: add Mastra to frameworks list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -86,6 +86,7 @@ These frameworks add ACP support through dedicated integrations or adapters:
 - [LangChain / LangGraph](https://docs.langchain.com/oss/python/deepagents/acp) — through [Deep Agents ACP](https://docs.langchain.com/oss/python/deepagents/acp)
 - [LlamaIndex](https://github.com/AstraBert/workflows-acp) — through the [`workflows-acp`](https://github.com/AstraBert/workflows-acp) adapter for Agent Workflows
 - [LLMling-Agent](https://github.com/phil65/llmling-agent) — with built-in ACP support for running agents through ACP clients
+- [Mastra](https://mastra.ai/docs/agents/acp) — through the [`@mastra/acp`](https://mastra.ai/docs/agents/acp) package for wrapping external ACP agents as tools or subagents
 
 ## Connectors
 


### PR DESCRIPTION
Adds [Mastra](https://mastra.ai/docs/agents/acp) to the **Frameworks** list in `docs/get-started/clients.mdx`.

Mastra integrates with ACP via the `@mastra/acp` package, which wraps external ACP agents (e.g. Claude Code) as tools or subagents while maintaining session context and file operations.

Listed alphabetically, after LLMling-Agent.