### PR TITLE
docs: add zooid client to the clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -79,6 +79,7 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 - [WeChat ACP](https://github.com/formulahendry/wechat-acp) (WeChat)
 - [Sniptail](https://github.com/Justkog/sniptail) (Discord, Slack) - self-hosted chat bridge for running coding agents across your team’s repositories
 - [Lark ACP](https://github.com/4t145/lark-acp) (Lark/飞书)
+- [Zooid](https://github.com/zooid-ai/zooid) (Matrix) - coding agent runtime paired with a Matrix client/ACP bridge for interacting with agents
 
 ## Frameworks
 


### PR DESCRIPTION
Zooid is a "self hosted slack" for teams with multiple agents. Built on matrix, fully open stack.