### PR TITLE
docs(rfd): Add JSON-RPC batch guidance for v2

### DIFF
--- a/docs/protocol/v2/draft/overview.mdx
+++ b/docs/protocol/v2/draft/overview.mdx
@@ -12,6 +12,10 @@ The protocol follows the [JSON-RPC 2.0](https://www.jsonrpc.org/specification) s
 - **Methods**: Request-response pairs that expect a result or error
 - **Notifications**: One-way messages that don't expect a response
 
+ACP v2 follows JSON-RPC 2.0 batch behavior. See
+[Transports](/protocol/v2/draft/transports#json-rpc-batch-messages) for batch
+handling requirements.
+
 ## Message Flow
 
 A typical flow follows this pattern:

--- a/docs/protocol/v2/draft/transports.mdx
+++ b/docs/protocol/v2/draft/transports.mdx
@@ -20,7 +20,8 @@ In the **stdio** transport:
 
 - The client launches the agent as a subprocess.
 - The agent reads JSON-RPC messages from its standard input (`stdin`) and sends messages to its standard output (`stdout`).
-- Messages are individual JSON-RPC requests, notifications, or responses.
+- Messages are individual JSON-RPC requests, notifications, responses, or
+  batch arrays.
 - Messages are delimited by newlines (`\n`), and **MUST NOT** contain embedded newlines.
 - The agent **MAY** write UTF-8 strings to its standard error (`stderr`) for logging purposes. Clients **MAY** capture, forward, or ignore this logging.
 - The agent **MUST NOT** write anything to its `stdout` that is not a valid ACP message.
@@ -40,6 +41,43 @@ sequenceDiagram
     Client->>Agent Process: Close stdin, terminate subprocess
     deactivate Agent Process
 ```
+
+## JSON-RPC Batch Messages
+
+JSON-RPC 2.0 allows a sender to combine multiple request and notification
+objects in a single batch array. ACP v2 follows the JSON-RPC 2.0 batch rules. A
+client or agent **MAY** send an array filled with Request objects. A Notification
+is a Request object without an `id`, so notification-only and mixed
+request/notification batches are valid.
+
+When receiving a batch call:
+
+- If the batch itself is invalid JSON, return a single `Parse error` response
+  (`code: -32700`) with `id: null`.
+- The batch **MUST** be an array with at least one value. An empty array
+  receives a single `Invalid Request` response (`code: -32600`) with `id: null`,
+  not a response array.
+- The receiver **MAY** process batch entries as concurrent tasks, in any order,
+  and with any degree of parallelism.
+- The receiver **SHOULD** respond with an array containing the corresponding
+  Response objects after all batch Request objects have been processed.
+- A Response object **SHOULD** exist for each Request object, except that there
+  **SHOULD NOT** be any Response object for Notifications.
+- The receiver **MUST NOT** reply to a Notification, including a Notification
+  within a batch.
+- Response objects **MAY** appear in any order within the response array. The
+  sender **SHOULD** match responses to requests by `id`.
+- If there are no Response objects to send, such as for an all-notification
+  batch, the receiver **MUST NOT** return an empty array and should return
+  nothing.
+- Invalid entries in a non-empty batch produce their own `Invalid Request`
+  responses (`code: -32600`) with `id: null`; they do not make the entire batch
+  fail.
+
+Clients and agents **SHOULD NOT** batch lifecycle-sensitive messages such as
+`initialize`, `authenticate`, `session/new`, `session/load`, and
+`session/prompt`. These messages are easier to reason about as individual
+transport messages and can change which later messages are valid.
 
 ## _Streamable HTTP_
 

--- a/docs/protocol/v2/overview.mdx
+++ b/docs/protocol/v2/overview.mdx
@@ -12,6 +12,10 @@ The protocol follows the [JSON-RPC 2.0](https://www.jsonrpc.org/specification) s
 - **Methods**: Request-response pairs that expect a result or error
 - **Notifications**: One-way messages that don't expect a response
 
+ACP v2 follows JSON-RPC 2.0 batch behavior. See
+[Transports](/protocol/v2/transports#json-rpc-batch-messages) for batch
+handling requirements.
+
 ## Message Flow
 
 A typical flow follows this pattern:

--- a/docs/protocol/v2/transports.mdx
+++ b/docs/protocol/v2/transports.mdx
@@ -20,7 +20,8 @@ In the **stdio** transport:
 
 - The client launches the agent as a subprocess.
 - The agent reads JSON-RPC messages from its standard input (`stdin`) and sends messages to its standard output (`stdout`).
-- Messages are individual JSON-RPC requests, notifications, or responses.
+- Messages are individual JSON-RPC requests, notifications, responses, or
+  batch arrays.
 - Messages are delimited by newlines (`\n`), and **MUST NOT** contain embedded newlines.
 - The agent **MAY** write UTF-8 strings to its standard error (`stderr`) for logging purposes. Clients **MAY** capture, forward, or ignore this logging.
 - The agent **MUST NOT** write anything to its `stdout` that is not a valid ACP message.
@@ -40,6 +41,43 @@ sequenceDiagram
     Client->>Agent Process: Close stdin, terminate subprocess
     deactivate Agent Process
 ```
+
+## JSON-RPC Batch Messages
+
+JSON-RPC 2.0 allows a sender to combine multiple request and notification
+objects in a single batch array. ACP v2 follows the JSON-RPC 2.0 batch rules. A
+client or agent **MAY** send an array filled with Request objects. A Notification
+is a Request object without an `id`, so notification-only and mixed
+request/notification batches are valid.
+
+When receiving a batch call:
+
+- If the batch itself is invalid JSON, return a single `Parse error` response
+  (`code: -32700`) with `id: null`.
+- The batch **MUST** be an array with at least one value. An empty array
+  receives a single `Invalid Request` response (`code: -32600`) with `id: null`,
+  not a response array.
+- The receiver **MAY** process batch entries as concurrent tasks, in any order,
+  and with any degree of parallelism.
+- The receiver **SHOULD** respond with an array containing the corresponding
+  Response objects after all batch Request objects have been processed.
+- A Response object **SHOULD** exist for each Request object, except that there
+  **SHOULD NOT** be any Response object for Notifications.
+- The receiver **MUST NOT** reply to a Notification, including a Notification
+  within a batch.
+- Response objects **MAY** appear in any order within the response array. The
+  sender **SHOULD** match responses to requests by `id`.
+- If there are no Response objects to send, such as for an all-notification
+  batch, the receiver **MUST NOT** return an empty array and should return
+  nothing.
+- Invalid entries in a non-empty batch produce their own `Invalid Request`
+  responses (`code: -32600`) with `id: null`; they do not make the entire batch
+  fail.
+
+Clients and agents **SHOULD NOT** batch lifecycle-sensitive messages such as
+`initialize`, `authenticate`, `session/new`, `session/load`, and
+`session/prompt`. These messages are easier to reason about as individual
+transport messages and can change which later messages are valid.
 
 ## _Streamable HTTP_
 

--- a/docs/rfds/v2/overview.mdx
+++ b/docs/rfds/v2/overview.mdx
@@ -44,6 +44,7 @@ Other RFDs will progress separately and are not dependent on breaking changes (s
 - Agents should expose mode-like and model-related state through [Session Config Options](../session-config-options.mdx) instead of dedicated mode or model selector APIs.
 - Remove the v1 Client filesystem and terminal execution surface from v2. This includes `clientCapabilities.fs`, the top-level `clientCapabilities.terminal` field, `fs/*` methods, `terminal/*` methods, and terminal tool-call content. Terminal authentication remains separate under `clientCapabilities.auth.terminal`.
 - Make [plan variants](./plan-variants.mdx) the default v2 plan shape by replacing the old `plan` session update with item-based `plan_update`.
+- Follow JSON-RPC 2.0 batch request and notification behavior.
 
 ### RFDs to be Written
 
@@ -53,7 +54,6 @@ Changes under consideration that still need to be drafted or moved to draft:
 - Streaming/Non-streaming consistency: Offer both options for both messages and tool calls
   - Also Terminal Output type for streaming terminal output from an agent
   - Expand diff types (delete, move)
-- JSON-RPC Batch messages: clearer guidance on how SDK support should work for these
 - Truncate/Edit support
 - session/new changes:
   - Providing starting message history
@@ -92,6 +92,7 @@ With the needed breaking changes, as much as possible I am targeting having a co
 
 ## Revision history
 
+2026-06-02: Recorded the v2 decision to follow JSON-RPC 2.0 batch request and notification behavior.
 2026-06-02: Recorded the v2 decision to remove Client filesystem and terminal execution capabilities, methods, and terminal tool-call content.
 2026-06-02: Added the v2 Plan Variants RFD to make item-based `plan_update` the default v2 plan shape.
 2026-06-01: Recorded that model selection should remain represented by session config options instead of a dedicated selector API.

--- a/schema/schema.unstable.json
+++ b/schema/schema.unstable.json
@@ -7818,19 +7818,41 @@
       "type": "object"
     },
     {
-      "anyOf": [
-        {
-          "allOf": [
+      "description": "A message (request, response, or notification) with `\"jsonrpc\": \"2.0\"` specified as\n[required by JSON-RPC 2.0 Specification][1].\n\n[1]: https://www.jsonrpc.org/specification#compatibility",
+      "properties": {
+        "jsonrpc": {
+          "enum": ["2.0"],
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "anyOf": [
             {
-              "$ref": "#/$defs/CancelRequestNotification"
+              "anyOf": [
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/CancelRequestNotification"
+                    }
+                  ],
+                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or\nchanged at any point.\n\nCancels an ongoing request.\n\nThis is a notification sent by the side that sent a request to cancel that request.\n\nUpon receiving this notification, the receiver:\n\n1. MUST cancel the corresponding request activity and all nested activities\n2. MAY send any pending notifications.\n3. MUST send one of these responses for the original request:\n  - Valid response with appropriate data (partial results or cancellation marker)\n  - Error response with code `-32800` (Cancelled)\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/cancellation)",
+                  "title": "CancelRequestNotification"
+                }
+              ],
+              "description": "General protocol-level notifications that all sides are expected to\nimplement.\n\nNotifications whose methods start with '$/' are messages which\nare protocol implementation dependent and might not be implementable in all\nclients or agents. For example if the implementation uses a single threaded\nsynchronous programming language then there is little it can do to react to\na `$/cancel_request` notification. If an agent or client receives\nnotifications starting with '$/' it is free to ignore the notification.\n\nNotifications do not expect a response."
+            },
+            {
+              "type": "null"
             }
-          ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or\nchanged at any point.\n\nCancels an ongoing request.\n\nThis is a notification sent by the side that sent a request to cancel that request.\n\nUpon receiving this notification, the receiver:\n\n1. MUST cancel the corresponding request activity and all nested activities\n2. MAY send any pending notifications.\n3. MUST send one of these responses for the original request:\n  - Valid response with appropriate data (partial results or cancellation marker)\n  - Error response with code `-32800` (Cancelled)\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/cancellation)",
-          "title": "CancelRequestNotification"
+          ]
         }
-      ],
-      "description": "General protocol-level notifications that all sides are expected to\nimplement.\n\nNotifications whose methods start with '$/' are messages which\nare protocol implementation dependent and might not be implementable in all\nclients or agents. For example if the implementation uses a single threaded\nsynchronous programming language then there is little it can do to react to\na `$/cancel_request` notification. If an agent or client receives\nnotifications starting with '$/' it is free to ignore the notification.\n\nNotifications do not expect a response.",
-      "title": "ProtocolLevel"
+      },
+      "required": ["jsonrpc", "method"],
+      "title": "ProtocolLevel",
+      "type": "object",
+      "x-docs-ignore": true
     }
   ],
   "title": "Agent Client Protocol"

--- a/schema/schema.v2.unstable.json
+++ b/schema/schema.v2.unstable.json
@@ -5261,6 +5261,37 @@
       "x-method": "session/prompt",
       "x-side": "agent"
     },
+    "ProtocolLevelNotification": {
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/CancelRequestNotification"
+                    }
+                  ],
+                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or\nchanged at any point.\n\nCancels an ongoing request.\n\nThis is a notification sent by the side that sent a request to cancel that request.\n\nUpon receiving this notification, the receiver:\n\n1. MUST cancel the corresponding request activity and all nested activities\n2. MAY send any pending notifications.\n3. MUST send one of these responses for the original request:\n  - Valid response with appropriate data (partial results or cancellation marker)\n  - Error response with code `-32800` (Cancelled)\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/cancellation)",
+                  "title": "CancelRequestNotification"
+                }
+              ],
+              "description": "General protocol-level notifications that all sides are expected to\nimplement.\n\nNotifications whose methods start with '$/' are messages which\nare protocol implementation dependent and might not be implementable in all\nclients or agents. For example if the implementation uses a single threaded\nsynchronous programming language then there is little it can do to react to\na `$/cancel_request` notification. If an agent or client receives\nnotifications starting with '$/' it is free to ignore the notification.\n\nNotifications do not expect a response."
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": ["method"],
+      "type": "object",
+      "x-docs-ignore": true
+    },
     "ProtocolVersion": {
       "description": "Protocol version identifier.\n\nThis version is only bumped for breaking changes.\nNon-breaking changes should be introduced via capabilities.",
       "format": "uint16",
@@ -7525,19 +7556,431 @@
       "type": "object"
     },
     {
-      "anyOf": [
-        {
-          "allOf": [
+      "description": "A non-empty JSON-RPC 2.0 batch message.",
+      "items": {
+        "anyOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/$defs/AgentRequest"
+              }
+            ],
+            "title": "Request"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/$defs/AgentNotification"
+              }
+            ],
+            "title": "Notification"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/$defs/ProtocolLevelNotification"
+              }
+            ],
+            "title": "ProtocolLevelNotification"
+          }
+        ],
+        "description": "A message (request, response, or notification) with `\"jsonrpc\": \"2.0\"` specified as\n[required by JSON-RPC 2.0 Specification][1].\n\n[1]: https://www.jsonrpc.org/specification#compatibility",
+        "properties": {
+          "jsonrpc": {
+            "enum": ["2.0"],
+            "type": "string"
+          }
+        },
+        "required": ["jsonrpc"],
+        "type": "object"
+      },
+      "minItems": 1,
+      "title": "AgentBatchCall",
+      "type": "array"
+    },
+    {
+      "description": "A non-empty JSON-RPC 2.0 batch message.",
+      "items": {
+        "anyOf": [
+          {
+            "properties": {
+              "id": {
+                "$ref": "#/$defs/RequestId"
+              },
+              "result": {
+                "anyOf": [
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/InitializeResponse"
+                      }
+                    ],
+                    "title": "InitializeResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/AuthenticateResponse"
+                      }
+                    ],
+                    "title": "AuthenticateResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/ListProvidersResponse"
+                      }
+                    ],
+                    "title": "ListProvidersResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/SetProviderResponse"
+                      }
+                    ],
+                    "title": "SetProviderResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/DisableProviderResponse"
+                      }
+                    ],
+                    "title": "DisableProviderResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/LogoutResponse"
+                      }
+                    ],
+                    "title": "LogoutResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/NewSessionResponse"
+                      }
+                    ],
+                    "title": "NewSessionResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/LoadSessionResponse"
+                      }
+                    ],
+                    "title": "LoadSessionResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/ListSessionsResponse"
+                      }
+                    ],
+                    "title": "ListSessionsResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/DeleteSessionResponse"
+                      }
+                    ],
+                    "title": "DeleteSessionResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/ForkSessionResponse"
+                      }
+                    ],
+                    "title": "ForkSessionResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/ResumeSessionResponse"
+                      }
+                    ],
+                    "title": "ResumeSessionResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/CloseSessionResponse"
+                      }
+                    ],
+                    "title": "CloseSessionResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/SetSessionConfigOptionResponse"
+                      }
+                    ],
+                    "title": "SetSessionConfigOptionResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/PromptResponse"
+                      }
+                    ],
+                    "title": "PromptResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/StartNesResponse"
+                      }
+                    ],
+                    "title": "StartNesResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/SuggestNesResponse"
+                      }
+                    ],
+                    "title": "SuggestNesResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/CloseNesResponse"
+                      }
+                    ],
+                    "title": "CloseNesResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/ExtResponse"
+                      }
+                    ],
+                    "title": "ExtMethodResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/MessageMcpResponse"
+                      }
+                    ],
+                    "title": "MessageMcpResponse"
+                  }
+                ],
+                "description": "All possible responses that an agent can send to a client.\n\nThis enum is used internally for routing RPC responses. You typically won't need\nto use this directly - the responses are handled automatically by the connection.\n\nThese are responses to the corresponding `ClientRequest` variants."
+              }
+            },
+            "required": ["id", "result"],
+            "title": "Result",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "error": {
+                "$ref": "#/$defs/Error"
+              },
+              "id": {
+                "$ref": "#/$defs/RequestId"
+              }
+            },
+            "required": ["id", "error"],
+            "title": "Error",
+            "type": "object"
+          }
+        ],
+        "description": "A message (request, response, or notification) with `\"jsonrpc\": \"2.0\"` specified as\n[required by JSON-RPC 2.0 Specification][1].\n\n[1]: https://www.jsonrpc.org/specification#compatibility",
+        "properties": {
+          "jsonrpc": {
+            "enum": ["2.0"],
+            "type": "string"
+          }
+        },
+        "required": ["jsonrpc"],
+        "type": "object",
+        "x-docs-ignore": true
+      },
+      "minItems": 1,
+      "title": "AgentBatchResponse",
+      "type": "array"
+    },
+    {
+      "description": "A non-empty JSON-RPC 2.0 batch message.",
+      "items": {
+        "anyOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/$defs/ClientRequest"
+              }
+            ],
+            "title": "Request"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/$defs/ClientNotification"
+              }
+            ],
+            "title": "Notification"
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/$defs/ProtocolLevelNotification"
+              }
+            ],
+            "title": "ProtocolLevelNotification"
+          }
+        ],
+        "description": "A message (request, response, or notification) with `\"jsonrpc\": \"2.0\"` specified as\n[required by JSON-RPC 2.0 Specification][1].\n\n[1]: https://www.jsonrpc.org/specification#compatibility",
+        "properties": {
+          "jsonrpc": {
+            "enum": ["2.0"],
+            "type": "string"
+          }
+        },
+        "required": ["jsonrpc"],
+        "type": "object"
+      },
+      "minItems": 1,
+      "title": "ClientBatchCall",
+      "type": "array"
+    },
+    {
+      "description": "A non-empty JSON-RPC 2.0 batch message.",
+      "items": {
+        "anyOf": [
+          {
+            "properties": {
+              "id": {
+                "$ref": "#/$defs/RequestId"
+              },
+              "result": {
+                "anyOf": [
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/RequestPermissionResponse"
+                      }
+                    ],
+                    "title": "RequestPermissionResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/CreateElicitationResponse"
+                      }
+                    ],
+                    "title": "CreateElicitationResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/ConnectMcpResponse"
+                      }
+                    ],
+                    "title": "ConnectMcpResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/DisconnectMcpResponse"
+                      }
+                    ],
+                    "title": "DisconnectMcpResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/ExtResponse"
+                      }
+                    ],
+                    "title": "ExtMethodResponse"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/MessageMcpResponse"
+                      }
+                    ],
+                    "title": "MessageMcpResponse"
+                  }
+                ],
+                "description": "All possible responses that a client can send to an agent.\n\nThis enum is used internally for routing RPC responses. You typically won't need\nto use this directly - the responses are handled automatically by the connection.\n\nThese are responses to the corresponding `AgentRequest` variants."
+              }
+            },
+            "required": ["id", "result"],
+            "title": "Result",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "error": {
+                "$ref": "#/$defs/Error"
+              },
+              "id": {
+                "$ref": "#/$defs/RequestId"
+              }
+            },
+            "required": ["id", "error"],
+            "title": "Error",
+            "type": "object"
+          }
+        ],
+        "description": "A message (request, response, or notification) with `\"jsonrpc\": \"2.0\"` specified as\n[required by JSON-RPC 2.0 Specification][1].\n\n[1]: https://www.jsonrpc.org/specification#compatibility",
+        "properties": {
+          "jsonrpc": {
+            "enum": ["2.0"],
+            "type": "string"
+          }
+        },
+        "required": ["jsonrpc"],
+        "type": "object",
+        "x-docs-ignore": true
+      },
+      "minItems": 1,
+      "title": "ClientBatchResponse",
+      "type": "array"
+    },
+    {
+      "description": "A message (request, response, or notification) with `\"jsonrpc\": \"2.0\"` specified as\n[required by JSON-RPC 2.0 Specification][1].\n\n[1]: https://www.jsonrpc.org/specification#compatibility",
+      "properties": {
+        "jsonrpc": {
+          "enum": ["2.0"],
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "anyOf": [
             {
-              "$ref": "#/$defs/CancelRequestNotification"
+              "anyOf": [
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/CancelRequestNotification"
+                    }
+                  ],
+                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or\nchanged at any point.\n\nCancels an ongoing request.\n\nThis is a notification sent by the side that sent a request to cancel that request.\n\nUpon receiving this notification, the receiver:\n\n1. MUST cancel the corresponding request activity and all nested activities\n2. MAY send any pending notifications.\n3. MUST send one of these responses for the original request:\n  - Valid response with appropriate data (partial results or cancellation marker)\n  - Error response with code `-32800` (Cancelled)\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/cancellation)",
+                  "title": "CancelRequestNotification"
+                }
+              ],
+              "description": "General protocol-level notifications that all sides are expected to\nimplement.\n\nNotifications whose methods start with '$/' are messages which\nare protocol implementation dependent and might not be implementable in all\nclients or agents. For example if the implementation uses a single threaded\nsynchronous programming language then there is little it can do to react to\na `$/cancel_request` notification. If an agent or client receives\nnotifications starting with '$/' it is free to ignore the notification.\n\nNotifications do not expect a response."
+            },
+            {
+              "type": "null"
             }
-          ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or\nchanged at any point.\n\nCancels an ongoing request.\n\nThis is a notification sent by the side that sent a request to cancel that request.\n\nUpon receiving this notification, the receiver:\n\n1. MUST cancel the corresponding request activity and all nested activities\n2. MAY send any pending notifications.\n3. MUST send one of these responses for the original request:\n  - Valid response with appropriate data (partial results or cancellation marker)\n  - Error response with code `-32800` (Cancelled)\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/cancellation)",
-          "title": "CancelRequestNotification"
+          ]
         }
-      ],
-      "description": "General protocol-level notifications that all sides are expected to\nimplement.\n\nNotifications whose methods start with '$/' are messages which\nare protocol implementation dependent and might not be implementable in all\nclients or agents. For example if the implementation uses a single threaded\nsynchronous programming language then there is little it can do to react to\na `$/cancel_request` notification. If an agent or client receives\nnotifications starting with '$/' it is free to ignore the notification.\n\nNotifications do not expect a response.",
-      "title": "ProtocolLevel"
+      },
+      "required": ["jsonrpc", "method"],
+      "title": "ProtocolLevel",
+      "type": "object",
+      "x-docs-ignore": true
     }
   ],
   "title": "Agent Client Protocol"

--- a/src/bin/generate.rs
+++ b/src/bin/generate.rs
@@ -2,8 +2,8 @@ use agent_client_protocol_schema::ProtocolVersion;
 #[cfg(feature = "unstable_protocol_v2")]
 use agent_client_protocol_schema::v2::{
     AGENT_METHOD_NAMES, AgentNotification, AgentRequest, AgentResponse, CLIENT_METHOD_NAMES,
-    ClientNotification, ClientRequest, ClientResponse, JsonRpcMessage, Notification, Request,
-    Response,
+    ClientNotification, ClientRequest, ClientResponse, JsonRpcBatch, JsonRpcMessage, Notification,
+    Request, Response,
 };
 #[cfg(all(feature = "unstable_cancel_request", feature = "unstable_protocol_v2"))]
 use agent_client_protocol_schema::v2::{PROTOCOL_LEVEL_METHOD_NAMES, ProtocolLevelNotification};
@@ -50,6 +50,32 @@ enum ClientOutgoingMessage {
     Notification(Notification<ClientNotification>),
 }
 
+/// Messages that an agent can include in a JSON-RPC batch call to a client.
+#[cfg(feature = "unstable_protocol_v2")]
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+#[schemars(inline)]
+#[allow(clippy::large_enum_variant)]
+enum AgentBatchCallMessage {
+    Request(Request<AgentRequest>),
+    Notification(Notification<AgentNotification>),
+    #[cfg(feature = "unstable_cancel_request")]
+    ProtocolLevelNotification(Notification<ProtocolLevelNotification>),
+}
+
+/// Messages that a client can include in a JSON-RPC batch call to an agent.
+#[cfg(feature = "unstable_protocol_v2")]
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+#[schemars(inline)]
+#[allow(clippy::large_enum_variant)]
+enum ClientBatchCallMessage {
+    Request(Request<ClientRequest>),
+    Notification(Notification<ClientNotification>),
+    #[cfg(feature = "unstable_cancel_request")]
+    ProtocolLevelNotification(Notification<ProtocolLevelNotification>),
+}
+
 #[expect(dead_code)]
 #[derive(JsonSchema)]
 #[serde(untagged)]
@@ -58,8 +84,16 @@ enum ClientOutgoingMessage {
 enum AcpTypes {
     Agent(JsonRpcMessage<AgentOutgoingMessage>),
     Client(JsonRpcMessage<ClientOutgoingMessage>),
+    #[cfg(feature = "unstable_protocol_v2")]
+    AgentBatchCall(JsonRpcBatch<AgentBatchCallMessage>),
+    #[cfg(feature = "unstable_protocol_v2")]
+    AgentBatchResponse(JsonRpcBatch<Response<AgentResponse>>),
+    #[cfg(feature = "unstable_protocol_v2")]
+    ClientBatchCall(JsonRpcBatch<ClientBatchCallMessage>),
+    #[cfg(feature = "unstable_protocol_v2")]
+    ClientBatchResponse(JsonRpcBatch<Response<ClientResponse>>),
     #[cfg(feature = "unstable_cancel_request")]
-    ProtocolLevel(ProtocolLevelNotification),
+    ProtocolLevel(JsonRpcMessage<Notification<ProtocolLevelNotification>>),
 }
 
 fn main() {
@@ -236,6 +270,72 @@ mod schema_annotation_tests {
         assert_bool_extension(auth_methods, SKIP_INVALID_ITEMS_EXTENSION);
     }
 
+    #[cfg(feature = "unstable_protocol_v2")]
+    #[test]
+    fn generated_v2_schema_includes_json_rpc_batch_messages() {
+        let schema = root_schema_value();
+        for title in [
+            "AgentBatchCall",
+            "AgentBatchResponse",
+            "ClientBatchCall",
+            "ClientBatchResponse",
+        ] {
+            let batch_schema = root_variant_schema(&schema, title);
+            assert_eq!(
+                batch_schema.get("type").and_then(Value::as_str),
+                Some("array")
+            );
+            assert_eq!(
+                batch_schema.get("minItems").and_then(Value::as_u64),
+                Some(1)
+            );
+        }
+
+        #[cfg(feature = "unstable_cancel_request")]
+        for title in ["AgentBatchCall", "ClientBatchCall"] {
+            let batch_schema = root_variant_schema(&schema, title);
+            assert!(
+                schema_contains_ref(batch_schema, "#/$defs/ProtocolLevelNotification"),
+                "missing ProtocolLevelNotification in {title}"
+            );
+        }
+
+        #[cfg(feature = "unstable_cancel_request")]
+        {
+            let protocol_level = root_variant_schema(&schema, "ProtocolLevel");
+            assert_eq!(
+                protocol_level
+                    .pointer("/properties/jsonrpc/enum/0")
+                    .and_then(Value::as_str),
+                Some("2.0")
+            );
+            assert_eq!(
+                protocol_level
+                    .pointer("/properties/method/type")
+                    .and_then(Value::as_str),
+                Some("string")
+            );
+
+            let protocol_notification = def_schema(&schema, "ProtocolLevelNotification");
+            assert_eq!(
+                protocol_notification
+                    .pointer("/properties/method/type")
+                    .and_then(Value::as_str),
+                Some("string")
+            );
+            assert!(
+                protocol_notification
+                    .pointer("/required")
+                    .and_then(Value::as_array)
+                    .is_some_and(|required| required.iter().any(|field| field == "method"))
+            );
+            assert!(
+                schema_contains_ref(protocol_notification, "#/$defs/CancelRequestNotification"),
+                "missing CancelRequestNotification in ProtocolLevelNotification"
+            );
+        }
+    }
+
     #[test]
     fn source_default_on_error_fields_are_schema_annotated() {
         let root = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -275,9 +375,28 @@ mod schema_annotation_tests {
     }
 
     fn property_schema<'a>(schema: &'a Value, def_name: &str, prop_name: &str) -> &'a Value {
-        schema
-            .pointer(&format!("/$defs/{def_name}/properties/{prop_name}"))
+        def_schema(schema, def_name)
+            .pointer(&format!("/properties/{prop_name}"))
             .unwrap_or_else(|| panic!("missing schema property {def_name}.{prop_name}"))
+    }
+
+    fn def_schema<'a>(schema: &'a Value, def_name: &str) -> &'a Value {
+        schema
+            .pointer(&format!("/$defs/{def_name}"))
+            .unwrap_or_else(|| panic!("missing schema definition {def_name}"))
+    }
+
+    #[cfg(feature = "unstable_protocol_v2")]
+    fn root_variant_schema<'a>(schema: &'a Value, title: &str) -> &'a Value {
+        schema
+            .get("anyOf")
+            .and_then(Value::as_array)
+            .and_then(|variants| {
+                variants
+                    .iter()
+                    .find(|variant| variant.get("title").and_then(Value::as_str) == Some(title))
+            })
+            .unwrap_or_else(|| panic!("missing root schema variant {title}"))
     }
 
     fn assert_bool_extension(schema: &Value, extension: &str) {
@@ -293,6 +412,20 @@ mod schema_annotation_tests {
             schema.get(extension).is_none(),
             "unexpected extension {extension} on {schema}"
         );
+    }
+
+    #[cfg(all(feature = "unstable_protocol_v2", feature = "unstable_cancel_request"))]
+    fn schema_contains_ref(schema: &Value, ref_path: &str) -> bool {
+        match schema {
+            Value::Object(object) => object.iter().any(|(key, value)| {
+                key == "$ref" && value.as_str() == Some(ref_path)
+                    || schema_contains_ref(value, ref_path)
+            }),
+            Value::Array(array) => array
+                .iter()
+                .any(|value| schema_contains_ref(value, ref_path)),
+            _ => false,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,9 @@
 //!
 //! - Wire-format types for every ACP method: request, response, and
 //!   notification structs grouped by which side handles them.
-//! - JSON-RPC envelope and routing types: [`JsonRpcMessage`], [`Request`],
-//!   [`Response`], [`Notification`], [`RequestId`], [`Error`].
+//! - JSON-RPC envelope and routing types: [`JsonRpcMessage`],
+//!   [`rpc::JsonRpcBatch`], [`Request`], [`Response`], [`Notification`],
+//!   [`RequestId`], [`Error`].
 //! - Aggregated routing enums: [`AgentRequest`], [`AgentResponse`],
 //!   [`AgentNotification`], and the matching client-side trio used by SDK
 //!   crates to dispatch incoming JSON-RPC messages.

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -130,6 +130,74 @@ impl<M> JsonRpcMessage<M> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Display)]
+#[display("JSON-RPC batch must contain at least one message")]
+#[non_exhaustive]
+pub struct EmptyJsonRpcBatch;
+
+impl std::error::Error for EmptyJsonRpcBatch {}
+
+/// A non-empty JSON-RPC 2.0 batch message.
+#[derive(Debug, Serialize, JsonSchema)]
+#[schemars(inline)]
+#[serde(transparent)]
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "This comes from the JSON-RPC specification itself"
+)]
+pub struct JsonRpcBatch<M>(#[schemars(length(min = 1))] Vec<JsonRpcMessage<M>>);
+
+impl<M> JsonRpcBatch<M> {
+    /// Creates a non-empty JSON-RPC batch.
+    ///
+    /// Returns an error if `messages` is empty, because JSON-RPC 2.0 treats an
+    /// empty batch array as an invalid request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EmptyJsonRpcBatch`] when `messages` is empty.
+    pub fn new(messages: Vec<JsonRpcMessage<M>>) -> Result<Self, EmptyJsonRpcBatch> {
+        if messages.is_empty() {
+            Err(EmptyJsonRpcBatch)
+        } else {
+            Ok(Self(messages))
+        }
+    }
+
+    /// Returns the messages in this batch.
+    #[must_use]
+    pub fn as_slice(&self) -> &[JsonRpcMessage<M>] {
+        &self.0
+    }
+
+    /// Consumes this batch and returns its messages.
+    #[must_use]
+    pub fn into_vec(self) -> Vec<JsonRpcMessage<M>> {
+        self.0
+    }
+}
+
+impl<M> TryFrom<Vec<JsonRpcMessage<M>>> for JsonRpcBatch<M> {
+    type Error = EmptyJsonRpcBatch;
+
+    fn try_from(messages: Vec<JsonRpcMessage<M>>) -> Result<Self, Self::Error> {
+        Self::new(messages)
+    }
+}
+
+impl<'de, M> Deserialize<'de> for JsonRpcBatch<M>
+where
+    M: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let messages = Vec::<JsonRpcMessage<M>>::deserialize(deserializer)?;
+        Self::new(messages).map_err(serde::de::Error::custom)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -185,6 +253,44 @@ mod tests {
 
         let id = RequestId::Str("id".to_owned());
         assert_eq!(id.to_string(), "id");
+    }
+
+    #[test]
+    fn batch_deserialization_requires_at_least_one_message() {
+        let err = serde_json::from_value::<JsonRpcBatch<Notification<ClientNotification>>>(
+            Value::Array(Vec::new()),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("at least one message"));
+    }
+
+    #[test]
+    fn batch_serialization_round_trips_non_empty_messages() {
+        let notification = JsonRpcMessage::wrap(Notification {
+            method: "cancel".into(),
+            params: Some(ClientNotification::CancelNotification(CancelNotification {
+                session_id: SessionId("test-123".into()),
+                meta: None,
+            })),
+        });
+
+        let batch = JsonRpcBatch::new(vec![notification]).unwrap();
+        let serialized = serde_json::to_value(&batch).unwrap();
+        assert_eq!(
+            serialized,
+            json!([{
+                "jsonrpc": "2.0",
+                "method": "cancel",
+                "params": {
+                    "sessionId": "test-123"
+                },
+            }])
+        );
+
+        let deserialized =
+            serde_json::from_value::<JsonRpcBatch<Notification<ClientNotification>>>(serialized)
+                .unwrap();
+        assert_eq!(deserialized.as_slice().len(), 1);
     }
 
     #[test]

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -29,7 +29,7 @@ mod protocol_level;
 pub(crate) mod schema_util;
 mod tool_call;
 
-pub use crate::rpc::{JsonRpcMessage, Notification, Request, RequestId};
+pub use crate::rpc::{JsonRpcBatch, JsonRpcMessage, Notification, Request, RequestId};
 pub use agent::*;
 pub use client::*;
 pub use content::*;


### PR DESCRIPTION
Matches JSON-RPC as close as possible.
Also fixes some missing pieces in the v1 unstable for cancel request
