### PR TITLE
feat(unstable): Remove unstable session model API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ unstable = [
     "unstable_session_additional_directories",
     "unstable_session_delete",
     "unstable_session_fork",
-    "unstable_session_model",
     "unstable_session_usage",
     "unstable_message_id",
     "unstable_boolean_config",
@@ -46,7 +45,6 @@ unstable_plan_operations = []
 unstable_session_additional_directories = []
 unstable_session_delete = []
 unstable_session_fork = []
-unstable_session_model = []
 unstable_session_usage = []
 unstable_message_id = []
 unstable_boolean_config = []

--- a/docs/protocol/draft/schema.mdx
+++ b/docs/protocol/draft/schema.mdx
@@ -1113,14 +1113,6 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 <ResponseField name="configOptions" type={<><span><a href="#sessionconfigoption">SessionConfigOption[]</a></span><span> | null</span></>} >
   Initial session configuration options if supported by the Agent.
 </ResponseField>
-<ResponseField name="models" type={<><span><a href="#sessionmodelstate">SessionModelState</a></span><span> | null</span></>} >
-  **UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-Initial model state if supported by the Agent
-
-</ResponseField>
 <ResponseField name="modes" type={<><span><a href="#sessionmodestate">SessionModeState</a></span><span> | null</span></>} >
   Initial mode state if supported by the Agent
 
@@ -1266,14 +1258,6 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 <ResponseField name="configOptions" type={<><span><a href="#sessionconfigoption">SessionConfigOption[]</a></span><span> | null</span></>} >
   Initial session configuration options if supported by the Agent.
 </ResponseField>
-<ResponseField name="models" type={<><span><a href="#sessionmodelstate">SessionModelState</a></span><span> | null</span></>} >
-  **UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-Initial model state if supported by the Agent
-
-</ResponseField>
 <ResponseField name="modes" type={<><span><a href="#sessionmodestate">SessionModeState</a></span><span> | null</span></>} >
   Initial mode state if supported by the Agent
 
@@ -1355,14 +1339,6 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </ResponseField>
 <ResponseField name="configOptions" type={<><span><a href="#sessionconfigoption">SessionConfigOption[]</a></span><span> | null</span></>} >
   Initial session configuration options if supported by the Agent.
-</ResponseField>
-<ResponseField name="models" type={<><span><a href="#sessionmodelstate">SessionModelState</a></span><span> | null</span></>} >
-  **UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-Initial model state if supported by the Agent
-
 </ResponseField>
 <ResponseField name="modes" type={<><span><a href="#sessionmodestate">SessionModeState</a></span><span> | null</span></>} >
   Initial mode state if supported by the Agent
@@ -1560,14 +1536,6 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 <ResponseField name="configOptions" type={<><span><a href="#sessionconfigoption">SessionConfigOption[]</a></span><span> | null</span></>} >
   Initial session configuration options if supported by the Agent.
 </ResponseField>
-<ResponseField name="models" type={<><span><a href="#sessionmodelstate">SessionModelState</a></span><span> | null</span></>} >
-  **UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-Initial model state if supported by the Agent
-
-</ResponseField>
 <ResponseField name="modes" type={<><span><a href="#sessionmodestate">SessionModeState</a></span><span> | null</span></>} >
   Initial mode state if supported by the Agent
 
@@ -1703,63 +1671,6 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 #### <span class="font-mono">SetSessionModeResponse</span>
 
 Response to `session/set_mode` method.
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField name="_meta" type={"object | null"} >
-  The _meta property is reserved by ACP to allow clients and agents to attach additional
-metadata to their interactions. Implementations MUST NOT make assumptions about values at
-these keys.
-
-See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-
-</ResponseField>
-
-<a id="session-set_model"></a>
-### <span class="font-mono">session/set_model</span>
-
-**UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-Select a model for a given session.
-
-#### <span class="font-mono">SetSessionModelRequest</span>
-
-**UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-Request parameters for setting a session model.
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField name="_meta" type={"object | null"} >
-  The _meta property is reserved by ACP to allow clients and agents to attach additional
-metadata to their interactions. Implementations MUST NOT make assumptions about values at
-these keys.
-
-See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-
-</ResponseField>
-<ResponseField name="modelId" type={<a href="#modelid">ModelId</a>} required>
-  The ID of the model to set.
-</ResponseField>
-<ResponseField name="sessionId" type={<a href="#sessionid">SessionId</a>} required>
-  The ID of the session to set the model for.
-</ResponseField>
-
-#### <span class="font-mono">SetSessionModelResponse</span>
-
-**UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-Response to `session/set_model` method.
 
 **Type:** Object
 
@@ -4999,46 +4910,6 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
   Human-readable name identifying this MCP server.
 </ResponseField>
 
-## <span class="font-mono">ModelId</span>
-
-**UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-A unique identifier for a model.
-
-**Type:** `string`
-
-## <span class="font-mono">ModelInfo</span>
-
-**UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-Information about a selectable model.
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField name="_meta" type={"object | null"} >
-  The _meta property is reserved by ACP to allow clients and agents to attach additional
-metadata to their interactions. Implementations MUST NOT make assumptions about values at
-these keys.
-
-See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-
-</ResponseField>
-<ResponseField name="description" type={"string | null"} >
-  Optional description of the model.
-</ResponseField>
-<ResponseField name="modelId" type={<a href="#modelid">ModelId</a>} required>
-  Unique identifier for the model.
-</ResponseField>
-<ResponseField name="name" type={"string"} required>
-  Human-readable name of the model.
-</ResponseField>
-
 ## <span class="font-mono">MultiSelectItems</span>
 
 Items for a multi-select (array) property schema.
@@ -7295,33 +7166,6 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/exte
 </ResponseField>
 <ResponseField name="currentModeId" type={<a href="#sessionmodeid">SessionModeId</a>} required>
   The current mode the Agent is in.
-</ResponseField>
-
-## <span class="font-mono">SessionModelState</span>
-
-**UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-The set of models and the one currently active.
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField name="_meta" type={"object | null"} >
-  The _meta property is reserved by ACP to allow clients and agents to attach additional
-metadata to their interactions. Implementations MUST NOT make assumptions about values at
-these keys.
-
-See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-
-</ResponseField>
-<ResponseField name="availableModels" type={<a href="#modelinfo">ModelInfo[]</a>} required>
-  The set of models that the Agent can use
-</ResponseField>
-<ResponseField name="currentModelId" type={<a href="#modelid">ModelId</a>} required>
-  The current model the Agent is in.
 </ResponseField>
 
 ## <span class="font-mono">SessionResumeCapabilities</span>

--- a/docs/rfds/updates.mdx
+++ b/docs/rfds/updates.mdx
@@ -6,6 +6,13 @@ rss: true
 
 This page tracks lifecycle changes for ACP Requests for Dialog. For broader ACP announcements, see [Updates](/updates).
 
+<Update label="June 1, 2026" tags={["Removed"]}>
+## Unstable Session Model API removed
+
+The never-stabilized `session/set_model` API and related session model response fields have been removed from the protocol artifacts. Agents should continue to expose model selection through [Session Config Options](/rfds/session-config-options).
+
+</Update>
+
 <Update label="May 27, 2026" tags={["Draft"]}>
 ## v2 Enum Variant Extension RFD moves to Draft stage
 

--- a/docs/rfds/v2/overview.mdx
+++ b/docs/rfds/v2/overview.mdx
@@ -39,8 +39,7 @@ Other RFDs will progress separately and are not dependent on breaking changes (s
 ### v2 Changes
 
 - Remove the dedicated session modes API from v2. This includes the `modes` session response fields, `session/set_mode`, `current_mode_update`, and the `SessionMode*` types.
-- Remove the unstable session model API from v2. This includes the `models` session response fields, `session/set_model`, `SessionModelState`, `ModelInfo`, and `ModelId`.
-- Agents should expose mode-like and model-related state through [Session Config Options](../session-config-options.mdx) instead.
+- Agents should expose mode-like and model-related state through [Session Config Options](../session-config-options.mdx) instead of dedicated mode or model selector APIs.
 
 ### RFDs to be Written
 
@@ -90,5 +89,6 @@ With the needed breaking changes, as much as possible I am targeting having a co
 
 ## Revision history
 
-2026-05-28: Recorded the v2 decision to remove session modes and unstable session models in favor of session config options
+2026-06-01: Recorded that model selection should remain represented by session config options instead of a dedicated selector API.
+2026-05-28: Recorded the v2 decision to remove session modes in favor of session config options
 2026-05-06: Initial draft

--- a/schema/meta.unstable.json
+++ b/schema/meta.unstable.json
@@ -27,8 +27,7 @@
     "session_prompt": "session/prompt",
     "session_resume": "session/resume",
     "session_set_config_option": "session/set_config_option",
-    "session_set_mode": "session/set_mode",
-    "session_set_model": "session/set_model"
+    "session_set_mode": "session/set_mode"
   },
   "clientMethods": {
     "elicitation_complete": "elicitation/complete",

--- a/schema/schema.unstable.json
+++ b/schema/schema.unstable.json
@@ -480,14 +480,6 @@
                 {
                   "allOf": [
                     {
-                      "$ref": "#/$defs/SetSessionModelResponse"
-                    }
-                  ],
-                  "title": "SetSessionModelResponse"
-                },
-                {
-                  "allOf": [
-                    {
                       "$ref": "#/$defs/StartNesResponse"
                     }
                   ],
@@ -1358,15 +1350,6 @@
                   ],
                   "description": "Processes a user prompt within a session.\n\nThis method handles the whole lifecycle of a prompt:\n- Receives user messages with optional context (files, images, etc.)\n- Processes the prompt using language models\n- Reports language model content and tool calls to the Clients\n- Requests permission to run tools\n- Executes any requested tool calls\n- Returns when the turn is complete with a stop reason\n\nSee protocol docs: [Prompt Turn](https://agentclientprotocol.com/protocol/prompt-turn)",
                   "title": "PromptRequest"
-                },
-                {
-                  "allOf": [
-                    {
-                      "$ref": "#/$defs/SetSessionModelRequest"
-                    }
-                  ],
-                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nSelect a model for a given session.",
-                  "title": "SetSessionModelRequest"
                 },
                 {
                   "allOf": [
@@ -2991,17 +2974,6 @@
           },
           "type": ["array", "null"]
         },
-        "models": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SessionModelState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nInitial model state if supported by the Agent"
-        },
         "modes": {
           "anyOf": [
             {
@@ -3455,17 +3427,6 @@
           },
           "type": ["array", "null"]
         },
-        "models": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SessionModelState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nInitial model state if supported by the Agent"
-        },
         "modes": {
           "anyOf": [
             {
@@ -3793,38 +3754,6 @@
       "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nResponse to `mcp/message`.\n\nThis is the inner MCP response result payload. Any JSON value is valid.",
       "x-method": "mcp/message",
       "x-side": "both"
-    },
-    "ModelId": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nA unique identifier for a model.",
-      "type": "string"
-    },
-    "ModelInfo": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nInformation about a selectable model.",
-      "properties": {
-        "_meta": {
-          "additionalProperties": true,
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-          "type": ["object", "null"]
-        },
-        "description": {
-          "description": "Optional description of the model.",
-          "type": ["string", "null"]
-        },
-        "modelId": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/ModelId"
-            }
-          ],
-          "description": "Unique identifier for the model."
-        },
-        "name": {
-          "description": "Human-readable name of the model.",
-          "type": "string"
-        }
-      },
-      "required": ["modelId", "name"],
-      "type": "object"
     },
     "MultiSelectItems": {
       "anyOf": [
@@ -4827,17 +4756,6 @@
           },
           "type": ["array", "null"]
         },
-        "models": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SessionModelState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nInitial model state if supported by the Agent"
-        },
         "modes": {
           "anyOf": [
             {
@@ -5802,17 +5720,6 @@
           },
           "type": ["array", "null"]
         },
-        "models": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SessionModelState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nInitial model state if supported by the Agent"
-        },
         "modes": {
           "anyOf": [
             {
@@ -6327,33 +6234,6 @@
       "required": ["currentModeId", "availableModes"],
       "type": "object"
     },
-    "SessionModelState": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe set of models and the one currently active.",
-      "properties": {
-        "_meta": {
-          "additionalProperties": true,
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-          "type": ["object", "null"]
-        },
-        "availableModels": {
-          "description": "The set of models that the Agent can use",
-          "items": {
-            "$ref": "#/$defs/ModelInfo"
-          },
-          "type": "array"
-        },
-        "currentModelId": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/ModelId"
-            }
-          ],
-          "description": "The current model the Agent is in."
-        }
-      },
-      "required": ["currentModelId", "availableModels"],
-      "type": "object"
-    },
     "SessionNotification": {
       "description": "Notification containing a session update from the agent.\n\nUsed to stream real-time progress and results during prompt processing.\n\nSee protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protocol/prompt-turn#3-agent-reports-output)",
       "properties": {
@@ -6786,49 +6666,6 @@
       },
       "type": "object",
       "x-method": "session/set_mode",
-      "x-side": "agent"
-    },
-    "SetSessionModelRequest": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest parameters for setting a session model.",
-      "properties": {
-        "_meta": {
-          "additionalProperties": true,
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-          "type": ["object", "null"]
-        },
-        "modelId": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/ModelId"
-            }
-          ],
-          "description": "The ID of the model to set."
-        },
-        "sessionId": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/SessionId"
-            }
-          ],
-          "description": "The ID of the session to set the model for."
-        }
-      },
-      "required": ["sessionId", "modelId"],
-      "type": "object",
-      "x-method": "session/set_model",
-      "x-side": "agent"
-    },
-    "SetSessionModelResponse": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nResponse to `session/set_model` method.",
-      "properties": {
-        "_meta": {
-          "additionalProperties": true,
-          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
-          "type": ["object", "null"]
-        }
-      },
-      "type": "object",
-      "x-method": "session/set_model",
       "x-side": "agent"
     },
     "StartNesRequest": {

--- a/src/bin/generate.rs
+++ b/src/bin/generate.rs
@@ -1279,7 +1279,6 @@ starting with '$/' it is free to ignore the notification."
                 }
                 "session/prompt" => self.agent.get("PromptRequest").unwrap(),
                 "session/cancel" => self.agent.get("CancelNotification").unwrap(),
-                "session/set_model" => self.agent.get("SetSessionModelRequest").unwrap(),
                 "session/close" => self.agent.get("CloseSessionRequest").unwrap(),
                 "logout" => self.agent.get("LogoutRequest").unwrap(),
                 "nes/start" => self.agent.get("StartNesRequest").unwrap(),

--- a/src/v1/agent.rs
+++ b/src/v1/agent.rs
@@ -993,15 +993,6 @@ pub struct NewSessionResponse {
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[serde(default)]
     pub modes: Option<SessionModeState>,
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// Initial model state if supported by the Agent
-    #[cfg(feature = "unstable_session_model")]
-    #[serde_as(deserialize_as = "DefaultOnError")]
-    #[serde(default)]
-    pub models: Option<SessionModelState>,
     /// Initial session configuration options if supported by the Agent.
     #[serde_as(deserialize_as = "DefaultOnError<Option<VecSkipError<_, SkipListener>>>")]
     #[serde(default)]
@@ -1021,8 +1012,6 @@ impl NewSessionResponse {
         Self {
             session_id: session_id.into(),
             modes: None,
-            #[cfg(feature = "unstable_session_model")]
-            models: None,
             config_options: None,
             meta: None,
         }
@@ -1034,18 +1023,6 @@ impl NewSessionResponse {
     #[must_use]
     pub fn modes(mut self, modes: impl IntoOption<SessionModeState>) -> Self {
         self.modes = modes.into_option();
-        self
-    }
-
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// Initial model state if supported by the Agent
-    #[cfg(feature = "unstable_session_model")]
-    #[must_use]
-    pub fn models(mut self, models: impl IntoOption<SessionModelState>) -> Self {
-        self.models = models.into_option();
         self
     }
 
@@ -1170,15 +1147,6 @@ pub struct LoadSessionResponse {
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[serde(default)]
     pub modes: Option<SessionModeState>,
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// Initial model state if supported by the Agent
-    #[cfg(feature = "unstable_session_model")]
-    #[serde_as(deserialize_as = "DefaultOnError")]
-    #[serde(default)]
-    pub models: Option<SessionModelState>,
     /// Initial session configuration options if supported by the Agent.
     #[serde_as(deserialize_as = "DefaultOnError<Option<VecSkipError<_, SkipListener>>>")]
     #[serde(default)]
@@ -1204,18 +1172,6 @@ impl LoadSessionResponse {
     #[must_use]
     pub fn modes(mut self, modes: impl IntoOption<SessionModeState>) -> Self {
         self.modes = modes.into_option();
-        self
-    }
-
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// Initial model state if supported by the Agent
-    #[cfg(feature = "unstable_session_model")]
-    #[must_use]
-    pub fn models(mut self, models: impl IntoOption<SessionModelState>) -> Self {
-        self.models = models.into_option();
         self
     }
 
@@ -1354,15 +1310,6 @@ pub struct ForkSessionResponse {
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[serde(default)]
     pub modes: Option<SessionModeState>,
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// Initial model state if supported by the Agent
-    #[cfg(feature = "unstable_session_model")]
-    #[serde_as(deserialize_as = "DefaultOnError")]
-    #[serde(default)]
-    pub models: Option<SessionModelState>,
     /// Initial session configuration options if supported by the Agent.
     #[serde_as(deserialize_as = "DefaultOnError<Option<VecSkipError<_, SkipListener>>>")]
     #[serde(default)]
@@ -1383,8 +1330,6 @@ impl ForkSessionResponse {
         Self {
             session_id: session_id.into(),
             modes: None,
-            #[cfg(feature = "unstable_session_model")]
-            models: None,
             config_options: None,
             meta: None,
         }
@@ -1396,18 +1341,6 @@ impl ForkSessionResponse {
     #[must_use]
     pub fn modes(mut self, modes: impl IntoOption<SessionModeState>) -> Self {
         self.modes = modes.into_option();
-        self
-    }
-
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// Initial model state if supported by the Agent
-    #[cfg(feature = "unstable_session_model")]
-    #[must_use]
-    pub fn models(mut self, models: impl IntoOption<SessionModelState>) -> Self {
-        self.models = models.into_option();
         self
     }
 
@@ -1534,15 +1467,6 @@ pub struct ResumeSessionResponse {
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[serde(default)]
     pub modes: Option<SessionModeState>,
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// Initial model state if supported by the Agent
-    #[cfg(feature = "unstable_session_model")]
-    #[serde_as(deserialize_as = "DefaultOnError")]
-    #[serde(default)]
-    pub models: Option<SessionModelState>,
     /// Initial session configuration options if supported by the Agent.
     #[serde_as(deserialize_as = "DefaultOnError<Option<VecSkipError<_, SkipListener>>>")]
     #[serde(default)]
@@ -1568,18 +1492,6 @@ impl ResumeSessionResponse {
     #[must_use]
     pub fn modes(mut self, modes: impl IntoOption<SessionModeState>) -> Self {
         self.modes = modes.into_option();
-        self
-    }
-
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// Initial model state if supported by the Agent
-    #[cfg(feature = "unstable_session_model")]
-    #[must_use]
-    pub fn models(mut self, models: impl IntoOption<SessionModelState>) -> Self {
-        self.models = models.into_option();
         self
     }
 
@@ -3350,223 +3262,6 @@ impl Usage {
     }
 }
 
-// Model
-
-/// **UNSTABLE**
-///
-/// This capability is not part of the spec yet, and may be removed or changed at any point.
-///
-/// The set of models and the one currently active.
-#[cfg(feature = "unstable_session_model")]
-#[serde_as]
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct SessionModelState {
-    /// The current model the Agent is in.
-    pub current_model_id: ModelId,
-    /// The set of models that the Agent can use
-    #[serde_as(deserialize_as = "DefaultOnError<VecSkipError<_, SkipListener>>")]
-    pub available_models: Vec<ModelInfo>,
-    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
-    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    /// these keys.
-    ///
-    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    #[serde(rename = "_meta")]
-    pub meta: Option<Meta>,
-}
-
-#[cfg(feature = "unstable_session_model")]
-impl SessionModelState {
-    #[must_use]
-    pub fn new(current_model_id: impl Into<ModelId>, available_models: Vec<ModelInfo>) -> Self {
-        Self {
-            current_model_id: current_model_id.into(),
-            available_models,
-            meta: None,
-        }
-    }
-
-    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
-    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    /// these keys.
-    ///
-    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    #[must_use]
-    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
-        self.meta = meta.into_option();
-        self
-    }
-}
-
-/// **UNSTABLE**
-///
-/// This capability is not part of the spec yet, and may be removed or changed at any point.
-///
-/// A unique identifier for a model.
-#[cfg(feature = "unstable_session_model")]
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash, Display, From)]
-#[serde(transparent)]
-#[from(Arc<str>, String, &'static str)]
-#[non_exhaustive]
-pub struct ModelId(pub Arc<str>);
-
-#[cfg(feature = "unstable_session_model")]
-impl ModelId {
-    #[must_use]
-    pub fn new(id: impl Into<Arc<str>>) -> Self {
-        Self(id.into())
-    }
-}
-
-/// **UNSTABLE**
-///
-/// This capability is not part of the spec yet, and may be removed or changed at any point.
-///
-/// Information about a selectable model.
-#[cfg(feature = "unstable_session_model")]
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct ModelInfo {
-    /// Unique identifier for the model.
-    pub model_id: ModelId,
-    /// Human-readable name of the model.
-    pub name: String,
-    /// Optional description of the model.
-    #[serde(default)]
-    pub description: Option<String>,
-    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
-    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    /// these keys.
-    ///
-    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    #[serde(rename = "_meta")]
-    pub meta: Option<Meta>,
-}
-
-#[cfg(feature = "unstable_session_model")]
-impl ModelInfo {
-    #[must_use]
-    pub fn new(model_id: impl Into<ModelId>, name: impl Into<String>) -> Self {
-        Self {
-            model_id: model_id.into(),
-            name: name.into(),
-            description: None,
-            meta: None,
-        }
-    }
-
-    /// Optional description of the model.
-    #[must_use]
-    pub fn description(mut self, description: impl IntoOption<String>) -> Self {
-        self.description = description.into_option();
-        self
-    }
-
-    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
-    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    /// these keys.
-    ///
-    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    #[must_use]
-    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
-        self.meta = meta.into_option();
-        self
-    }
-}
-
-/// **UNSTABLE**
-///
-/// This capability is not part of the spec yet, and may be removed or changed at any point.
-///
-/// Request parameters for setting a session model.
-#[cfg(feature = "unstable_session_model")]
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[schemars(extend("x-side" = "agent", "x-method" = SESSION_SET_MODEL_METHOD_NAME))]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct SetSessionModelRequest {
-    /// The ID of the session to set the model for.
-    pub session_id: SessionId,
-    /// The ID of the model to set.
-    pub model_id: ModelId,
-    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
-    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    /// these keys.
-    ///
-    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    #[serde(rename = "_meta")]
-    pub meta: Option<Meta>,
-}
-
-#[cfg(feature = "unstable_session_model")]
-impl SetSessionModelRequest {
-    #[must_use]
-    pub fn new(session_id: impl Into<SessionId>, model_id: impl Into<ModelId>) -> Self {
-        Self {
-            session_id: session_id.into(),
-            model_id: model_id.into(),
-            meta: None,
-        }
-    }
-
-    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
-    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    /// these keys.
-    ///
-    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    #[must_use]
-    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
-        self.meta = meta.into_option();
-        self
-    }
-}
-
-/// **UNSTABLE**
-///
-/// This capability is not part of the spec yet, and may be removed or changed at any point.
-///
-/// Response to `session/set_model` method.
-#[cfg(feature = "unstable_session_model")]
-#[skip_serializing_none]
-#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[schemars(extend("x-side" = "agent", "x-method" = SESSION_SET_MODEL_METHOD_NAME))]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct SetSessionModelResponse {
-    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
-    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    /// these keys.
-    ///
-    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    #[serde(rename = "_meta")]
-    pub meta: Option<Meta>,
-}
-
-#[cfg(feature = "unstable_session_model")]
-impl SetSessionModelResponse {
-    #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
-    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
-    /// these keys.
-    ///
-    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    #[must_use]
-    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
-        self.meta = meta.into_option();
-        self
-    }
-}
-
 // Providers
 
 /// **UNSTABLE**
@@ -4729,9 +4424,6 @@ pub struct AgentMethodNames {
     /// Method for exchanging MCP-over-ACP messages.
     #[cfg(feature = "unstable_mcp_over_acp")]
     pub mcp_message: &'static str,
-    /// Method for selecting a model for a given session.
-    #[cfg(feature = "unstable_session_model")]
-    pub session_set_model: &'static str,
     /// Method for listing existing sessions.
     pub session_list: &'static str,
     /// Method for deleting an existing session.
@@ -4796,8 +4488,6 @@ pub const AGENT_METHOD_NAMES: AgentMethodNames = AgentMethodNames {
     session_cancel: SESSION_CANCEL_METHOD_NAME,
     #[cfg(feature = "unstable_mcp_over_acp")]
     mcp_message: MCP_MESSAGE_METHOD_NAME,
-    #[cfg(feature = "unstable_session_model")]
-    session_set_model: SESSION_SET_MODEL_METHOD_NAME,
     session_list: SESSION_LIST_METHOD_NAME,
     #[cfg(feature = "unstable_session_delete")]
     session_delete: SESSION_DELETE_METHOD_NAME,
@@ -4853,9 +4543,6 @@ pub(crate) const SESSION_SET_CONFIG_OPTION_METHOD_NAME: &str = "session/set_conf
 pub(crate) const SESSION_PROMPT_METHOD_NAME: &str = "session/prompt";
 /// Method name for the cancel notification.
 pub(crate) const SESSION_CANCEL_METHOD_NAME: &str = "session/cancel";
-/// Method name for selecting a model for a given session.
-#[cfg(feature = "unstable_session_model")]
-pub(crate) const SESSION_SET_MODEL_METHOD_NAME: &str = "session/set_model";
 /// Method name for listing existing sessions.
 pub(crate) const SESSION_LIST_METHOD_NAME: &str = "session/list";
 /// Method name for deleting an existing session.
@@ -5024,13 +4711,6 @@ pub enum ClientRequest {
     ///
     /// See protocol docs: [Prompt Turn](https://agentclientprotocol.com/protocol/prompt-turn)
     PromptRequest(PromptRequest),
-    #[cfg(feature = "unstable_session_model")]
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// Select a model for a given session.
-    SetSessionModelRequest(SetSessionModelRequest),
     #[cfg(feature = "unstable_nes")]
     /// **UNSTABLE**
     ///
@@ -5097,8 +4777,6 @@ impl ClientRequest {
             Self::SetSessionModeRequest(_) => AGENT_METHOD_NAMES.session_set_mode,
             Self::SetSessionConfigOptionRequest(_) => AGENT_METHOD_NAMES.session_set_config_option,
             Self::PromptRequest(_) => AGENT_METHOD_NAMES.session_prompt,
-            #[cfg(feature = "unstable_session_model")]
-            Self::SetSessionModelRequest(_) => AGENT_METHOD_NAMES.session_set_model,
             #[cfg(feature = "unstable_nes")]
             Self::StartNesRequest(_) => AGENT_METHOD_NAMES.nes_start,
             #[cfg(feature = "unstable_nes")]
@@ -5145,8 +4823,6 @@ pub enum AgentResponse {
     SetSessionModeResponse(#[serde(default)] SetSessionModeResponse),
     SetSessionConfigOptionResponse(SetSessionConfigOptionResponse),
     PromptResponse(PromptResponse),
-    #[cfg(feature = "unstable_session_model")]
-    SetSessionModelResponse(#[serde(default)] SetSessionModelResponse),
     #[cfg(feature = "unstable_nes")]
     StartNesResponse(StartNesResponse),
     #[cfg(feature = "unstable_nes")]

--- a/src/v2/conversion.rs
+++ b/src/v2/conversion.rs
@@ -3516,8 +3516,6 @@ impl IntoV1 for super::NewSessionResponse {
         Ok(crate::v1::NewSessionResponse {
             session_id: session_id.into_v1()?,
             modes: None,
-            #[cfg(feature = "unstable_session_model")]
-            models: None,
             config_options: config_options.into_v1()?,
             meta: meta.into_v1()?,
         })
@@ -3531,8 +3529,6 @@ impl IntoV2 for crate::v1::NewSessionResponse {
         let Self {
             session_id,
             modes: _,
-            #[cfg(feature = "unstable_session_model")]
-                models: _,
             config_options,
             meta,
         } = self;
@@ -3600,8 +3596,6 @@ impl IntoV1 for super::LoadSessionResponse {
         } = self;
         Ok(crate::v1::LoadSessionResponse {
             modes: None,
-            #[cfg(feature = "unstable_session_model")]
-            models: None,
             config_options: config_options.into_v1()?,
             meta: meta.into_v1()?,
         })
@@ -3614,8 +3608,6 @@ impl IntoV2 for crate::v1::LoadSessionResponse {
     fn into_v2(self) -> Result<Self::Output> {
         let Self {
             modes: _,
-            #[cfg(feature = "unstable_session_model")]
-                models: _,
             config_options,
             meta,
         } = self;
@@ -3687,8 +3679,6 @@ impl IntoV1 for super::ForkSessionResponse {
         Ok(crate::v1::ForkSessionResponse {
             session_id: session_id.into_v1()?,
             modes: None,
-            #[cfg(feature = "unstable_session_model")]
-            models: None,
             config_options: config_options.into_v1()?,
             meta: meta.into_v1()?,
         })
@@ -3703,8 +3693,6 @@ impl IntoV2 for crate::v1::ForkSessionResponse {
         let Self {
             session_id,
             modes: _,
-            #[cfg(feature = "unstable_session_model")]
-                models: _,
             config_options,
             meta,
         } = self;
@@ -3772,8 +3760,6 @@ impl IntoV1 for super::ResumeSessionResponse {
         } = self;
         Ok(crate::v1::ResumeSessionResponse {
             modes: None,
-            #[cfg(feature = "unstable_session_model")]
-            models: None,
             config_options: config_options.into_v1()?,
             meta: meta.into_v1()?,
         })
@@ -3786,8 +3772,6 @@ impl IntoV2 for crate::v1::ResumeSessionResponse {
     fn into_v2(self) -> Result<Self::Output> {
         let Self {
             modes: _,
-            #[cfg(feature = "unstable_session_model")]
-                models: _,
             config_options,
             meta,
         } = self;
@@ -5608,13 +5592,6 @@ impl IntoV2 for crate::v1::ClientRequest {
                 super::ClientRequest::SetSessionConfigOptionRequest(value.into_v2()?)
             }
             Self::PromptRequest(value) => super::ClientRequest::PromptRequest(value.into_v2()?),
-            #[cfg(feature = "unstable_session_model")]
-            Self::SetSessionModelRequest(_) => {
-                return Err(removed_v1_enum_variant(
-                    "ClientRequest",
-                    "session/set_model",
-                ));
-            }
             #[cfg(feature = "unstable_nes")]
             Self::StartNesRequest(value) => super::ClientRequest::StartNesRequest(value.into_v2()?),
             #[cfg(feature = "unstable_nes")]
@@ -5766,13 +5743,6 @@ impl IntoV2 for crate::v1::AgentResponse {
                 super::AgentResponse::SetSessionConfigOptionResponse(value.into_v2()?)
             }
             Self::PromptResponse(value) => super::AgentResponse::PromptResponse(value.into_v2()?),
-            #[cfg(feature = "unstable_session_model")]
-            Self::SetSessionModelResponse(_) => {
-                return Err(removed_v1_enum_variant(
-                    "AgentResponse",
-                    "session/set_model",
-                ));
-            }
             #[cfg(feature = "unstable_nes")]
             Self::StartNesResponse(value) => {
                 super::AgentResponse::StartNesResponse(value.into_v2()?)
@@ -9414,21 +9384,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "unstable_session_model")]
-    #[test]
-    fn v1_session_model_methods_do_not_convert_to_v2() {
-        assert_v1_to_v2_error(
-            v1::ClientRequest::SetSessionModelRequest(v1::SetSessionModelRequest::new(
-                "sess", "model-1",
-            )),
-            "v1 ClientRequest variant `session/set_model` cannot be represented in v2",
-        );
-        assert_v1_to_v2_error(
-            v1::AgentResponse::SetSessionModelResponse(v1::SetSessionModelResponse::new()),
-            "v1 AgentResponse variant `session/set_model` cannot be represented in v2",
-        );
-    }
-
     #[test]
     fn v1_session_response_modes_fall_back_to_none_in_v2() {
         let response = v1::NewSessionResponse::new("sess").modes(v1::SessionModeState::new(
@@ -9442,28 +9397,12 @@ mod tests {
         assert!(back_to_v1.modes.is_none());
     }
 
-    #[cfg(feature = "unstable_session_model")]
     #[test]
-    fn v1_session_response_models_fall_back_to_none_in_v2() {
-        let response = v1::NewSessionResponse::new("sess").models(v1::SessionModelState::new(
-            "model-1",
-            vec![v1::ModelInfo::new("model-1", "Model 1")],
-        ));
-
-        let as_v2: v2::NewSessionResponse = v1_to_v2(response).unwrap();
-        let back_to_v1: v1::NewSessionResponse = v2_to_v1(as_v2).unwrap();
-
-        assert!(back_to_v1.models.is_none());
-    }
-
-    #[test]
-    fn v2_session_response_converts_to_v1_without_mode_or_model_state() {
+    fn v2_session_response_converts_to_v1_without_mode_state() {
         let response: v1::NewSessionResponse =
             v2_to_v1(v2::NewSessionResponse::new("sess")).unwrap();
 
         assert!(response.modes.is_none());
-        #[cfg(feature = "unstable_session_model")]
-        assert!(response.models.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Session config options have been around long enough, so cleaning up the old iteration.