### PR TITLE
docs: add Bub to agents list

### DIFF
--- a/docs/get-started/agents.mdx
+++ b/docs/get-started/agents.mdx
@@ -9,6 +9,7 @@ The following agents can be used with an ACP Client:
 - [Augment Code](https://docs.augmentcode.com/cli/acp)
 - [AutoDev](https://github.com/phodal/auto-dev)
 - [Blackbox AI](https://docs.blackbox.ai/features/blackbox-cli/introduction)
+- [Bub](https://github.com/bubbuild/bub) (via [bub-acp-server](https://github.com/bubbuild/bub-contrib/tree/main/packages/bub-acp-server))
 - [Claude Agent](https://platform.claude.com/docs/en/agent-sdk/overview) (via [Zed's SDK adapter](https://github.com/zed-industries/claude-agent-acp))
 - [Cline](https://cline.bot/)
 - [Codex CLI](https://developers.openai.com/codex/cli) (via [Zed's adapter](https://github.com/zed-industries/codex-acp))


### PR DESCRIPTION
- [Bub](https://github.com/bubbuild/bub) is a small Python runtime for building agents (via [bub-acp-server](https://github.com/bubbuild/bub-contrib/tree/main/packages/bub-acp-server))
- Docs: [Use Bub as an ACP agent](https://bub.build/docs/tutorials/acp-server/)