### PR TITLE
docs(rfd): Clarify agent-owned message IDs in RFDs

### DIFF
--- a/docs/protocol/v1/draft/prompt-turn.mdx
+++ b/docs/protocol/v1/draft/prompt-turn.mdx
@@ -154,6 +154,7 @@ The Agent then reports text responses from the model:
     "sessionId": "sess_abc123def456",
     "update": {
       "sessionUpdate": "agent_message_chunk",
+      "messageId": "msg_agent_c42b9",
       "content": {
         "type": "text",
         "text": "I'll analyze your code for potential issues. Let me examine it..."
@@ -162,6 +163,8 @@ The Agent then reports text responses from the model:
   }
 }
 ```
+
+The Agent **MAY** include an opaque, unique `messageId` on message chunks. Chunks with the same `messageId` belong to the same message; a changed `messageId` indicates a new message.
 
 If the model requested tool calls, these are also reported immediately:
 

--- a/docs/protocol/v1/draft/schema.mdx
+++ b/docs/protocol/v1/draft/schema.mdx
@@ -1377,18 +1377,6 @@ these keys.
 See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/draft/extensibility)
 
 </ResponseField>
-<ResponseField name="messageId" type={"string | null"} >
-  **UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-A client-generated unique identifier for this user message.
-
-If provided, the Agent SHOULD echo this value as `userMessageId` in the
-`PromptResponse` to confirm it was recorded.
-Both clients and agents MUST use UUID format for message IDs.
-
-</ResponseField>
 <ResponseField name="prompt" type={<a href="#contentblock">ContentBlock[]</a>} required>
   The blocks of content that compose the user's message.
 
@@ -1436,18 +1424,6 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
 Token usage for this turn (optional).
-
-</ResponseField>
-<ResponseField name="userMessageId" type={"string | null"} >
-  **UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-The acknowledged user message ID.
-
-If the client provided a `messageId` in the `PromptRequest`, the agent echoes it here
-to confirm it was recorded. If the client did not provide one, the agent MAY assign one
-and return it here. Absence of this field indicates the agent did not record a message ID.
 
 </ResponseField>
 
@@ -3545,7 +3521,6 @@ A unique identifier for the message this chunk belongs to.
 
 All chunks belonging to the same message share the same `messageId`.
 A change in `messageId` indicates a new message has started.
-Both clients and agents MUST use UUID format for message IDs.
 
 </ResponseField>
 
@@ -7194,7 +7169,6 @@ A unique identifier for the message this chunk belongs to.
 
 All chunks belonging to the same message share the same `messageId`.
 A change in `messageId` indicates a new message has started.
-Both clients and agents MUST use UUID format for message IDs.
 
 </ResponseField>
 <ResponseField name="sessionUpdate" type={"string"} required>
@@ -7229,7 +7203,6 @@ A unique identifier for the message this chunk belongs to.
 
 All chunks belonging to the same message share the same `messageId`.
 A change in `messageId` indicates a new message has started.
-Both clients and agents MUST use UUID format for message IDs.
 
 </ResponseField>
 <ResponseField name="sessionUpdate" type={"string"} required>
@@ -7264,7 +7237,6 @@ A unique identifier for the message this chunk belongs to.
 
 All chunks belonging to the same message share the same `messageId`.
 A change in `messageId` indicates a new message has started.
-Both clients and agents MUST use UUID format for message IDs.
 
 </ResponseField>
 <ResponseField name="sessionUpdate" type={"string"} required>

--- a/docs/protocol/v1/draft/session-setup.mdx
+++ b/docs/protocol/v1/draft/session-setup.mdx
@@ -145,6 +145,7 @@ For example, a user message from the conversation history:
     "sessionId": "sess_789xyz",
     "update": {
       "sessionUpdate": "user_message_chunk",
+      "messageId": "msg_user_8f7a1",
       "content": {
         "type": "text",
         "text": "What's the capital of France?"
@@ -164,6 +165,7 @@ Followed by the agent's response:
     "sessionId": "sess_789xyz",
     "update": {
       "sessionUpdate": "agent_message_chunk",
+      "messageId": "msg_agent_c42b9",
       "content": {
         "type": "text",
         "text": "The capital of France is Paris."
@@ -172,6 +174,8 @@ Followed by the agent's response:
   }
 }
 ```
+
+If the Agent provides message IDs during replay, each `messageId` is an opaque, unique identifier for the replayed message.
 
 When **all** the conversation entries have been streamed to the Client, the
 Agent **MUST** respond to the original `session/load` request.

--- a/docs/protocol/v2/draft/prompt-turn.mdx
+++ b/docs/protocol/v2/draft/prompt-turn.mdx
@@ -154,6 +154,7 @@ The Agent then reports text responses from the model:
     "sessionId": "sess_abc123def456",
     "update": {
       "sessionUpdate": "agent_message_chunk",
+      "messageId": "msg_agent_c42b9",
       "content": {
         "type": "text",
         "text": "I'll analyze your code for potential issues. Let me examine it..."
@@ -162,6 +163,8 @@ The Agent then reports text responses from the model:
   }
 }
 ```
+
+The Agent **MAY** include an opaque `messageId` on message chunks. Chunks with the same `messageId` belong to the same message; a changed `messageId` indicates a new message.
 
 If the model requested tool calls, these are also reported immediately:
 

--- a/docs/protocol/v2/draft/schema.mdx
+++ b/docs/protocol/v2/draft/schema.mdx
@@ -1360,18 +1360,6 @@ these keys.
 See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
 
 </ResponseField>
-<ResponseField name="messageId" type={"string | null"} >
-  **UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-A client-generated unique identifier for this user message.
-
-If provided, the Agent SHOULD echo this value as `userMessageId` in the
-`PromptResponse` to confirm it was recorded.
-Both clients and agents MUST use UUID format for message IDs.
-
-</ResponseField>
 <ResponseField name="prompt" type={<a href="#contentblock">ContentBlock[]</a>} required>
   The blocks of content that compose the user's message.
 
@@ -1419,18 +1407,6 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
 Token usage for this turn (optional).
-
-</ResponseField>
-<ResponseField name="userMessageId" type={"string | null"} >
-  **UNSTABLE**
-
-This capability is not part of the spec yet, and may be removed or changed at any point.
-
-The acknowledged user message ID.
-
-If the client provided a `messageId` in the `PromptRequest`, the agent echoes it here
-to confirm it was recorded. If the client did not provide one, the agent MAY assign one
-and return it here. Absence of this field indicates the agent did not record a message ID.
 
 </ResponseField>
 
@@ -3562,7 +3538,6 @@ A unique identifier for the message this chunk belongs to.
 
 All chunks belonging to the same message share the same `messageId`.
 A change in `messageId` indicates a new message has started.
-Both clients and agents MUST use UUID format for message IDs.
 
 </ResponseField>
 
@@ -7282,7 +7257,6 @@ A unique identifier for the message this chunk belongs to.
 
 All chunks belonging to the same message share the same `messageId`.
 A change in `messageId` indicates a new message has started.
-Both clients and agents MUST use UUID format for message IDs.
 
 </ResponseField>
 <ResponseField name="sessionUpdate" type={"string"} required>
@@ -7317,7 +7291,6 @@ A unique identifier for the message this chunk belongs to.
 
 All chunks belonging to the same message share the same `messageId`.
 A change in `messageId` indicates a new message has started.
-Both clients and agents MUST use UUID format for message IDs.
 
 </ResponseField>
 <ResponseField name="sessionUpdate" type={"string"} required>
@@ -7352,7 +7325,6 @@ A unique identifier for the message this chunk belongs to.
 
 All chunks belonging to the same message share the same `messageId`.
 A change in `messageId` indicates a new message has started.
-Both clients and agents MUST use UUID format for message IDs.
 
 </ResponseField>
 <ResponseField name="sessionUpdate" type={"string"} required>

--- a/docs/protocol/v2/draft/session-setup.mdx
+++ b/docs/protocol/v2/draft/session-setup.mdx
@@ -145,6 +145,7 @@ For example, a user message from the conversation history:
     "sessionId": "sess_789xyz",
     "update": {
       "sessionUpdate": "user_message_chunk",
+      "messageId": "msg_user_8f7a1",
       "content": {
         "type": "text",
         "text": "What's the capital of France?"
@@ -164,6 +165,7 @@ Followed by the agent's response:
     "sessionId": "sess_789xyz",
     "update": {
       "sessionUpdate": "agent_message_chunk",
+      "messageId": "msg_agent_c42b9",
       "content": {
         "type": "text",
         "text": "The capital of France is Paris."
@@ -172,6 +174,8 @@ Followed by the agent's response:
   }
 }
 ```
+
+If the Agent provides message IDs during replay, each `messageId` is an opaque, unique identifier for the replayed message.
 
 When **all** the conversation entries have been streamed to the Client, the
 Agent **MUST** respond to the original `session/load` request.

--- a/docs/rfds/message-id.mdx
+++ b/docs/rfds/message-id.mdx
@@ -7,7 +7,7 @@ title: "Message ID"
 
 ## Elevator pitch
 
-Add a `messageId` field to `agent_message_chunk`, `user_message_chunk`, `agent_thought_chunk` session updates and `session/prompt` requests, and a `userMessageId` field to `session/prompt` responses, to uniquely identify individual messages within a conversation. Both clients and agents can generate message IDs using UUID format. This enables clients to distinguish between different messages beyond changes in update type and lays the groundwork for future capabilities like message editing and session deduplication.
+Add a `messageId` field to `agent_message_chunk`, `user_message_chunk`, `agent_thought_chunk` session updates to uniquely identify individual messages within a conversation. Only agents generate message IDs, and the IDs are opaque strings. This enables clients to distinguish between different messages beyond changes in update type and lays the groundwork for future capabilities like message editing and session deduplication.
 
 ## Status quo
 
@@ -60,7 +60,7 @@ As an example, consider this sequence where a Client cannot reliably determine m
 
 ## What we propose to do about it
 
-Add a `messageId` field to `AgentMessageChunk`, `UserMessageChunk`, `AgentThoughtChunk` session updates and `PromptRequest`, and a `userMessageId` field to `PromptResponse`. These fields would:
+Add a `messageId` field to `AgentMessageChunk`, `UserMessageChunk`, and `AgentThoughtChunk` session updates. This field would:
 
 1. **Provide stable message identification** - Each message gets a unique identifier that remains constant across all chunks of that message.
 
@@ -70,58 +70,7 @@ Add a `messageId` field to `AgentMessageChunk`, `UserMessageChunk`, `AgentThough
 
 ### Proposed Structure
 
-When the Client sends a user message via `session/prompt`, it can optionally include a `messageId`:
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 2,
-  "method": "session/prompt",
-  "params": {
-    "sessionId": "sess_abc123def456",
-    "messageId": "4c12d49b-729c-4086-bfed-5b82e9a53400",
-    "prompt": [
-      {
-        "type": "text",
-        "text": "Can you analyze this code?"
-      }
-    ]
-  }
-}
-```
-
-The Agent echoes this as `userMessageId` in the response (or assigns one if the client didn't provide it):
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 2,
-  "result": {
-    "userMessageId": "4c12d49b-729c-4086-bfed-5b82e9a53400",
-    "stopReason": "end_turn"
-  }
-}
-```
-
-For agent message chunks, the Agent generates and includes a `messageId`:
-
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "session/update",
-  "params": {
-    "sessionId": "sess_abc123def456",
-    "update": {
-      "sessionUpdate": "agent_message_chunk",
-      "messageId": "ea87d0e7-beb8-484a-a404-94a30b78a5a8",
-      "content": {
-        "type": "text",
-        "text": "Let me analyze your code..."
-      }
-    }
-  }
-}
-```
+The `session/prompt` response does not include a message ID. In v1, there won't be a message ID for user-submitted messages. In v2, the agent will replay the message and attach the appropriate message ID to the user message.
 
 If the Agent sends `user_message_chunk` updates (e.g., during `session/load`), it uses the user message ID:
 
@@ -133,10 +82,30 @@ If the Agent sends `user_message_chunk` updates (e.g., during `session/load`), i
     "sessionId": "sess_abc123def456",
     "update": {
       "sessionUpdate": "user_message_chunk",
-      "messageId": "4c12d49b-729c-4086-bfed-5b82e9a53400",
+      "messageId": "msg_user_8f7a1",
       "content": {
         "type": "text",
-        "text": "Can you..."
+        "text": "Can you analyze this code?"
+      }
+    }
+  }
+}
+```
+
+For agent message chunks, the Agent also generates and includes a `messageId`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "session/update",
+  "params": {
+    "sessionId": "sess_abc123def456",
+    "update": {
+      "sessionUpdate": "agent_message_chunk",
+      "messageId": "msg_agent_c42b9",
+      "content": {
+        "type": "text",
+        "text": "Let me analyze your code..."
       }
     }
   }
@@ -145,25 +114,13 @@ If the Agent sends `user_message_chunk` updates (e.g., during `session/load`), i
 
 The `messageId` field would be:
 
-- **Optional** on `agent_message_chunk`, `user_message_chunk`, `agent_thought_chunk` updates and `session/prompt` requests (as `messageId`)
-- **Optional** in `session/prompt` responses (as `userMessageId`)
-- **UUID format** - Both clients and agents MUST use UUID format to ensure collision avoidance
+- **Optional** on `agent_message_chunk`, `user_message_chunk`, and `agent_thought_chunk` updates
+- **Agent-generated** - the Agent is the only participant that creates protocol message IDs
 - **Unique per message** within a session
 - **Stable across chunks** - all chunks belonging to the same message share the same `messageId`
 - **Opaque** - Implementations treat it as an identifier without parsing its structure
-- **Dual-origin** - Clients generate IDs for user messages, agents generate IDs for agent messages
 
-### Message ID Acknowledgment
-
-When a Client includes `messageId` in a `session/prompt` request, the Agent's response behavior indicates whether message IDs are supported:
-
-- **If the Agent supports message IDs** and records the client-provided ID, it MUST include `userMessageId` in the response with the same value.
-- **If the Agent assigns its own ID** (when the client didn't provide one), it SHOULD include `userMessageId` in the response so the client knows the assigned ID.
-- **If the Agent does not support message IDs** or chooses not to record it, it MUST omit `userMessageId` from the response.
-
-Clients MUST interpret the absence of `userMessageId` in the response as confirmation that the message ID was **not recorded**. Clients SHOULD NOT rely on that ID for subsequent operations (e.g., message editing, truncation, or forking) when `userMessageId` is absent.
-
-This creates predictable behavior: the presence of `userMessageId` in the response is an explicit acknowledgment that the Agent recorded the ID and will recognize it in future operations.
+If an Agent supports message IDs and emits an accepted or replayed user message through `session/update`, it SHOULD include `messageId` on that user message update.
 
 ## Shiny future
 
@@ -212,23 +169,16 @@ Example future editing capability:
 
 1. **Update schema** (`schema/schema.json`):
    - Add optional `messageId` field (type: `string`) to `ContentChunk` (used by `AgentMessageChunk`, `UserMessageChunk`, `AgentThoughtChunk`)
-   - Add optional `messageId` field (type: `string`) to `PromptRequest` (client-provided)
-   - Add optional `userMessageId` field (type: `string`) to `PromptResponse` (echoed or agent-assigned)
 
 2. **Update Rust SDK** (`rust/client.rs` and `rust/agent.rs`):
    - Add `message_id: Option<String>` field to `ContentChunk` struct
-   - Add `message_id: Option<String>` field to `PromptRequest` struct
-   - Add `user_message_id: Option<String>` field to `PromptResponse` struct
-   - Update serialization to include `messageId`/`userMessageId` in JSON output when present
+   - Update serialization to include `messageId` in JSON output when present
 
 3. **Update TypeScript SDK** (if applicable):
-   - Add `messageId` field to corresponding types
+   - Add `messageId` field to corresponding session update types
 
 4. **Update documentation** (`docs/protocol/prompt-turn.mdx`):
-   - Document the `messageId` and `userMessageId` fields and their semantics
-   - Clarify that clients can provide `messageId` for user messages in prompt requests
-   - Clarify that agents echo the ID as `userMessageId` in prompt responses
-   - Clarify that agents generate `messageId` for agent messages in chunks
+   - Document the `messageId` field and its semantics
    - Add examples showing message boundaries
    - Explain that `messageId` changes indicate new messages
 
@@ -236,7 +186,6 @@ Example future editing capability:
 
 5. **Update example agents**:
    - Modify example agents to generate and include `messageId` in chunks
-   - Use simple ID generation (e.g., incrementing counter, UUID)
    - Demonstrate consistent IDs across chunks of the same message
 
 6. **Update example clients**:
@@ -246,7 +195,7 @@ Example future editing capability:
 
 ### Backward Compatibility
 
-The `messageId` field is **optional** to ensure this is a non-breaking change. Agents SHOULD include the `messageId` field, but it is not required for v1 compatibility. Features that rely on `messageId` (such as future message editing capabilities) will implicitly require the field to be present - Agents that don't provide it simply won't support those features.
+The `messageId` field is **optional** to ensure this is a non-breaking change. Agents SHOULD include the `messageId` field on message chunks they can identify, but it is not required for v1 compatibility. Features that rely on `messageId` (such as future message editing capabilities) will implicitly require the field to be present - Agents that don't provide it simply won't support those features.
 
 Making this field required will be considered for a future v2 version of the protocol after wide adoption.
 
@@ -269,32 +218,30 @@ Making this field required will be considered for a future v2 version of the pro
    - Requires additional notifications
    - More state to track on both sides
 
-4. **Agent-only message IDs** - Have the Agent generate all IDs (including for user messages):
-   - Consistent with protocol patterns (`sessionId`, `terminalId`, `toolCallId`)
-   - But creates complexity for returning user message IDs (response comes after streaming)
-   - Not all agents support passing user message IDs through
-   - Clients may need IDs immediately for deduplication or multi-client scenarios
+4. **Client-generated prompt IDs** - Let Clients generate IDs for `session/prompt` requests:
+   - Creates two sources of truth for protocol IDs
+   - Requires agreement on uniqueness across clients and agents
+   - Conflicts with the Agent's role as owner of the session history
 
 The proposed approach with `messageId` is:
 
 - **Simple** - Just one new field with clear semantics
 - **Flexible** - Enables future capabilities without further protocol changes
-- **Practical** - Clients generate IDs for their messages, agents for theirs
-- **Collision-safe** - UUID format ensures uniqueness across both sides
+- **Practical** - IDs come from the same side that owns and emits session history
+- **Format-agnostic** - Agents can use identifiers that fit their own storage model
 
 ### Who generates message IDs?
 
-**Both clients and agents can generate message IDs**, each for their own messages:
+**Only the Agent generates protocol message IDs.**
 
-- **For user messages**: The Client generates a UUID and includes it as `messageId` in the `session/prompt` request. The Agent echoes this ID as `userMessageId` in the response to confirm it was recorded. If the client doesn't provide one, the Agent MAY assign one and return it in the response so the client knows the assigned ID.
-- **For agent messages**: The Agent generates the UUID when creating its response and includes it in session update chunks.
+- **For user messages**: The Client sends a prompt without a message ID. If the Agent emits that accepted or replayed user message as a `session/update`, the Agent generates the message ID and includes it in that notification.
+- **For agent messages and thoughts**: The Agent generates the ID when creating the message or thought and includes it in session update chunks.
 
-This differs from other protocol identifiers (`sessionId`, `terminalId`, `toolCallId`) which are agent-generated, but provides practical benefits:
+This matches other protocol identifiers (`sessionId`, `terminalId`, `toolCallId`) which are agent-generated, and provides practical benefits:
 
-- **Immediate availability** - Clients have the ID as soon as they send the message, without waiting for a response
-- **Deduplication** - Clients can use IDs to deduplicate messages on `session/load` or when echoing to multiple clients
-- **Collision-safe** - UUID format ensures uniqueness without coordination
-- **Adapter-friendly** - Adapters for agents that don't support message IDs can simply not pass them through
+- **Single source of truth** - The Agent owns session persistence and message ordering
+- **No format coordination** - The protocol does not need to standardize UUIDs or another shared ID format
+- **Adapter-friendly** - Adapters for agents that don't support message IDs can simply omit them
 
 ### Should this field be required or optional?
 
@@ -304,13 +251,11 @@ Making this field required will be considered for a future v2 version of the pro
 
 ### What format should message IDs use?
 
-Both clients and agents **MUST** use UUID format for message IDs. This is required because both sides can generate IDs, and UUID format ensures:
+Message IDs are opaque strings generated by the Agent.
 
-- **No collisions** - UUIDs are globally unique without coordination between client and agent
-- **Interoperability** - Both sides use the same format, so either side can rely on uniqueness guarantees
-- **Simplicity** - Standard libraries available in all languages
+Clients MUST compare message IDs as opaque strings and MUST NOT parse or infer meaning from their structure.
 
-While `messageId` values are UUIDs, implementations **SHOULD** treat them as opaque strings when reading/comparing them, and not parse or interpret their internal structure.
+Because IDs only come from the Agent, collision avoidance is the Agent's responsibility within the session.
 
 ### What about message IDs across session loads?
 
@@ -333,6 +278,7 @@ Future RFDs may propose extending `messageId` to other update types if use cases
 
 ## Revision history
 
+- **2026-06-02**: Updated the proposal so message IDs are Agent-generated only, removed client-provided prompt IDs and prompt response acknowledgments, and removed the UUID requirement in favor of opaque strings
 - **2026-02-17**: Added "Message ID Acknowledgment" section to clarify that presence/absence of `userMessageId` in response indicates whether the Agent recorded the ID; clarified that UUID format is MUST (not SHOULD) since both sides generate IDs; renamed response field to `userMessageId` for clarity (request keeps `messageId`)
 - **2026-01-29**: Updated to allow both clients and agents to generate message IDs using UUID format
 - **2025-11-09**: Initial draft

--- a/docs/rfds/v2/prompt.mdx
+++ b/docs/rfds/v2/prompt.mdx
@@ -32,21 +32,19 @@ In the spirit of allowing as much flexibility in the protocol for new paradigms 
 
 ### Change the `session/prompt` response
 
-`session/prompt` is still a request, but both its response lifecycle and payload will change.
+`session/prompt` is still a request, but its response lifecycle will change.
 
-The agent will respond once the prompt has been _accepted_, not when the turn is over. And the agent would be able to respond with the given id for that prompt, a current problem we have in the [message id RFD](/rfds/message-id) in terms of how to get the message id back soon enough.
+The agent will respond once the prompt has been _accepted_, not when the turn is over. Message IDs do not need to be returned from the prompt response; per the [message id RFD](/rfds/message-id), the agent remains the source of truth for message IDs and provides them through the session update stream when it emits the accepted user message.
 
 ```json
 {
   "jsonrpc": "2.0",
   "id": "req_12345",
-  "result": {
-    "messageId": "msg_789xyz"
-  }
+  "result": {}
 }
 ```
 
-Given there will need to be some more exploration for Message IDs in general, I won't tie that RFD to this one unnecessarily, but it becomes a much more natural point to provide the information if we decide to do so.
+Given there will need to be some more exploration for Message IDs in general, I won't tie that RFD to this one unnecessarily. The accepted user message notification becomes the natural point to provide the ID if the agent has one.
 
 Queueing messages (still an ongoing discussion) would also fit much nicer in this pattern. Either by adding additional parameters or a separate method, we can allow a client to submit queued messages and either cancel or edit them before they get accepted without having to mess with the turn semantics of the previous prompt request approach. Again, queueing is decidedly not part of this RFD, but it seems to fall more naturally into this semantic change in the prompt request.
 
@@ -66,9 +64,9 @@ The question then turns to what makes up this notification. Which brings us to:
 
 **Who owns the user message id?**
 
-This is an open question at the moment for the [message id RFD](/rfds/message-id). If we allow the client to define the message id, this allows the client to eagerly create it and rely on it. However, if there isn't an agreement on "uniqueness", or if a given agent requires all message ids to be UUIDs or something similar, this could cause issues if both sides are allowed to treat ids as an opaque string, since there would need to be some agreement on how they are actually derived to ensure constraints.
+The [message id RFD](/rfds/message-id) proposes that the agent owns message IDs. This means the client cannot eagerly create a protocol message ID for a prompt, but it also means we avoid a shared uniqueness or UUID requirement between clients and agents.
 
-By allowing the agent to replay the message, we have a natural place for the agent to both provide the content as well as the id once it is inserted in the session. The client will be able to associate that a given user message was from their prompt request by seeing the same message id in the prompt response as this notification. Overall with message ids, I propose to let the agent continue to generate their own ids, and it is the sole source of truth. Ultimately the agent is responsible for the session persistence, and otherwise we may need to align on UUIDs or something similar for message ids, which may or may not fit well with the current agent implementations. If there is only one source for ids, we can continue to treat them as opaque strings that fit well into the agent's individual implementations.
+By allowing the agent to replay or acknowledge the user message as a session update, we have a natural place for the agent to provide both the content and the ID once it is inserted in the session. Ultimately the agent is responsible for session persistence. If there is only one source for IDs, we can continue to treat them as opaque strings that fit well into each agent's implementation.
 
 My current proposal is that this would look like the client sending the following message:
 
@@ -95,9 +93,7 @@ And the Agent responds with:
 {
   "jsonrpc": "2.0",
   "id": "req_12345",
-  "result": {
-    "messageId": "mess_456def"
-  }
+  "result": {}
 }
 ```
 
@@ -123,7 +119,7 @@ And also send the notification:
 }
 ```
 
-The client can then make sure the prompt sits nicely in the feed at the right place, and also allows for multiple clients to be attached to the same session because they would receive a user message that they didn't prompt.
+The client can then make sure the prompt sits nicely in the feed at the right place, and also allows for multiple clients to be attached to the same session because they would receive a user message that they didn't prompt. If the agent includes a `messageId` in that notification, the client can use that agent-provided ID for future message-specific operations.
 
 This is a new message type as well. Not a `user_message_chunk` but just a `user_message` that allows for sending the entire message at once. For v2 we will make sure to allow for the agent to do the same on their messages as well, providing both full and partial streaming update patterns for a given message.
 

--- a/schema/schema.unstable.json
+++ b/schema/schema.unstable.json
@@ -1846,7 +1846,7 @@
           "description": "A single item of content"
         },
         "messageId": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nA unique identifier for the message this chunk belongs to.\n\nAll chunks belonging to the same message share the same `messageId`.\nA change in `messageId` indicates a new message has started.\nBoth clients and agents MUST use UUID format for message IDs.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nA unique identifier for the message this chunk belongs to.\n\nAll chunks belonging to the same message share the same `messageId`.\nA change in `messageId` indicates a new message has started.",
           "type": ["string", "null"]
         }
       },
@@ -5295,10 +5295,6 @@
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": ["object", "null"]
         },
-        "messageId": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nA client-generated unique identifier for this user message.\n\nIf provided, the Agent SHOULD echo this value as `userMessageId` in the\n[`PromptResponse`] to confirm it was recorded.\nBoth clients and agents MUST use UUID format for message IDs.",
-          "type": ["string", "null"]
-        },
         "prompt": {
           "description": "The blocks of content that compose the user's message.\n\nAs a baseline, the Agent MUST support [`ContentBlock::Text`] and [`ContentBlock::ResourceLink`],\nwhile other variants are optionally enabled via [`PromptCapabilities`].\n\nThe Client MUST adapt its interface according to [`PromptCapabilities`].\n\nThe client MAY include referenced pieces of context as either\n[`ContentBlock::Resource`] or [`ContentBlock::ResourceLink`].\n\nWhen available, [`ContentBlock::Resource`] is preferred\nas it avoids extra round-trips and allows the message to include\npieces of context from sources the agent may not have access to.",
           "items": {
@@ -5347,10 +5343,6 @@
           ],
           "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nToken usage for this turn (optional).",
           "x-deserialize-default-on-error": true
-        },
-        "userMessageId": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe acknowledged user message ID.\n\nIf the client provided a `messageId` in the [`PromptRequest`], the agent echoes it here\nto confirm it was recorded. If the client did not provide one, the agent MAY assign one\nand return it here. Absence of this field indicates the agent did not record a message ID.",
-          "type": ["string", "null"]
         }
       },
       "required": ["stopReason"],

--- a/schema/schema.v2.unstable.json
+++ b/schema/schema.v2.unstable.json
@@ -1984,7 +1984,7 @@
           "description": "A single item of content"
         },
         "messageId": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nA unique identifier for the message this chunk belongs to.\n\nAll chunks belonging to the same message share the same `messageId`.\nA change in `messageId` indicates a new message has started.\nBoth clients and agents MUST use UUID format for message IDs.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nA unique identifier for the message this chunk belongs to.\n\nAll chunks belonging to the same message share the same `messageId`.\nA change in `messageId` indicates a new message has started.",
           "type": ["string", "null"]
         }
       },
@@ -5511,10 +5511,6 @@
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": ["object", "null"]
         },
-        "messageId": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nA client-generated unique identifier for this user message.\n\nIf provided, the Agent SHOULD echo this value as `userMessageId` in the\n[`PromptResponse`] to confirm it was recorded.\nBoth clients and agents MUST use UUID format for message IDs.",
-          "type": ["string", "null"]
-        },
         "prompt": {
           "description": "The blocks of content that compose the user's message.\n\nAs a baseline, the Agent MUST support [`ContentBlock::Text`] and [`ContentBlock::ResourceLink`],\nwhile other variants are optionally enabled via [`PromptCapabilities`].\n\nThe Client MUST adapt its interface according to [`PromptCapabilities`].\n\nThe client MAY include referenced pieces of context as either\n[`ContentBlock::Resource`] or [`ContentBlock::ResourceLink`].\n\nWhen available, [`ContentBlock::Resource`] is preferred\nas it avoids extra round-trips and allows the message to include\npieces of context from sources the agent may not have access to.",
           "items": {
@@ -5563,10 +5559,6 @@
           ],
           "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nToken usage for this turn (optional).",
           "x-deserialize-default-on-error": true
-        },
-        "userMessageId": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe acknowledged user message ID.\n\nIf the client provided a `messageId` in the [`PromptRequest`], the agent echoes it here\nto confirm it was recorded. If the client did not provide one, the agent MAY assign one\nand return it here. Absence of this field indicates the agent did not record a message ID.",
-          "type": ["string", "null"]
         }
       },
       "required": ["stopReason"],

--- a/src/v1/agent.rs
+++ b/src/v1/agent.rs
@@ -2969,17 +2969,6 @@ impl HttpHeader {
 pub struct PromptRequest {
     /// The ID of the session to send this user message to
     pub session_id: SessionId,
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// A client-generated unique identifier for this user message.
-    ///
-    /// If provided, the Agent SHOULD echo this value as `userMessageId` in the
-    /// [`PromptResponse`] to confirm it was recorded.
-    /// Both clients and agents MUST use UUID format for message IDs.
-    #[cfg(feature = "unstable_message_id")]
-    pub message_id: Option<String>,
     /// The blocks of content that compose the user's message.
     ///
     /// As a baseline, the Agent MUST support [`ContentBlock::Text`] and [`ContentBlock::ResourceLink`],
@@ -3008,27 +2997,9 @@ impl PromptRequest {
     pub fn new(session_id: impl Into<SessionId>, prompt: Vec<ContentBlock>) -> Self {
         Self {
             session_id: session_id.into(),
-            #[cfg(feature = "unstable_message_id")]
-            message_id: None,
             prompt,
             meta: None,
         }
-    }
-
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// A client-generated unique identifier for this user message.
-    ///
-    /// If provided, the Agent SHOULD echo this value as `userMessageId` in the
-    /// [`PromptResponse`] to confirm it was recorded.
-    /// Both clients and agents MUST use UUID format for message IDs.
-    #[cfg(feature = "unstable_message_id")]
-    #[must_use]
-    pub fn message_id(mut self, message_id: impl IntoOption<String>) -> Self {
-        self.message_id = message_id.into_option();
-        self
     }
 
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -3053,17 +3024,6 @@ impl PromptRequest {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct PromptResponse {
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// The acknowledged user message ID.
-    ///
-    /// If the client provided a `messageId` in the [`PromptRequest`], the agent echoes it here
-    /// to confirm it was recorded. If the client did not provide one, the agent MAY assign one
-    /// and return it here. Absence of this field indicates the agent did not record a message ID.
-    #[cfg(feature = "unstable_message_id")]
-    pub user_message_id: Option<String>,
     /// Indicates why the agent stopped processing the turn.
     pub stop_reason: StopReason,
     /// **UNSTABLE**
@@ -3089,29 +3049,11 @@ impl PromptResponse {
     #[must_use]
     pub fn new(stop_reason: StopReason) -> Self {
         Self {
-            #[cfg(feature = "unstable_message_id")]
-            user_message_id: None,
             stop_reason,
             #[cfg(feature = "unstable_session_usage")]
             usage: None,
             meta: None,
         }
-    }
-
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// The acknowledged user message ID.
-    ///
-    /// If the client provided a `messageId` in the [`PromptRequest`], the agent echoes it here
-    /// to confirm it was recorded. If the client did not provide one, the agent MAY assign one
-    /// and return it here. Absence of this field indicates the agent did not record a message ID.
-    #[cfg(feature = "unstable_message_id")]
-    #[must_use]
-    pub fn user_message_id(mut self, user_message_id: impl IntoOption<String>) -> Self {
-        self.user_message_id = user_message_id.into_option();
-        self
     }
 
     /// **UNSTABLE**

--- a/src/v1/client.rs
+++ b/src/v1/client.rs
@@ -378,7 +378,6 @@ pub struct ContentChunk {
     ///
     /// All chunks belonging to the same message share the same `messageId`.
     /// A change in `messageId` indicates a new message has started.
-    /// Both clients and agents MUST use UUID format for message IDs.
     #[cfg(feature = "unstable_message_id")]
     pub message_id: Option<String>,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -409,7 +408,6 @@ impl ContentChunk {
     ///
     /// All chunks belonging to the same message share the same `messageId`.
     /// A change in `messageId` indicates a new message has started.
-    /// Both clients and agents MUST use UUID format for message IDs.
     #[cfg(feature = "unstable_message_id")]
     #[must_use]
     pub fn message_id(mut self, message_id: impl IntoOption<String>) -> Self {

--- a/src/v2/agent.rs
+++ b/src/v2/agent.rs
@@ -3006,17 +3006,6 @@ impl HttpHeader {
 pub struct PromptRequest {
     /// The ID of the session to send this user message to
     pub session_id: SessionId,
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// A client-generated unique identifier for this user message.
-    ///
-    /// If provided, the Agent SHOULD echo this value as `userMessageId` in the
-    /// [`PromptResponse`] to confirm it was recorded.
-    /// Both clients and agents MUST use UUID format for message IDs.
-    #[cfg(feature = "unstable_message_id")]
-    pub message_id: Option<String>,
     /// The blocks of content that compose the user's message.
     ///
     /// As a baseline, the Agent MUST support [`ContentBlock::Text`] and [`ContentBlock::ResourceLink`],
@@ -3045,27 +3034,9 @@ impl PromptRequest {
     pub fn new(session_id: impl Into<SessionId>, prompt: Vec<ContentBlock>) -> Self {
         Self {
             session_id: session_id.into(),
-            #[cfg(feature = "unstable_message_id")]
-            message_id: None,
             prompt,
             meta: None,
         }
-    }
-
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// A client-generated unique identifier for this user message.
-    ///
-    /// If provided, the Agent SHOULD echo this value as `userMessageId` in the
-    /// [`PromptResponse`] to confirm it was recorded.
-    /// Both clients and agents MUST use UUID format for message IDs.
-    #[cfg(feature = "unstable_message_id")]
-    #[must_use]
-    pub fn message_id(mut self, message_id: impl IntoOption<String>) -> Self {
-        self.message_id = message_id.into_option();
-        self
     }
 
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -3090,17 +3061,6 @@ impl PromptRequest {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct PromptResponse {
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// The acknowledged user message ID.
-    ///
-    /// If the client provided a `messageId` in the [`PromptRequest`], the agent echoes it here
-    /// to confirm it was recorded. If the client did not provide one, the agent MAY assign one
-    /// and return it here. Absence of this field indicates the agent did not record a message ID.
-    #[cfg(feature = "unstable_message_id")]
-    pub user_message_id: Option<String>,
     /// Indicates why the agent stopped processing the turn.
     pub stop_reason: StopReason,
     /// **UNSTABLE**
@@ -3126,29 +3086,11 @@ impl PromptResponse {
     #[must_use]
     pub fn new(stop_reason: StopReason) -> Self {
         Self {
-            #[cfg(feature = "unstable_message_id")]
-            user_message_id: None,
             stop_reason,
             #[cfg(feature = "unstable_session_usage")]
             usage: None,
             meta: None,
         }
-    }
-
-    /// **UNSTABLE**
-    ///
-    /// This capability is not part of the spec yet, and may be removed or changed at any point.
-    ///
-    /// The acknowledged user message ID.
-    ///
-    /// If the client provided a `messageId` in the [`PromptRequest`], the agent echoes it here
-    /// to confirm it was recorded. If the client did not provide one, the agent MAY assign one
-    /// and return it here. Absence of this field indicates the agent did not record a message ID.
-    #[cfg(feature = "unstable_message_id")]
-    #[must_use]
-    pub fn user_message_id(mut self, user_message_id: impl IntoOption<String>) -> Self {
-        self.user_message_id = user_message_id.into_option();
-        self
     }
 
     /// **UNSTABLE**

--- a/src/v2/client.rs
+++ b/src/v2/client.rs
@@ -451,7 +451,6 @@ pub struct ContentChunk {
     ///
     /// All chunks belonging to the same message share the same `messageId`.
     /// A change in `messageId` indicates a new message has started.
-    /// Both clients and agents MUST use UUID format for message IDs.
     #[cfg(feature = "unstable_message_id")]
     pub message_id: Option<String>,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -482,7 +481,6 @@ impl ContentChunk {
     ///
     /// All chunks belonging to the same message share the same `messageId`.
     /// A change in `messageId` indicates a new message has started.
-    /// Both clients and agents MUST use UUID format for message IDs.
     #[cfg(feature = "unstable_message_id")]
     #[must_use]
     pub fn message_id(mut self, message_id: impl IntoOption<String>) -> Self {

--- a/src/v2/conversion.rs
+++ b/src/v2/conversion.rs
@@ -4641,15 +4641,11 @@ impl IntoV1 for super::PromptRequest {
     fn into_v1(self) -> Result<Self::Output> {
         let Self {
             session_id,
-            #[cfg(feature = "unstable_message_id")]
-            message_id,
             prompt,
             meta,
         } = self;
         Ok(crate::v1::PromptRequest {
             session_id: session_id.into_v1()?,
-            #[cfg(feature = "unstable_message_id")]
-            message_id: message_id.into_v1()?,
             prompt: prompt.into_v1()?,
             meta: meta.into_v1()?,
         })
@@ -4662,15 +4658,11 @@ impl IntoV2 for crate::v1::PromptRequest {
     fn into_v2(self) -> Result<Self::Output> {
         let Self {
             session_id,
-            #[cfg(feature = "unstable_message_id")]
-            message_id,
             prompt,
             meta,
         } = self;
         Ok(super::PromptRequest {
             session_id: session_id.into_v2()?,
-            #[cfg(feature = "unstable_message_id")]
-            message_id: message_id.into_v2()?,
             prompt: prompt.into_v2()?,
             meta: meta.into_v2()?,
         })
@@ -4682,16 +4674,12 @@ impl IntoV1 for super::PromptResponse {
 
     fn into_v1(self) -> Result<Self::Output> {
         let Self {
-            #[cfg(feature = "unstable_message_id")]
-            user_message_id,
             stop_reason,
             #[cfg(feature = "unstable_session_usage")]
             usage,
             meta,
         } = self;
         Ok(crate::v1::PromptResponse {
-            #[cfg(feature = "unstable_message_id")]
-            user_message_id: user_message_id.into_v1()?,
             stop_reason: stop_reason.into_v1()?,
             #[cfg(feature = "unstable_session_usage")]
             usage: usage.into_v1()?,
@@ -4705,16 +4693,12 @@ impl IntoV2 for crate::v1::PromptResponse {
 
     fn into_v2(self) -> Result<Self::Output> {
         let Self {
-            #[cfg(feature = "unstable_message_id")]
-            user_message_id,
             stop_reason,
             #[cfg(feature = "unstable_session_usage")]
             usage,
             meta,
         } = self;
         Ok(super::PromptResponse {
-            #[cfg(feature = "unstable_message_id")]
-            user_message_id: user_message_id.into_v2()?,
             stop_reason: stop_reason.into_v2()?,
             #[cfg(feature = "unstable_session_usage")]
             usage: usage.into_v2()?,


### PR DESCRIPTION
Removes client-submitted ids in preparation for v2. This avoids the
issue of agreeing on id format, and allows the agent to own them.

This means they won't be fully useful in v1 for all purposes, but will
still solve several of the main pain points.
