### PR TITLE
docs: add London AI Meetup @ Revolut talk (02.06.26)

### DIFF
--- a/docs/publications.mdx
+++ b/docs/publications.mdx
@@ -64,12 +64,20 @@ description: ACP publications, talks, presentations, and videos
   March 21, 2026 · Jun Han
 </Card>
 
+<Card
+  title="GitHub Copilot Dev Days Shanghai: Agent Client Protocol in GitHub Copilot"
+  href="https://raw.githubusercontent.com/agentclientprotocol/agent-client-protocol/main/docs/assets/publications/ACP%20talk%20Shanghai%2C%2011.04.26.pdf"
+  horizontal
+>
+  April 11, 2026 · Jun Han
+</Card>
+
   <Card
-    title="GitHub Copilot Dev Days Shanghai: Agent Client Protocol in GitHub Copilot"
-    href="https://raw.githubusercontent.com/agentclientprotocol/agent-client-protocol/main/docs/assets/publications/ACP%20talk%20Shanghai%2C%2011.04.26.pdf"
+    title="London AI Meetup @ Revolut: ACP Beyond the Editor"
+    href="https://raw.githubusercontent.com/agentclientprotocol/agent-client-protocol/main/docs/assets/publications/ACP%20talk%20London%2C%2002.06.26.pdf"
     horizontal
   >
-    April 11, 2026 · Jun Han
+    June 2, 2026 · Sergey Ignatov
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
Adds the slide deck from the **London AI Meetup @ Revolut** (June 2, 2026, Sergey Ignatov) to the Publications page.

- Adds `docs/assets/publications/ACP talk London, 02.06.26.pdf` 
- Adds a Talks card linking to it on `docs/publications.mdx`.

Note: title on the card is "London AI Meetup @ Revolut: ACP Beyond the Editor" — happy to adjust the wording.