### PR TITLE
feat(unstable-v2): Clean up capability objects

### DIFF
--- a/docs/protocol/v2/authentication.mdx
+++ b/docs/protocol/v2/authentication.mdx
@@ -36,7 +36,7 @@ sequenceDiagram
 
 Agents advertise authentication options in the `authMethods` field of the `initialize` response. Each method has an `id` that the Client passes back to the Agent in a later `authenticate` request.
 
-Agents that support `logout` also advertise `agentCapabilities.auth.logout`:
+Agents that support `logout` also advertise `capabilities.auth.logout`:
 
 ```json highlight={7-11,12-18}
 {
@@ -44,7 +44,7 @@ Agents that support `logout` also advertise `agentCapabilities.auth.logout`:
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
+    "capabilities": {
       "auth": {
         "logout": {}
       }
@@ -60,7 +60,7 @@ Agents that support `logout` also advertise `agentCapabilities.auth.logout`:
 }
 ```
 
-If `agentCapabilities.auth.logout` is omitted or `null`, the Agent does not support `logout` and Clients **MUST NOT** call it. Supplying `{}` means the Agent supports the method.
+If `capabilities.auth.logout` is omitted or `null`, the Agent does not support `logout` and Clients **MUST NOT** call it. Supplying `{}` means the Agent supports the method.
 
 ### Authentication Method Types
 
@@ -114,7 +114,7 @@ After successful authentication, the Client can create new sessions without rece
 
 ## Logging Out
 
-The `logout` method allows Clients to end the current authenticated state. Clients should only call it after verifying the Agent advertised `agentCapabilities.auth.logout` during initialization.
+The `logout` method allows Clients to end the current authenticated state. Clients should only call it after verifying the Agent advertised `capabilities.auth.logout` during initialization.
 
 ```json
 {

--- a/docs/protocol/v2/draft/authentication.mdx
+++ b/docs/protocol/v2/draft/authentication.mdx
@@ -36,7 +36,7 @@ sequenceDiagram
 
 Agents advertise authentication options in the `authMethods` field of the `initialize` response. Each method has an `id` that the Client passes back to the Agent in a later `authenticate` request.
 
-Agents that support `logout` also advertise `agentCapabilities.auth.logout`:
+Agents that support `logout` also advertise `capabilities.auth.logout`:
 
 ```json highlight={7-11,12-18}
 {
@@ -44,7 +44,7 @@ Agents that support `logout` also advertise `agentCapabilities.auth.logout`:
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
+    "capabilities": {
       "auth": {
         "logout": {}
       }
@@ -60,7 +60,7 @@ Agents that support `logout` also advertise `agentCapabilities.auth.logout`:
 }
 ```
 
-If `agentCapabilities.auth.logout` is omitted or `null`, the Agent does not support `logout` and Clients **MUST NOT** call it. Supplying `{}` means the Agent supports the method.
+If `capabilities.auth.logout` is omitted or `null`, the Agent does not support `logout` and Clients **MUST NOT** call it. Supplying `{}` means the Agent supports the method.
 
 ### Authentication method types
 
@@ -81,7 +81,7 @@ Draft authentication method types provide additional information so Clients can 
 
 In v2, authentication method `type` values can be custom or future variants. Custom method types **MUST** begin with `_`. Unknown non-underscore method types are reserved for future ACP variants. Clients that do not understand a method type should preserve the raw method payload when storing, replaying, proxying, or forwarding initialization data, and otherwise ignore the method or display it generically.
 
-`terminal` authentication methods require Client support. Clients advertise this during initialization with `clientCapabilities.auth.terminal`:
+`terminal` authentication methods require Client support. Clients advertise this during initialization with `capabilities.auth.terminal`:
 
 ```json highlight={7-9}
 {
@@ -90,7 +90,7 @@ In v2, authentication method `type` values can be custom or future variants. Cus
   "method": "initialize",
   "params": {
     "protocolVersion": 2,
-    "clientCapabilities": {
+    "capabilities": {
       "auth": {
         "terminal": true
       }
@@ -135,7 +135,7 @@ After successful authentication, the Client can create new sessions without rece
 
 ## Logging Out
 
-The `logout` method allows Clients to end the current authenticated state. Clients should only call it after verifying the Agent advertised `agentCapabilities.auth.logout` during initialization.
+The `logout` method allows Clients to end the current authenticated state. Clients should only call it after verifying the Agent advertised `capabilities.auth.logout` during initialization.
 
 ```json
 {

--- a/docs/protocol/v2/draft/authentication.mdx
+++ b/docs/protocol/v2/draft/authentication.mdx
@@ -92,12 +92,16 @@ In v2, authentication method `type` values can be custom or future variants. Cus
     "protocolVersion": 2,
     "capabilities": {
       "auth": {
-        "terminal": true
+        "terminal": {}
       }
     }
   }
 }
 ```
+
+If `capabilities.auth.terminal` is omitted or `null`, the Client does not
+advertise support for terminal authentication methods. Supplying `{}` means the
+Client supports terminal authentication methods.
 
 See the [draft schema](/protocol/v2/draft/schema#authmethod) for the full `AuthMethod` definitions.
 

--- a/docs/protocol/v2/draft/extensibility.mdx
+++ b/docs/protocol/v2/draft/extensibility.mdx
@@ -131,8 +131,10 @@ Implementations **SHOULD** use the `_meta` field in capability objects to advert
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "loadSession": true,
+    "capabilities": {
+      "session": {
+        "load": {}
+      },
       "_meta": {
         "zed.dev": {
           "workspace": true,

--- a/docs/protocol/v2/draft/initialization.mdx
+++ b/docs/protocol/v2/draft/initialization.mdx
@@ -37,7 +37,7 @@ They **SHOULD** also provide a name and version to the Agent.
   "method": "initialize",
   "params": {
     "protocolVersion": 2,
-    "clientCapabilities": {},
+    "capabilities": {},
     "clientInfo": {
       "name": "my-client",
       "title": "My Client",
@@ -55,14 +55,16 @@ The Agent **MUST** respond with the chosen [protocol version](#protocol-version)
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "loadSession": true,
-      "promptCapabilities": {
+    "capabilities": {
+      "session": {
+        "load": {}
+      },
+      "prompt": {
         "image": true,
         "audio": true,
         "embeddedContext": true
       },
-      "mcpCapabilities": {
+      "mcp": {
         "http": true,
         "sse": true
       }
@@ -109,19 +111,14 @@ Implementations can also [advertise custom capabilities](/protocol/v2/draft/exte
 
 ### Client Capabilities
 
-Clients **MAY** include defined capability fields in `clientCapabilities`.
+Clients **MAY** include defined capability fields in `capabilities`.
 Omitted fields mean unsupported.
 
 ### Agent Capabilities
 
 The Agent **SHOULD** specify whether it supports the following capabilities:
 
-<ResponseField name="loadSession" type="boolean" post={["default: false"]}>
-  The [`session/load`](/protocol/v2/draft/session-setup#loading-sessions) method
-  is available.
-</ResponseField>
-
-<ResponseField name="promptCapabilities" type="PromptCapabilities Object">
+<ResponseField name="prompt" type="PromptCapabilities Object">
   Object indicating the different types of [content](/protocol/v2/draft/content)
   that may be included in `session/prompt` requests.
 </ResponseField>
@@ -178,6 +175,12 @@ As a baseline, all Agents **MUST** support `session/new`, `session/prompt`, `ses
 
 Optionally, they **MAY** support other session methods and notifications by specifying additional capabilities.
 
+<ResponseField name="load" type="SessionLoadCapabilities Object">
+  The [`session/load`](/protocol/v2/draft/session-setup#loading-sessions) method
+  is available. Omitted or `null` means the Agent does not advertise support.
+  Supplying `{}` means the Agent supports loading sessions.
+</ResponseField>
+
 <ResponseField
   name="additionalDirectories"
   type="SessionAdditionalDirectoriesCapabilities Object"
@@ -186,11 +189,6 @@ Optionally, they **MAY** support other session methods and notifications by spec
   requests. Omitted or `null` means the Agent does not advertise support.
   Supplying `{}` means the Agent supports additional workspace roots.
 </ResponseField>
-
-<Note>
-  `session/load` is still handled by the top-level `load_session` capability.
-  This will be unified in future versions of the protocol.
-</Note>
 
 ## Implementation Information
 

--- a/docs/protocol/v2/draft/initialization.mdx
+++ b/docs/protocol/v2/draft/initialization.mdx
@@ -60,13 +60,13 @@ The Agent **MUST** respond with the chosen [protocol version](#protocol-version)
         "load": {}
       },
       "prompt": {
-        "image": true,
-        "audio": true,
-        "embeddedContext": true
+        "image": {},
+        "audio": {},
+        "embeddedContext": {}
       },
       "mcp": {
-        "http": true,
-        "sse": true
+        "http": {},
+        "sse": {}
       }
     },
     "agentInfo": {
@@ -133,26 +133,39 @@ As a baseline, all Agents **MUST** support `ContentBlock::Text` and `ContentBloc
 
 Optionally, they **MAY** support richer types of [content](/protocol/v2/draft/content) by specifying the following capabilities:
 
-<ResponseField name="image" type="boolean" post={["default: false"]}>
-  The prompt may include `ContentBlock::Image`
+<ResponseField name="image" type="PromptImageCapabilities Object">
+  The prompt may include `ContentBlock::Image`. Omitted or `null` means the
+  Agent does not advertise support. Supplying `{}` means the Agent supports
+  image content in prompts.
 </ResponseField>
 
-<ResponseField name="audio" type="boolean" post={["default: false"]}>
-  The prompt may include `ContentBlock::Audio`
+<ResponseField name="audio" type="PromptAudioCapabilities Object">
+  The prompt may include `ContentBlock::Audio`. Omitted or `null` means the
+  Agent does not advertise support. Supplying `{}` means the Agent supports
+  audio content in prompts.
 </ResponseField>
 
-<ResponseField name="embeddedContext" type="boolean" post={["default: false"]}>
-  The prompt may include `ContentBlock::Resource`
+<ResponseField
+  name="embeddedContext"
+  type="PromptEmbeddedContextCapabilities Object"
+>
+  The prompt may include `ContentBlock::Resource`. Omitted or `null` means the
+  Agent does not advertise support. Supplying `{}` means the Agent supports
+  embedded context in prompts.
 </ResponseField>
 
 #### MCP capabilities
 
-<ResponseField name="http" type="boolean" post={["default: false"]}>
-  The Agent supports connecting to MCP servers over HTTP.
+<ResponseField name="http" type="McpHttpCapabilities Object">
+  The Agent supports connecting to MCP servers over HTTP. Omitted or `null`
+  means the Agent does not advertise support. Supplying `{}` means the Agent
+  supports HTTP MCP server transports.
 </ResponseField>
 
-<ResponseField name="sse" type="boolean" post={["default: false"]}>
-  The Agent supports connecting to MCP servers over SSE.
+<ResponseField name="sse" type="McpSseCapabilities Object">
+  The Agent supports connecting to MCP servers over SSE. Omitted or `null` means
+  the Agent does not advertise support. Supplying `{}` means the Agent supports
+  SSE MCP server transports.
 
 Note: This transport has been deprecated by the MCP spec.
 

--- a/docs/protocol/v2/draft/overview.mdx
+++ b/docs/protocol/v2/draft/overview.mdx
@@ -88,7 +88,7 @@ Agents are programs that use generative AI to autonomously modify code. They typ
   post={[<a href="/protocol/v2/draft/schema#session%2Fload">Schema</a>]}
 >
   [Load an existing session](/protocol/v2/draft/session-setup#loading-sessions)
-  (requires `loadSession` capability).
+  (requires `session.load` capability).
 </ResponseField>
 
 <ResponseField
@@ -97,7 +97,7 @@ Agents are programs that use generative AI to autonomously modify code. They typ
 >
   [End the current authenticated
   state](/protocol/v2/draft/authentication#logging-out) (requires
-  `agentCapabilities.auth.logout` capability).
+  `capabilities.auth.logout` capability).
 </ResponseField>
 
 ### Notifications

--- a/docs/protocol/v2/draft/schema.mdx
+++ b/docs/protocol/v2/draft/schema.mdx
@@ -327,7 +327,7 @@ Note: in future versions of the protocol, this will be required.
 <ResponseField name="capabilities" type={<a href="#agentcapabilities">AgentCapabilities</a>} >
   Capabilities supported by the agent.
 
-    - Default: `{"auth":{},"loadSession":false,"mcp":{"acp":false,"http":false,"sse":false},"prompt":{"audio":false,"embeddedContext":false,"image":false},"session":{}}`
+    - Default: `{"auth":{},"mcp":{"acp":false,"http":false,"sse":false},"prompt":{"audio":false,"embeddedContext":false,"image":false},"session":{}}`
 
 </ResponseField>
 <ResponseField name="protocolVersion" type={<a href="#protocolversion">ProtocolVersion</a>} required>
@@ -923,7 +923,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 
 Closes an active session and frees up any resources associated with it.
 
-This method is only available if the agent advertises the `sessionCapabilities.close` capability.
+This method is only available if the agent advertises the `session.close` capability.
 
 The agent must cancel any ongoing work (as if `session/cancel` was called)
 and then free up any resources associated with the session.
@@ -936,7 +936,7 @@ If supported, the agent **must** cancel any ongoing work related to the session
 (treat it as if `session/cancel` was called) and then free up any resources
 associated with the session.
 
-Only available if the Agent supports the `sessionCapabilities.close` capability.
+Only available if the Agent supports the `session.close` capability.
 
 **Type:** Object
 
@@ -980,7 +980,7 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 Deletes an existing session from `session/list`.
 
-This method is only available if the agent advertises the `sessionCapabilities.delete` capability.
+This method is only available if the agent advertises the `session.delete` capability.
 
 #### <span class="font-mono">DeleteSessionRequest</span>
 
@@ -990,7 +990,7 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 Request parameters for deleting an existing session from `session/list`.
 
-Only available if the Agent supports the `sessionCapabilities.delete` capability.
+Only available if the Agent supports the `session.delete` capability.
 
 **Type:** Object
 
@@ -1119,7 +1119,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 
 Lists existing sessions known to the agent.
 
-This method is only available if the agent advertises the `sessionCapabilities.list` capability.
+This method is only available if the agent advertises the `session.list` capability.
 
 The agent should return metadata about sessions with optional filtering and pagination support.
 
@@ -1127,7 +1127,7 @@ The agent should return metadata about sessions with optional filtering and pagi
 
 Request parameters for listing existing sessions.
 
-Only available if the Agent supports the `sessionCapabilities.list` capability.
+Only available if the Agent supports the `session.list` capability.
 
 **Type:** Object
 
@@ -1177,7 +1177,7 @@ to fetch the next page. If absent, there are no more results.
 
 Loads an existing session to resume a previous conversation.
 
-This method is only available if the agent advertises the `loadSession` capability.
+This method is only available if the agent advertises the `session.load` capability.
 
 The agent should:
 
@@ -1191,7 +1191,7 @@ See protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/v
 
 Request parameters for loading an existing session.
 
-Only available if the Agent supports the `loadSession` capability.
+Only available if the Agent supports the `session.load` capability.
 
 See protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/v2/draft/session-setup#loading-sessions)
 
@@ -1415,7 +1415,7 @@ Token usage for this turn (optional).
 
 Resumes an existing session without returning previous messages.
 
-This method is only available if the agent advertises the `sessionCapabilities.resume` capability.
+This method is only available if the agent advertises the `session.resume` capability.
 
 The agent should resume the session context, allowing the conversation to continue
 without replaying the message history (unlike `session/load`).
@@ -1427,7 +1427,7 @@ Request parameters for resuming an existing session.
 Resumes an existing session without returning previous messages (unlike `session/load`).
 This is useful for agents that can resume sessions but don't implement full session loading.
 
-Only available if the Agent supports the `sessionCapabilities.resume` capability.
+Only available if the Agent supports the `session.resume` capability.
 
 **Type:** Object
 
@@ -2161,12 +2161,6 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
   Authentication-related capabilities supported by the agent.
 
     - Default: `{}`
-
-</ResponseField>
-<ResponseField name="loadSession" type={"boolean"} >
-  Whether the agent supports `session/load`.
-
-    - Default: `false`
 
 </ResponseField>
 <ResponseField name="mcp" type={<a href="#mcpcapabilities">McpCapabilities</a>} >
@@ -6193,8 +6187,6 @@ As a baseline, all Agents **MUST** support `session/new`, `session/prompt`, `ses
 
 Optionally, they **MAY** support other session methods and notifications by specifying additional capabilities.
 
-Note: `session/load` is still handled by the top-level `load_session` capability. This will be unified in future versions of the protocol.
-
 See protocol docs: [Session Capabilities](https://agentclientprotocol.com/protocol/v2/draft/initialization#session-capabilities)
 
 **Type:** Object
@@ -6241,6 +6233,13 @@ Whether the agent supports `session/fork`.
 </ResponseField>
 <ResponseField name="list" type={<><span><a href="#sessionlistcapabilities">SessionListCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/list`.
+</ResponseField>
+<ResponseField name="load" type={<><span><a href="#sessionloadcapabilities">SessionLoadCapabilities</a></span><span> | null</span></>} >
+  Whether the agent supports `session/load`.
+
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports loading sessions.
+
 </ResponseField>
 <ResponseField name="resume" type={<><span><a href="#sessionresumecapabilities">SessionResumeCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/resume`.
@@ -6649,6 +6648,25 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 Capabilities for the `session/list` method.
 
 By supplying `\{\}` it means that the agent supports listing of sessions.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
+
+</ResponseField>
+
+## <span class="font-mono">SessionLoadCapabilities</span>
+
+Capabilities for the `session/load` method.
+
+Supplying `\{\}` means the agent supports loading sessions.
 
 **Type:** Object
 

--- a/docs/protocol/v2/draft/schema.mdx
+++ b/docs/protocol/v2/draft/schema.mdx
@@ -276,7 +276,7 @@ these keys.
 See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
 
 </ResponseField>
-<ResponseField name="clientCapabilities" type={<a href="#clientcapabilities">ClientCapabilities</a>} >
+<ResponseField name="capabilities" type={<a href="#clientcapabilities">ClientCapabilities</a>} >
   Capabilities supported by the client.
 
     - Default: `{"auth":{"terminal":false}}`
@@ -312,12 +312,6 @@ these keys.
 See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
 
 </ResponseField>
-<ResponseField name="agentCapabilities" type={<a href="#agentcapabilities">AgentCapabilities</a>} >
-  Capabilities supported by the agent.
-
-    - Default: `{"auth":{},"loadSession":false,"mcpCapabilities":{"acp":false,"http":false,"sse":false},"promptCapabilities":{"audio":false,"embeddedContext":false,"image":false},"sessionCapabilities":{}}`
-
-</ResponseField>
 <ResponseField name="agentInfo" type={<><span><a href="#implementation">Implementation</a></span><span> | null</span></>} >
   Information about the Agent name and version sent to the Client.
 
@@ -328,6 +322,12 @@ Note: in future versions of the protocol, this will be required.
   Authentication methods supported by the agent.
 
     - Default: `[]`
+
+</ResponseField>
+<ResponseField name="capabilities" type={<a href="#agentcapabilities">AgentCapabilities</a>} >
+  Capabilities supported by the agent.
+
+    - Default: `{"auth":{},"loadSession":false,"mcp":{"acp":false,"http":false,"sse":false},"prompt":{"audio":false,"embeddedContext":false,"image":false},"session":{}}`
 
 </ResponseField>
 <ResponseField name="protocolVersion" type={<a href="#protocolversion">ProtocolVersion</a>} required>
@@ -2169,7 +2169,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
     - Default: `false`
 
 </ResponseField>
-<ResponseField name="mcpCapabilities" type={<a href="#mcpcapabilities">McpCapabilities</a>} >
+<ResponseField name="mcp" type={<a href="#mcpcapabilities">McpCapabilities</a>} >
   MCP capabilities supported by the agent.
 
     - Default: `{"acp":false,"http":false,"sse":false}`
@@ -2191,7 +2191,7 @@ This capability is not part of the spec yet, and may be removed or changed at an
 The position encoding selected by the agent from the client's supported encodings.
 
 </ResponseField>
-<ResponseField name="promptCapabilities" type={<a href="#promptcapabilities">PromptCapabilities</a>} >
+<ResponseField name="prompt" type={<a href="#promptcapabilities">PromptCapabilities</a>} >
   Prompt capabilities supported by the agent.
 
     - Default: `{"audio":false,"embeddedContext":false,"image":false}`
@@ -2207,7 +2207,7 @@ Provider configuration capabilities supported by the agent.
 By supplying `\{\}` it means that the agent supports provider configuration methods.
 
 </ResponseField>
-<ResponseField name="sessionCapabilities" type={<a href="#sessioncapabilities">SessionCapabilities</a>} >
+<ResponseField name="session" type={<a href="#sessioncapabilities">SessionCapabilities</a>} >
 
     - Default: `{}`
 
@@ -4123,7 +4123,7 @@ See protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/v2/dra
 <ResponseField name="http" type="object">
 HTTP transport configuration
 
-Only available when the Agent capabilities indicate `mcp_capabilities.http` is `true`.
+Only available when the Agent capabilities indicate `mcp.http` is `true`.
 
 <Expandable title="Properties">
 
@@ -4154,7 +4154,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 <ResponseField name="sse" type="object">
 SSE transport configuration
 
-Only available when the Agent capabilities indicate `mcp_capabilities.sse` is `true`.
+Only available when the Agent capabilities indicate `mcp.sse` is `true`.
 
 <Expandable title="Properties">
 
@@ -4189,7 +4189,7 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 ACP transport configuration
 
-Only available when the Agent capabilities indicate `mcp_capabilities.acp` is `true`.
+Only available when the Agent capabilities indicate `mcp.acp` is `true`.
 The MCP server is provided by an ACP component and communicates over the ACP channel.
 
 <Expandable title="Properties">

--- a/docs/protocol/v2/draft/schema.mdx
+++ b/docs/protocol/v2/draft/schema.mdx
@@ -279,7 +279,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 <ResponseField name="capabilities" type={<a href="#clientcapabilities">ClientCapabilities</a>} >
   Capabilities supported by the client.
 
-    - Default: `{"auth":{"terminal":false}}`
+    - Default: `{"auth":{}}`
 
 </ResponseField>
 <ResponseField name="clientInfo" type={<><span><a href="#implementation">Implementation</a></span><span> | null</span></>} >
@@ -327,7 +327,7 @@ Note: in future versions of the protocol, this will be required.
 <ResponseField name="capabilities" type={<a href="#agentcapabilities">AgentCapabilities</a>} >
   Capabilities supported by the agent.
 
-    - Default: `{"auth":{},"mcp":{"acp":false,"http":false,"sse":false},"prompt":{"audio":false,"embeddedContext":false,"image":false},"session":{}}`
+    - Default: `{"auth":{},"mcp":{},"prompt":{},"session":{}}`
 
 </ResponseField>
 <ResponseField name="protocolVersion" type={<a href="#protocolversion">ProtocolVersion</a>} required>
@@ -2166,7 +2166,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 <ResponseField name="mcp" type={<a href="#mcpcapabilities">McpCapabilities</a>} >
   MCP capabilities supported by the agent.
 
-    - Default: `{"acp":false,"http":false,"sse":false}`
+    - Default: `{}`
 
 </ResponseField>
 <ResponseField name="nes" type={<><span><a href="#nescapabilities">NesCapabilities</a></span><span> | null</span></>} >
@@ -2188,7 +2188,7 @@ The position encoding selected by the agent from the client's supported encoding
 <ResponseField name="prompt" type={<a href="#promptcapabilities">PromptCapabilities</a>} >
   Prompt capabilities supported by the agent.
 
-    - Default: `{"audio":false,"embeddedContext":false,"image":false}`
+    - Default: `{}`
 
 </ResponseField>
 <ResponseField name="providers" type={<><span><a href="#providerscapabilities">ProvidersCapabilities</a></span><span> | null</span></>} >
@@ -2277,12 +2277,11 @@ these keys.
 See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
 
 </ResponseField>
-<ResponseField name="terminal" type={"boolean"} >
+<ResponseField name="terminal" type={<><span><a href="#terminalauthcapabilities">TerminalAuthCapabilities</a></span><span> | null</span></>} >
   Whether the client supports `terminal` authentication methods.
 
-When `true`, the agent may include `terminal` entries in its authentication methods.
-
-    - Default: `false`
+Optional. Omitted or `null` both mean the client does not advertise support.
+Supplying `\{\}` means the agent may include `terminal` entries in its authentication methods.
 
 </ResponseField>
 
@@ -2760,7 +2759,7 @@ Authentication capabilities supported by the client.
 Determines which authentication method types the agent may include
 in its `InitializeResponse`.
 
-    - Default: `{"terminal":false}`
+    - Default: `{}`
 
 </ResponseField>
 <ResponseField name="elicitation" type={<><span><a href="#elicitationcapabilities">ElicitationCapabilities</a></span><span> | null</span></>} >
@@ -4054,6 +4053,29 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 
 </ResponseField>
 
+## <span class="font-mono">McpAcpCapabilities</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Capabilities for ACP MCP server transports.
+
+Supplying `\{\}` means the agent supports ACP MCP server transports.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
+
+</ResponseField>
+
 ## <span class="font-mono">McpCapabilities</span>
 
 MCP capabilities supported by the agent
@@ -4070,26 +4092,29 @@ these keys.
 See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
 
 </ResponseField>
-<ResponseField name="acp" type={"boolean"} >
+<ResponseField name="acp" type={<><span><a href="#mcpacpcapabilities">McpAcpCapabilities</a></span><span> | null</span></>} >
   **UNSTABLE**
 
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
 Agent supports `McpServer::Acp`.
 
-    - Default: `false`
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports ACP MCP server transports.
 
 </ResponseField>
-<ResponseField name="http" type={"boolean"} >
+<ResponseField name="http" type={<><span><a href="#mcphttpcapabilities">McpHttpCapabilities</a></span><span> | null</span></>} >
   Agent supports `McpServer::Http`.
 
-    - Default: `false`
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports HTTP MCP server transports.
 
 </ResponseField>
-<ResponseField name="sse" type={"boolean"} >
+<ResponseField name="sse" type={<><span><a href="#mcpssecapabilities">McpSseCapabilities</a></span><span> | null</span></>} >
   Agent supports `McpServer::Sse`.
 
-    - Default: `false`
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports SSE MCP server transports.
 
 </ResponseField>
 
@@ -4102,6 +4127,25 @@ This capability is not part of the spec yet, and may be removed or changed at an
 A unique identifier for an active MCP-over-ACP connection.
 
 **Type:** `string`
+
+## <span class="font-mono">McpHttpCapabilities</span>
+
+Capabilities for HTTP MCP server transports.
+
+Supplying `\{\}` means the agent supports HTTP MCP server transports.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
+
+</ResponseField>
 
 ## <span class="font-mono">McpServer</span>
 
@@ -4117,7 +4161,7 @@ See protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/v2/dra
 <ResponseField name="http" type="object">
 HTTP transport configuration
 
-Only available when the Agent capabilities indicate `mcp.http` is `true`.
+Only available when the Agent capabilities include `mcp.http`.
 
 <Expandable title="Properties">
 
@@ -4148,7 +4192,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 <ResponseField name="sse" type="object">
 SSE transport configuration
 
-Only available when the Agent capabilities indicate `mcp.sse` is `true`.
+Only available when the Agent capabilities include `mcp.sse`.
 
 <Expandable title="Properties">
 
@@ -4183,7 +4227,7 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 ACP transport configuration
 
-Only available when the Agent capabilities indicate `mcp.acp` is `true`.
+Only available when the Agent capabilities include `mcp.acp`.
 The MCP server is provided by an ACP component and communicates over the ACP channel.
 
 <Expandable title="Properties">
@@ -4371,6 +4415,25 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 </ResponseField>
 <ResponseField name="name" type={"string"} required>
   Human-readable name identifying this MCP server.
+</ResponseField>
+
+## <span class="font-mono">McpSseCapabilities</span>
+
+Capabilities for SSE MCP server transports.
+
+Supplying `\{\}` means the agent supports SSE MCP server transports.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
+
 </ResponseField>
 
 ## <span class="font-mono">MessageId</span>
@@ -5855,6 +5918,25 @@ Follows the same conventions as LSP 3.17. The default is UTF-16.
   Character offsets count UTF-8 code units (bytes).
 </ResponseField>
 
+## <span class="font-mono">PromptAudioCapabilities</span>
+
+Capabilities for audio content in prompt requests.
+
+Supplying `\{\}` means the agent supports audio content in prompts.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
+
+</ResponseField>
+
 ## <span class="font-mono">PromptCapabilities</span>
 
 Prompt capabilities supported by the agent in `session/prompt` requests.
@@ -5882,25 +5964,66 @@ these keys.
 See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
 
 </ResponseField>
-<ResponseField name="audio" type={"boolean"} >
+<ResponseField name="audio" type={<><span><a href="#promptaudiocapabilities">PromptAudioCapabilities</a></span><span> | null</span></>} >
   Agent supports `ContentBlock::Audio`.
 
-    - Default: `false`
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports audio content in prompts.
 
 </ResponseField>
-<ResponseField name="embeddedContext" type={"boolean"} >
+<ResponseField name="embeddedContext" type={<><span><a href="#promptembeddedcontextcapabilities">PromptEmbeddedContextCapabilities</a></span><span> | null</span></>} >
   Agent supports embedded context in `session/prompt` requests.
 
 When enabled, the Client is allowed to include `ContentBlock::Resource`
 in prompt requests for pieces of context that are referenced in the message.
 
-    - Default: `false`
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports embedded context in prompts.
 
 </ResponseField>
-<ResponseField name="image" type={"boolean"} >
+<ResponseField name="image" type={<><span><a href="#promptimagecapabilities">PromptImageCapabilities</a></span><span> | null</span></>} >
   Agent supports `ContentBlock::Image`.
 
-    - Default: `false`
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports image content in prompts.
+
+</ResponseField>
+
+## <span class="font-mono">PromptEmbeddedContextCapabilities</span>
+
+Capabilities for embedded context in prompt requests.
+
+Supplying `\{\}` means the agent supports embedded context in prompts.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
+
+</ResponseField>
+
+## <span class="font-mono">PromptImageCapabilities</span>
+
+Capabilities for image content in prompt requests.
+
+Supplying `\{\}` means the agent supports image content in prompts.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
 
 </ResponseField>
 
@@ -7196,6 +7319,29 @@ with `"type": "string"`.
 </ResponseField>
 <ResponseField name="title" type={"string | null"} >
   Optional title for the property.
+</ResponseField>
+
+## <span class="font-mono">TerminalAuthCapabilities</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Capabilities for terminal authentication methods.
+
+Supplying `\{\}` means the client supports terminal authentication methods.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/draft/extensibility)
+
 </ResponseField>
 
 ## <span class="font-mono">TextContent</span>

--- a/docs/protocol/v2/draft/session-delete.mdx
+++ b/docs/protocol/v2/draft/session-delete.mdx
@@ -32,7 +32,7 @@ sequenceDiagram
 
 ## Checking Support
 
-Before attempting to delete a session, Clients **MUST** verify that the Agent supports this capability by checking the unstable `sessionCapabilities.delete` field in the `initialize` response:
+Before attempting to delete a session, Clients **MUST** verify that the Agent supports this capability by checking the unstable `session.delete` field in the `initialize` response:
 
 ```json highlight={7-9}
 {
@@ -40,8 +40,8 @@ Before attempting to delete a session, Clients **MUST** verify that the Agent su
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "sessionCapabilities": {
+    "capabilities": {
+      "session": {
         "delete": {}
       }
     }
@@ -49,7 +49,7 @@ Before attempting to delete a session, Clients **MUST** verify that the Agent su
 }
 ```
 
-If `sessionCapabilities.delete` is omitted or `null`, the Agent does not support deleting sessions and Clients **MUST NOT** attempt to call `session/delete`. Supplying `{}` means the Agent supports the method.
+If `session.delete` is omitted or `null`, the Agent does not support deleting sessions and Clients **MUST NOT** attempt to call `session/delete`. Supplying `{}` means the Agent supports the method.
 
 ## Deleting a Session
 
@@ -82,7 +82,7 @@ On success, the Agent returns an empty result:
 
 ## Semantics
 
-- Agents **MUST NOT** accept `session/delete` calls unless they advertised `sessionCapabilities.delete` during initialization.
+- Agents **MUST NOT** accept `session/delete` calls unless they advertised `session.delete` during initialization.
 - Deleted sessions no longer appear in future `session/list` results.
 - Deleting an already-deleted session, or a session that never existed, **SHOULD** succeed silently.
 - Agents may implement soft delete or hard delete. ACP only specifies the user-facing session-list behavior.

--- a/docs/protocol/v2/draft/session-list.mdx
+++ b/docs/protocol/v2/draft/session-list.mdx
@@ -34,7 +34,7 @@ sequenceDiagram
 
 ## Checking Support
 
-Before attempting to list sessions, Clients **MUST** verify that the Agent supports this capability by checking the `sessionCapabilities.list` field in the `initialize` response:
+Before attempting to list sessions, Clients **MUST** verify that the Agent supports this capability by checking the `session.list` field in the `initialize` response:
 
 ```json highlight={7-9}
 {
@@ -42,8 +42,8 @@ Before attempting to list sessions, Clients **MUST** verify that the Agent suppo
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "sessionCapabilities": {
+    "capabilities": {
+      "session": {
         "list": {}
       }
     }
@@ -51,15 +51,15 @@ Before attempting to list sessions, Clients **MUST** verify that the Agent suppo
 }
 ```
 
-If `sessionCapabilities.list` is not present, the Agent does not support listing sessions and Clients **MUST NOT** attempt to call `session/list`.
+If `session.list` is not present, the Agent does not support listing sessions and Clients **MUST NOT** attempt to call `session/list`.
 
-Agents that also advertise `sessionCapabilities.additionalDirectories` may
+Agents that also advertise `session.additionalDirectories` may
 include `additionalDirectories` in returned `SessionInfo` objects to report
 additional workspace roots for listed sessions.
 
 <Note>
-  If the Agent advertises the unstable `sessionCapabilities.delete` capability,
-  Clients can remove sessions from future `session/list` results with
+  If the Agent advertises the unstable `session.delete` capability, Clients can
+  remove sessions from future `session/list` results with
   [`session/delete`](/protocol/v2/draft/session-delete).
 </Note>
 
@@ -137,7 +137,7 @@ The Agent **MUST** respond with a list of sessions and optional pagination metad
       Working directory for the session. Always an absolute path.
     </ResponseField>
     <ResponseField name="additionalDirectories" type="string[]">
-      If the Agent advertises `sessionCapabilities.additionalDirectories`, it
+      If the Agent advertises `session.additionalDirectories`, it
       MAY include this field to report the complete ordered additional-root list
       associated with the listed session. Omitted and empty values are
       equivalent: this `SessionInfo` response reports no additional roots.

--- a/docs/protocol/v2/draft/session-setup.mdx
+++ b/docs/protocol/v2/draft/session-setup.mdx
@@ -556,16 +556,17 @@ Before using HTTP or SSE transports, Clients **MUST** verify the Agent's capabil
     "protocolVersion": 2,
     "capabilities": {
       "mcp": {
-        "http": true,
-        "sse": true
+        "http": {},
+        "sse": {}
       }
     }
   }
 }
 ```
 
-If `mcp.http` is `false` or not present, the Agent does not support HTTP transport.
-If `mcp.sse` is `false` or not present, the Agent does not support SSE transport.
+If `mcp.http` is omitted or `null`, the Agent does not support HTTP transport.
+If `mcp.sse` is omitted or `null`, the Agent does not support SSE transport.
+Supplying `{}` means the Agent supports the corresponding transport.
 
 Agents **SHOULD** connect to all MCP servers specified by the Client.
 

--- a/docs/protocol/v2/draft/session-setup.mdx
+++ b/docs/protocol/v2/draft/session-setup.mdx
@@ -84,11 +84,11 @@ The Agent **MUST** respond with a unique [Session ID](#session-id) that identifi
 
 ## Loading Sessions
 
-Agents that support the `loadSession` capability allow Clients to resume previous conversations with history replay. This feature enables persistence across restarts and sharing sessions between different Client instances.
+Agents that support the `session.load` capability allow Clients to resume previous conversations with history replay. This feature enables persistence across restarts and sharing sessions between different Client instances.
 
 ### Checking Support
 
-Before attempting to load a session, Clients **MUST** verify that the Agent supports this capability by checking the `loadSession` field in the `initialize` response:
+Before attempting to load a session, Clients **MUST** verify that the Agent supports this capability by checking the `session.load` field in the `initialize` response:
 
 ```json highlight={7}
 {
@@ -96,14 +96,16 @@ Before attempting to load a session, Clients **MUST** verify that the Agent supp
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "loadSession": true
+    "capabilities": {
+      "session": {
+        "load": {}
+      }
     }
   }
 }
 ```
 
-If `loadSession` is `false` or not present, the Agent does not support loading sessions and Clients **MUST NOT** attempt to call `session/load`.
+If `session.load` is omitted or `null`, the Agent does not support loading sessions and Clients **MUST NOT** attempt to call `session/load`.
 
 ### Loading a Session
 
@@ -196,13 +198,13 @@ interrupted.
 
 ## Resuming Sessions
 
-Agents that advertise `sessionCapabilities.resume` allow Clients to reconnect to
+Agents that advertise `session.resume` allow Clients to reconnect to
 an existing session without replaying the conversation history.
 
 ### Checking Support
 
 Before attempting to resume a session, Clients **MUST** verify that the Agent
-supports this capability by checking for the `sessionCapabilities.resume` field
+supports this capability by checking for the `session.resume` field
 in the `initialize` response:
 
 ```json highlight={7-9}
@@ -211,8 +213,8 @@ in the `initialize` response:
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "sessionCapabilities": {
+    "capabilities": {
+      "session": {
         "resume": {}
       }
     }
@@ -220,7 +222,7 @@ in the `initialize` response:
 }
 ```
 
-If `sessionCapabilities.resume` is not present, the Agent does not support
+If `session.resume` is not present, the Agent does not support
 resuming sessions and Clients **MUST NOT** attempt to call `session/resume`.
 
 ### Resuming a Session
@@ -270,14 +272,14 @@ feature is supported by the Agent.
 
 ## Closing Active Sessions
 
-Agents that advertise `sessionCapabilities.close` allow Clients to tell the
+Agents that advertise `session.close` allow Clients to tell the
 Agent to cancel any ongoing work for a session and free any resources
 associated with that active session.
 
 ### Checking Support
 
 Before attempting to close a session, Clients **MUST** verify that the Agent
-supports this capability by checking the `sessionCapabilities.close` field in
+supports this capability by checking the `session.close` field in
 the `initialize` response:
 
 ```json highlight={7-9}
@@ -286,8 +288,8 @@ the `initialize` response:
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "sessionCapabilities": {
+    "capabilities": {
+      "session": {
         "close": {}
       }
     }
@@ -295,7 +297,7 @@ the `initialize` response:
 }
 ```
 
-If `sessionCapabilities.close` is not present, the Agent does not support
+If `session.close` is not present, the Agent does not support
 closing sessions and Clients **MUST NOT** attempt to call `session/close`.
 
 ### Closing a Session
@@ -337,7 +339,7 @@ active.
 
 ## Additional Workspace Roots
 
-Agents that advertise `sessionCapabilities.additionalDirectories` allow Clients
+Agents that advertise `session.additionalDirectories` allow Clients
 to include `additionalDirectories` on supported session lifecycle requests to
 expand the session's effective workspace root set. Supported stable lifecycle
 requests include `session/new`, `session/load`, and `session/resume`.
@@ -366,7 +368,7 @@ When present, `additionalDirectories` has the following behavior:
 - omitting the field or providing an empty array activates no additional roots for the resulting session
 - on `session/load` and `session/resume`, Clients must send the full intended additional-root list again; that list may differ from any previous or reported list as long as the request `cwd` matches the session's `cwd`, and omitting the field or providing an empty array does not restore stored roots implicitly
 
-Clients **MUST** only send `additionalDirectories` when the Agent advertises `sessionCapabilities.additionalDirectories`.
+Clients **MUST** only send `additionalDirectories` when the Agent advertises `session.additionalDirectories`.
 
 ## Session ID
 
@@ -376,9 +378,9 @@ Clients use this ID to:
 
 - Send prompt requests via `session/prompt`
 - Cancel ongoing operations via `session/cancel`
-- Load previous sessions via `session/load` (if the Agent supports the `loadSession` capability)
-- Resume previous sessions via `session/resume` (if the Agent supports the `sessionCapabilities.resume` capability)
-- Close active sessions via `session/close` (if the Agent supports the `sessionCapabilities.close` capability)
+- Load previous sessions via `session/load` (if the Agent supports the `session.load` capability)
+- Resume previous sessions via `session/resume` (if the Agent supports the `session.resume` capability)
+- Close active sessions via `session/close` (if the Agent supports the `session.close` capability)
 
 ## Working Directory
 
@@ -389,7 +391,7 @@ The `cwd` (current working directory) parameter establishes the primary file sys
 - **MUST** remain the base for relative-path resolution
 - **MUST** be part of the session's effective root set
 
-When `sessionCapabilities.additionalDirectories` is in use, the session's effective root set is `[cwd, ...additionalDirectories]`. This root set **SHOULD** serve as a boundary for tool operations on the file system.
+When `session.additionalDirectories` is in use, the session's effective root set is `[cwd, ...additionalDirectories]`. This root set **SHOULD** serve as a boundary for tool operations on the file system.
 
 ## MCP Servers
 
@@ -448,7 +450,7 @@ Example stdio transport configuration:
 
 #### HTTP Transport
 
-When the Agent supports `mcpCapabilities.http`, Clients can specify MCP servers configurations using the HTTP transport.
+When the Agent supports `mcp.http`, Clients can specify MCP servers configurations using the HTTP transport.
 
 <ParamField path="type" type="string" required>
   Must be `"http"` to indicate HTTP transport
@@ -497,7 +499,7 @@ Example HTTP transport configuration:
 
 #### SSE Transport
 
-When the Agent supports `mcpCapabilities.sse`, Clients can specify MCP servers configurations using the SSE transport.
+When the Agent supports `mcp.sse`, Clients can specify MCP servers configurations using the SSE transport.
 
 <Warning>This transport was deprecated by the MCP spec.</Warning>
 
@@ -552,8 +554,8 @@ Before using HTTP or SSE transports, Clients **MUST** verify the Agent's capabil
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "mcpCapabilities": {
+    "capabilities": {
+      "mcp": {
         "http": true,
         "sse": true
       }
@@ -562,8 +564,8 @@ Before using HTTP or SSE transports, Clients **MUST** verify the Agent's capabil
 }
 ```
 
-If `mcpCapabilities.http` is `false` or not present, the Agent does not support HTTP transport.
-If `mcpCapabilities.sse` is `false` or not present, the Agent does not support SSE transport.
+If `mcp.http` is `false` or not present, the Agent does not support HTTP transport.
+If `mcp.sse` is `false` or not present, the Agent does not support SSE transport.
 
 Agents **SHOULD** connect to all MCP servers specified by the Client.
 

--- a/docs/protocol/v2/extensibility.mdx
+++ b/docs/protocol/v2/extensibility.mdx
@@ -131,8 +131,10 @@ Implementations **SHOULD** use the `_meta` field in capability objects to advert
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "loadSession": true,
+    "capabilities": {
+      "session": {
+        "load": {}
+      },
       "_meta": {
         "zed.dev": {
           "workspace": true,

--- a/docs/protocol/v2/initialization.mdx
+++ b/docs/protocol/v2/initialization.mdx
@@ -60,13 +60,13 @@ The Agent **MUST** respond with the chosen [protocol version](#protocol-version)
         "load": {}
       },
       "prompt": {
-        "image": true,
-        "audio": true,
-        "embeddedContext": true
+        "image": {},
+        "audio": {},
+        "embeddedContext": {}
       },
       "mcp": {
-        "http": true,
-        "sse": true
+        "http": {},
+        "sse": {}
       }
     },
     "agentInfo": {
@@ -134,26 +134,39 @@ As a baseline, all Agents **MUST** support `ContentBlock::Text` and `ContentBloc
 
 Optionally, they **MAY** support richer types of [content](/protocol/v2/content) by specifying the following capabilities:
 
-<ResponseField name="image" type="boolean" post={["default: false"]}>
-  The prompt may include `ContentBlock::Image`
+<ResponseField name="image" type="PromptImageCapabilities Object">
+  The prompt may include `ContentBlock::Image`. Omitted or `null` means the
+  Agent does not advertise support. Supplying `{}` means the Agent supports
+  image content in prompts.
 </ResponseField>
 
-<ResponseField name="audio" type="boolean" post={["default: false"]}>
-  The prompt may include `ContentBlock::Audio`
+<ResponseField name="audio" type="PromptAudioCapabilities Object">
+  The prompt may include `ContentBlock::Audio`. Omitted or `null` means the
+  Agent does not advertise support. Supplying `{}` means the Agent supports
+  audio content in prompts.
 </ResponseField>
 
-<ResponseField name="embeddedContext" type="boolean" post={["default: false"]}>
-  The prompt may include `ContentBlock::Resource`
+<ResponseField
+  name="embeddedContext"
+  type="PromptEmbeddedContextCapabilities Object"
+>
+  The prompt may include `ContentBlock::Resource`. Omitted or `null` means the
+  Agent does not advertise support. Supplying `{}` means the Agent supports
+  embedded context in prompts.
 </ResponseField>
 
 #### MCP capabilities
 
-<ResponseField name="http" type="boolean" post={["default: false"]}>
-  The Agent supports connecting to MCP servers over HTTP.
+<ResponseField name="http" type="McpHttpCapabilities Object">
+  The Agent supports connecting to MCP servers over HTTP. Omitted or `null`
+  means the Agent does not advertise support. Supplying `{}` means the Agent
+  supports HTTP MCP server transports.
 </ResponseField>
 
-<ResponseField name="sse" type="boolean" post={["default: false"]}>
-  The Agent supports connecting to MCP servers over SSE.
+<ResponseField name="sse" type="McpSseCapabilities Object">
+  The Agent supports connecting to MCP servers over SSE. Omitted or `null` means
+  the Agent does not advertise support. Supplying `{}` means the Agent supports
+  SSE MCP server transports.
 
 Note: This transport has been deprecated by the MCP spec.
 

--- a/docs/protocol/v2/initialization.mdx
+++ b/docs/protocol/v2/initialization.mdx
@@ -37,7 +37,7 @@ They **SHOULD** also provide a name and version to the Agent.
   "method": "initialize",
   "params": {
     "protocolVersion": 2,
-    "clientCapabilities": {},
+    "capabilities": {},
     "clientInfo": {
       "name": "my-client",
       "title": "My Client",
@@ -55,14 +55,16 @@ The Agent **MUST** respond with the chosen [protocol version](#protocol-version)
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "loadSession": true,
-      "promptCapabilities": {
+    "capabilities": {
+      "session": {
+        "load": {}
+      },
+      "prompt": {
         "image": true,
         "audio": true,
         "embeddedContext": true
       },
-      "mcpCapabilities": {
+      "mcp": {
         "http": true,
         "sse": true
       }
@@ -109,7 +111,7 @@ Implementations can also [advertise custom capabilities](/protocol/v2/extensibil
 
 ### Client Capabilities
 
-Clients **MAY** include defined capability fields in `clientCapabilities`.
+Clients **MAY** include defined capability fields in `capabilities`.
 Omitted fields mean unsupported. Extension-specific capabilities belong in
 `_meta`.
 
@@ -117,12 +119,7 @@ Omitted fields mean unsupported. Extension-specific capabilities belong in
 
 The Agent **SHOULD** specify whether it supports the following capabilities:
 
-<ResponseField name="loadSession" type="boolean" post={["default: false"]}>
-  The [`session/load`](/protocol/v2/session-setup#loading-sessions) method is
-  available.
-</ResponseField>
-
-<ResponseField name="promptCapabilities" type="PromptCapabilities Object">
+<ResponseField name="prompt" type="PromptCapabilities Object">
   Object indicating the different types of [content](/protocol/v2/content) that
   may be included in `session/prompt` requests.
 </ResponseField>
@@ -178,6 +175,12 @@ As a baseline, all Agents **MUST** support `session/new`, `session/prompt`, `ses
 
 Optionally, they **MAY** support other session methods and notifications by specifying additional capabilities.
 
+<ResponseField name="load" type="SessionLoadCapabilities Object">
+  The [`session/load`](/protocol/v2/session-setup#loading-sessions) method is
+  available. Omitted or `null` means the Agent does not advertise support.
+  Supplying `{}` means the Agent supports loading sessions.
+</ResponseField>
+
 <ResponseField
   name="additionalDirectories"
   type="SessionAdditionalDirectoriesCapabilities Object"
@@ -186,11 +189,6 @@ Optionally, they **MAY** support other session methods and notifications by spec
   requests. Omitted or `null` means the Agent does not advertise support.
   Supplying `{}` means the Agent supports additional workspace roots.
 </ResponseField>
-
-<Note>
-  `session/load` is still handled by the top-level `load_session` capability.
-  This will be unified in future versions of the protocol.
-</Note>
 
 ## Implementation Information
 

--- a/docs/protocol/v2/overview.mdx
+++ b/docs/protocol/v2/overview.mdx
@@ -86,7 +86,7 @@ Agents are programs that use generative AI to autonomously modify code. They typ
   post={[<a href="/protocol/v2/schema#session%2Fload">Schema</a>]}
 >
   [Load an existing session](/protocol/v2/session-setup#loading-sessions)
-  (requires `loadSession` capability).
+  (requires `session.load` capability).
 </ResponseField>
 
 <ResponseField
@@ -94,7 +94,7 @@ Agents are programs that use generative AI to autonomously modify code. They typ
   post={[<a href="/protocol/v2/schema#logout">Schema</a>]}
 >
   [End the current authenticated state](/protocol/v2/authentication#logging-out)
-  (requires `agentCapabilities.auth.logout` capability).
+  (requires `capabilities.auth.logout` capability).
 </ResponseField>
 
 ### Notifications

--- a/docs/protocol/v2/schema.mdx
+++ b/docs/protocol/v2/schema.mdx
@@ -152,7 +152,7 @@ Note: in future versions of the protocol, this will be required.
 <ResponseField name="capabilities" type={<a href="#agentcapabilities">AgentCapabilities</a>} >
   Capabilities supported by the agent.
 
-    - Default: `{"auth":{},"loadSession":false,"mcp":{"http":false,"sse":false},"prompt":{"audio":false,"embeddedContext":false,"image":false},"session":{}}`
+    - Default: `{"auth":{},"mcp":{"http":false,"sse":false},"prompt":{"audio":false,"embeddedContext":false,"image":false},"session":{}}`
 
 </ResponseField>
 <ResponseField name="protocolVersion" type={<a href="#protocolversion">ProtocolVersion</a>} required>
@@ -249,7 +249,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 
 Closes an active session and frees up any resources associated with it.
 
-This method is only available if the agent advertises the `sessionCapabilities.close` capability.
+This method is only available if the agent advertises the `session.close` capability.
 
 The agent must cancel any ongoing work (as if `session/cancel` was called)
 and then free up any resources associated with the session.
@@ -262,7 +262,7 @@ If supported, the agent **must** cancel any ongoing work related to the session
 (treat it as if `session/cancel` was called) and then free up any resources
 associated with the session.
 
-Only available if the Agent supports the `sessionCapabilities.close` capability.
+Only available if the Agent supports the `session.close` capability.
 
 **Type:** Object
 
@@ -302,7 +302,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 
 Lists existing sessions known to the agent.
 
-This method is only available if the agent advertises the `sessionCapabilities.list` capability.
+This method is only available if the agent advertises the `session.list` capability.
 
 The agent should return metadata about sessions with optional filtering and pagination support.
 
@@ -310,7 +310,7 @@ The agent should return metadata about sessions with optional filtering and pagi
 
 Request parameters for listing existing sessions.
 
-Only available if the Agent supports the `sessionCapabilities.list` capability.
+Only available if the Agent supports the `session.list` capability.
 
 **Type:** Object
 
@@ -360,7 +360,7 @@ to fetch the next page. If absent, there are no more results.
 
 Loads an existing session to resume a previous conversation.
 
-This method is only available if the agent advertises the `loadSession` capability.
+This method is only available if the agent advertises the `session.load` capability.
 
 The agent should:
 
@@ -374,7 +374,7 @@ See protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/v
 
 Request parameters for loading an existing session.
 
-Only available if the Agent supports the `loadSession` capability.
+Only available if the Agent supports the `session.load` capability.
 
 See protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/v2/session-setup#loading-sessions)
 
@@ -590,7 +590,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 
 Resumes an existing session without returning previous messages.
 
-This method is only available if the agent advertises the `sessionCapabilities.resume` capability.
+This method is only available if the agent advertises the `session.resume` capability.
 
 The agent should resume the session context, allowing the conversation to continue
 without replaying the message history (unlike `session/load`).
@@ -602,7 +602,7 @@ Request parameters for resuming an existing session.
 Resumes an existing session without returning previous messages (unlike `session/load`).
 This is useful for agents that can resume sessions but don't implement full session loading.
 
-Only available if the Agent supports the `sessionCapabilities.resume` capability.
+Only available if the Agent supports the `session.resume` capability.
 
 **Type:** Object
 
@@ -868,12 +868,6 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
   Authentication-related capabilities supported by the agent.
 
     - Default: `{}`
-
-</ResponseField>
-<ResponseField name="loadSession" type={"boolean"} >
-  Whether the agent supports `session/load`.
-
-    - Default: `false`
 
 </ResponseField>
 <ResponseField name="mcp" type={<a href="#mcpcapabilities">McpCapabilities</a>} >
@@ -2503,8 +2497,6 @@ As a baseline, all Agents **MUST** support `session/new`, `session/prompt`, `ses
 
 Optionally, they **MAY** support other session methods and notifications by specifying additional capabilities.
 
-Note: `session/load` is still handled by the top-level `load_session` capability. This will be unified in future versions of the protocol.
-
 See protocol docs: [Session Capabilities](https://agentclientprotocol.com/protocol/v2/initialization#session-capabilities)
 
 **Type:** Object
@@ -2532,6 +2524,13 @@ additional-root list associated with a listed session.
 </ResponseField>
 <ResponseField name="list" type={<><span><a href="#sessionlistcapabilities">SessionListCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/list`.
+</ResponseField>
+<ResponseField name="load" type={<><span><a href="#sessionloadcapabilities">SessionLoadCapabilities</a></span><span> | null</span></>} >
+  Whether the agent supports `session/load`.
+
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports loading sessions.
+
 </ResponseField>
 <ResponseField name="resume" type={<><span><a href="#sessionresumecapabilities">SessionResumeCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/resume`.
@@ -2859,6 +2858,25 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 Capabilities for the `session/list` method.
 
 By supplying `\{\}` it means that the agent supports listing of sessions.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)
+
+</ResponseField>
+
+## <span class="font-mono">SessionLoadCapabilities</span>
+
+Capabilities for the `session/load` method.
+
+Supplying `\{\}` means the agent supports loading sessions.
 
 **Type:** Object
 

--- a/docs/protocol/v2/schema.mdx
+++ b/docs/protocol/v2/schema.mdx
@@ -101,7 +101,7 @@ these keys.
 See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)
 
 </ResponseField>
-<ResponseField name="clientCapabilities" type={<a href="#clientcapabilities">ClientCapabilities</a>} >
+<ResponseField name="capabilities" type={<a href="#clientcapabilities">ClientCapabilities</a>} >
   Capabilities supported by the client.
 
     - Default: `{}`
@@ -137,12 +137,6 @@ these keys.
 See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)
 
 </ResponseField>
-<ResponseField name="agentCapabilities" type={<a href="#agentcapabilities">AgentCapabilities</a>} >
-  Capabilities supported by the agent.
-
-    - Default: `{"auth":{},"loadSession":false,"mcpCapabilities":{"http":false,"sse":false},"promptCapabilities":{"audio":false,"embeddedContext":false,"image":false},"sessionCapabilities":{}}`
-
-</ResponseField>
 <ResponseField name="agentInfo" type={<><span><a href="#implementation">Implementation</a></span><span> | null</span></>} >
   Information about the Agent name and version sent to the Client.
 
@@ -153,6 +147,12 @@ Note: in future versions of the protocol, this will be required.
   Authentication methods supported by the agent.
 
     - Default: `[]`
+
+</ResponseField>
+<ResponseField name="capabilities" type={<a href="#agentcapabilities">AgentCapabilities</a>} >
+  Capabilities supported by the agent.
+
+    - Default: `{"auth":{},"loadSession":false,"mcp":{"http":false,"sse":false},"prompt":{"audio":false,"embeddedContext":false,"image":false},"session":{}}`
 
 </ResponseField>
 <ResponseField name="protocolVersion" type={<a href="#protocolversion">ProtocolVersion</a>} required>
@@ -876,19 +876,19 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
     - Default: `false`
 
 </ResponseField>
-<ResponseField name="mcpCapabilities" type={<a href="#mcpcapabilities">McpCapabilities</a>} >
+<ResponseField name="mcp" type={<a href="#mcpcapabilities">McpCapabilities</a>} >
   MCP capabilities supported by the agent.
 
     - Default: `{"http":false,"sse":false}`
 
 </ResponseField>
-<ResponseField name="promptCapabilities" type={<a href="#promptcapabilities">PromptCapabilities</a>} >
+<ResponseField name="prompt" type={<a href="#promptcapabilities">PromptCapabilities</a>} >
   Prompt capabilities supported by the agent.
 
     - Default: `{"audio":false,"embeddedContext":false,"image":false}`
 
 </ResponseField>
-<ResponseField name="sessionCapabilities" type={<a href="#sessioncapabilities">SessionCapabilities</a>} >
+<ResponseField name="session" type={<a href="#sessioncapabilities">SessionCapabilities</a>} >
 
     - Default: `{}`
 
@@ -1816,7 +1816,7 @@ See protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/v2/ses
 <ResponseField name="http" type="object">
 HTTP transport configuration
 
-Only available when the Agent capabilities indicate `mcp_capabilities.http` is `true`.
+Only available when the Agent capabilities indicate `mcp.http` is `true`.
 
 <Expandable title="Properties">
 
@@ -1847,7 +1847,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 <ResponseField name="sse" type="object">
 SSE transport configuration
 
-Only available when the Agent capabilities indicate `mcp_capabilities.sse` is `true`.
+Only available when the Agent capabilities indicate `mcp.sse` is `true`.
 
 <Expandable title="Properties">
 

--- a/docs/protocol/v2/schema.mdx
+++ b/docs/protocol/v2/schema.mdx
@@ -152,7 +152,7 @@ Note: in future versions of the protocol, this will be required.
 <ResponseField name="capabilities" type={<a href="#agentcapabilities">AgentCapabilities</a>} >
   Capabilities supported by the agent.
 
-    - Default: `{"auth":{},"mcp":{"http":false,"sse":false},"prompt":{"audio":false,"embeddedContext":false,"image":false},"session":{}}`
+    - Default: `{"auth":{},"mcp":{},"prompt":{},"session":{}}`
 
 </ResponseField>
 <ResponseField name="protocolVersion" type={<a href="#protocolversion">ProtocolVersion</a>} required>
@@ -873,13 +873,13 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 <ResponseField name="mcp" type={<a href="#mcpcapabilities">McpCapabilities</a>} >
   MCP capabilities supported by the agent.
 
-    - Default: `{"http":false,"sse":false}`
+    - Default: `{}`
 
 </ResponseField>
 <ResponseField name="prompt" type={<a href="#promptcapabilities">PromptCapabilities</a>} >
   Prompt capabilities supported by the agent.
 
-    - Default: `{"audio":false,"embeddedContext":false,"image":false}`
+    - Default: `{}`
 
 </ResponseField>
 <ResponseField name="session" type={<a href="#sessioncapabilities">SessionCapabilities</a>} >
@@ -1783,16 +1783,37 @@ these keys.
 See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)
 
 </ResponseField>
-<ResponseField name="http" type={"boolean"} >
+<ResponseField name="http" type={<><span><a href="#mcphttpcapabilities">McpHttpCapabilities</a></span><span> | null</span></>} >
   Agent supports `McpServer::Http`.
 
-    - Default: `false`
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports HTTP MCP server transports.
 
 </ResponseField>
-<ResponseField name="sse" type={"boolean"} >
+<ResponseField name="sse" type={<><span><a href="#mcpssecapabilities">McpSseCapabilities</a></span><span> | null</span></>} >
   Agent supports `McpServer::Sse`.
 
-    - Default: `false`
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports SSE MCP server transports.
+
+</ResponseField>
+
+## <span class="font-mono">McpHttpCapabilities</span>
+
+Capabilities for HTTP MCP server transports.
+
+Supplying `\{\}` means the agent supports HTTP MCP server transports.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)
 
 </ResponseField>
 
@@ -1810,7 +1831,7 @@ See protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/v2/ses
 <ResponseField name="http" type="object">
 HTTP transport configuration
 
-Only available when the Agent capabilities indicate `mcp.http` is `true`.
+Only available when the Agent capabilities include `mcp.http`.
 
 <Expandable title="Properties">
 
@@ -1841,7 +1862,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 <ResponseField name="sse" type="object">
 SSE transport configuration
 
-Only available when the Agent capabilities indicate `mcp.sse` is `true`.
+Only available when the Agent capabilities include `mcp.sse`.
 
 <Expandable title="Properties">
 
@@ -1979,6 +2000,25 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 </ResponseField>
 <ResponseField name="name" type={"string"} required>
   Human-readable name identifying this MCP server.
+</ResponseField>
+
+## <span class="font-mono">McpSseCapabilities</span>
+
+Capabilities for SSE MCP server transports.
+
+Supplying `\{\}` means the agent supports SSE MCP server transports.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)
+
 </ResponseField>
 
 ## <span class="font-mono">MessageId</span>
@@ -2261,6 +2301,25 @@ future ACP variants.
 </Expandable>
 </ResponseField>
 
+## <span class="font-mono">PromptAudioCapabilities</span>
+
+Capabilities for audio content in prompt requests.
+
+Supplying `\{\}` means the agent supports audio content in prompts.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)
+
+</ResponseField>
+
 ## <span class="font-mono">PromptCapabilities</span>
 
 Prompt capabilities supported by the agent in `session/prompt` requests.
@@ -2288,25 +2347,66 @@ these keys.
 See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)
 
 </ResponseField>
-<ResponseField name="audio" type={"boolean"} >
+<ResponseField name="audio" type={<><span><a href="#promptaudiocapabilities">PromptAudioCapabilities</a></span><span> | null</span></>} >
   Agent supports `ContentBlock::Audio`.
 
-    - Default: `false`
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports audio content in prompts.
 
 </ResponseField>
-<ResponseField name="embeddedContext" type={"boolean"} >
+<ResponseField name="embeddedContext" type={<><span><a href="#promptembeddedcontextcapabilities">PromptEmbeddedContextCapabilities</a></span><span> | null</span></>} >
   Agent supports embedded context in `session/prompt` requests.
 
 When enabled, the Client is allowed to include `ContentBlock::Resource`
 in prompt requests for pieces of context that are referenced in the message.
 
-    - Default: `false`
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports embedded context in prompts.
 
 </ResponseField>
-<ResponseField name="image" type={"boolean"} >
+<ResponseField name="image" type={<><span><a href="#promptimagecapabilities">PromptImageCapabilities</a></span><span> | null</span></>} >
   Agent supports `ContentBlock::Image`.
 
-    - Default: `false`
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports image content in prompts.
+
+</ResponseField>
+
+## <span class="font-mono">PromptEmbeddedContextCapabilities</span>
+
+Capabilities for embedded context in prompt requests.
+
+Supplying `\{\}` means the agent supports embedded context in prompts.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)
+
+</ResponseField>
+
+## <span class="font-mono">PromptImageCapabilities</span>
+
+Capabilities for image content in prompt requests.
+
+Supplying `\{\}` means the agent supports image content in prompts.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)
 
 </ResponseField>
 

--- a/docs/protocol/v2/session-list.mdx
+++ b/docs/protocol/v2/session-list.mdx
@@ -34,7 +34,7 @@ sequenceDiagram
 
 ## Checking Support
 
-Before attempting to list sessions, Clients **MUST** verify that the Agent supports this capability by checking the `sessionCapabilities.list` field in the `initialize` response:
+Before attempting to list sessions, Clients **MUST** verify that the Agent supports this capability by checking the `session.list` field in the `initialize` response:
 
 ```json highlight={7-9}
 {
@@ -42,8 +42,8 @@ Before attempting to list sessions, Clients **MUST** verify that the Agent suppo
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "sessionCapabilities": {
+    "capabilities": {
+      "session": {
         "list": {}
       }
     }
@@ -51,9 +51,9 @@ Before attempting to list sessions, Clients **MUST** verify that the Agent suppo
 }
 ```
 
-If `sessionCapabilities.list` is not present, the Agent does not support listing sessions and Clients **MUST NOT** attempt to call `session/list`.
+If `session.list` is not present, the Agent does not support listing sessions and Clients **MUST NOT** attempt to call `session/list`.
 
-Agents that also advertise `sessionCapabilities.additionalDirectories` may
+Agents that also advertise `session.additionalDirectories` may
 include `additionalDirectories` in returned `SessionInfo` objects to report
 additional workspace roots for listed sessions.
 
@@ -131,7 +131,7 @@ The Agent **MUST** respond with a list of sessions and optional pagination metad
       Working directory for the session. Always an absolute path.
     </ResponseField>
     <ResponseField name="additionalDirectories" type="string[]">
-      If the Agent advertises `sessionCapabilities.additionalDirectories`, it
+      If the Agent advertises `session.additionalDirectories`, it
       MAY include this field to report the complete ordered additional-root list
       associated with the listed session. Omitted and empty values are
       equivalent: this `SessionInfo` response reports no additional roots.

--- a/docs/protocol/v2/session-setup.mdx
+++ b/docs/protocol/v2/session-setup.mdx
@@ -82,11 +82,11 @@ The Agent **MUST** respond with a unique [Session ID](#session-id) that identifi
 
 ## Loading Sessions
 
-Agents that support the `loadSession` capability allow Clients to resume previous conversations. This feature enables persistence across restarts and sharing sessions between different Client instances.
+Agents that support the `session.load` capability allow Clients to resume previous conversations. This feature enables persistence across restarts and sharing sessions between different Client instances.
 
 ### Checking Support
 
-Before attempting to load a session, Clients **MUST** verify that the Agent supports this capability by checking the `loadSession` field in the `initialize` response:
+Before attempting to load a session, Clients **MUST** verify that the Agent supports this capability by checking the `session.load` field in the `initialize` response:
 
 ```json highlight={7}
 {
@@ -94,14 +94,16 @@ Before attempting to load a session, Clients **MUST** verify that the Agent supp
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "loadSession": true
+    "capabilities": {
+      "session": {
+        "load": {}
+      }
     }
   }
 }
 ```
 
-If `loadSession` is `false` or not present, the Agent does not support loading sessions and Clients **MUST NOT** attempt to call `session/load`.
+If `session.load` is omitted or `null`, the Agent does not support loading sessions and Clients **MUST NOT** attempt to call `session/load`.
 
 ### Loading a Session
 
@@ -185,11 +187,11 @@ The Client can then continue sending prompts as if the session was never interru
 
 ## Resuming Sessions
 
-Agents that advertise `sessionCapabilities.resume` allow Clients to reconnect to an existing session without replaying the conversation history.
+Agents that advertise `session.resume` allow Clients to reconnect to an existing session without replaying the conversation history.
 
 ### Checking Support
 
-Before attempting to resume a session, Clients **MUST** verify that the Agent supports this capability by checking for the `sessionCapabilities.resume` field in the `initialize` response:
+Before attempting to resume a session, Clients **MUST** verify that the Agent supports this capability by checking for the `session.resume` field in the `initialize` response:
 
 ```json highlight={7-9}
 {
@@ -197,8 +199,8 @@ Before attempting to resume a session, Clients **MUST** verify that the Agent su
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "sessionCapabilities": {
+    "capabilities": {
+      "session": {
         "resume": {}
       }
     }
@@ -206,7 +208,7 @@ Before attempting to resume a session, Clients **MUST** verify that the Agent su
 }
 ```
 
-If `sessionCapabilities.resume` is not present, the Agent does not support resuming sessions and Clients **MUST NOT** attempt to call `session/resume`.
+If `session.resume` is not present, the Agent does not support resuming sessions and Clients **MUST NOT** attempt to call `session/resume`.
 
 ### Resuming a Session
 
@@ -251,11 +253,11 @@ feature is supported by the Agent.
 
 ## Closing Active Sessions
 
-Agents that advertise `sessionCapabilities.close` allow Clients to tell the Agent to cancel any ongoing work for a session and free any resources associated with that active session.
+Agents that advertise `session.close` allow Clients to tell the Agent to cancel any ongoing work for a session and free any resources associated with that active session.
 
 ### Checking Support
 
-Before attempting to close a session, Clients **MUST** verify that the Agent supports this capability by checking the `sessionCapabilities.close` field in the `initialize` response:
+Before attempting to close a session, Clients **MUST** verify that the Agent supports this capability by checking the `session.close` field in the `initialize` response:
 
 ```json highlight={7-9}
 {
@@ -263,8 +265,8 @@ Before attempting to close a session, Clients **MUST** verify that the Agent sup
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "sessionCapabilities": {
+    "capabilities": {
+      "session": {
         "close": {}
       }
     }
@@ -272,7 +274,7 @@ Before attempting to close a session, Clients **MUST** verify that the Agent sup
 }
 ```
 
-If `sessionCapabilities.close` is not present, the Agent does not support closing sessions and Clients **MUST NOT** attempt to call `session/close`.
+If `session.close` is not present, the Agent does not support closing sessions and Clients **MUST NOT** attempt to call `session/close`.
 
 ### Closing a Session
 
@@ -309,7 +311,7 @@ Agents MAY return an error if the session does not exist or is not currently act
 
 ## Additional Workspace Roots
 
-Agents that advertise `sessionCapabilities.additionalDirectories` allow Clients
+Agents that advertise `session.additionalDirectories` allow Clients
 to include `additionalDirectories` on supported session lifecycle requests to
 expand the session's effective workspace root set. Supported stable lifecycle
 requests include `session/new`, `session/load`, and `session/resume`.
@@ -338,7 +340,7 @@ When present, `additionalDirectories` has the following behavior:
 - omitting the field or providing an empty array activates no additional roots for the resulting session
 - on `session/load` and `session/resume`, Clients must send the full intended additional-root list again; that list may differ from any previous or reported list as long as the request `cwd` matches the session's `cwd`, and omitting the field or providing an empty array does not restore stored roots implicitly
 
-Clients **MUST** only send `additionalDirectories` when the Agent advertises `sessionCapabilities.additionalDirectories`.
+Clients **MUST** only send `additionalDirectories` when the Agent advertises `session.additionalDirectories`.
 
 ## Session ID
 
@@ -348,9 +350,9 @@ Clients use this ID to:
 
 - Send prompt requests via `session/prompt`
 - Cancel ongoing operations via `session/cancel`
-- Load previous sessions via `session/load` (if the Agent supports the `loadSession` capability)
-- Resume previous sessions via `session/resume` (if the Agent supports the `sessionCapabilities.resume` capability)
-- Close active sessions via `session/close` (if the Agent supports the `sessionCapabilities.close` capability)
+- Load previous sessions via `session/load` (if the Agent supports the `session.load` capability)
+- Resume previous sessions via `session/resume` (if the Agent supports the `session.resume` capability)
+- Close active sessions via `session/close` (if the Agent supports the `session.close` capability)
 
 ## Working Directory
 
@@ -361,7 +363,7 @@ The `cwd` (current working directory) parameter establishes the primary file sys
 - **MUST** remain the base for relative-path resolution
 - **MUST** be part of the session's effective root set
 
-When `sessionCapabilities.additionalDirectories` is in use, the session's effective root set is `[cwd, ...additionalDirectories]`. This root set **SHOULD** serve as a boundary for tool operations on the file system.
+When `session.additionalDirectories` is in use, the session's effective root set is `[cwd, ...additionalDirectories]`. This root set **SHOULD** serve as a boundary for tool operations on the file system.
 
 ## MCP Servers
 
@@ -420,7 +422,7 @@ Example stdio transport configuration:
 
 #### HTTP Transport
 
-When the Agent supports `mcpCapabilities.http`, Clients can specify MCP servers configurations using the HTTP transport.
+When the Agent supports `mcp.http`, Clients can specify MCP servers configurations using the HTTP transport.
 
 <ParamField path="type" type="string" required>
   Must be `"http"` to indicate HTTP transport
@@ -469,7 +471,7 @@ Example HTTP transport configuration:
 
 #### SSE Transport
 
-When the Agent supports `mcpCapabilities.sse`, Clients can specify MCP servers configurations using the SSE transport.
+When the Agent supports `mcp.sse`, Clients can specify MCP servers configurations using the SSE transport.
 
 <Warning>This transport was deprecated by the MCP spec.</Warning>
 
@@ -524,8 +526,8 @@ Before using HTTP or SSE transports, Clients **MUST** verify the Agent's capabil
   "id": 0,
   "result": {
     "protocolVersion": 2,
-    "agentCapabilities": {
-      "mcpCapabilities": {
+    "capabilities": {
+      "mcp": {
         "http": true,
         "sse": true
       }
@@ -534,8 +536,8 @@ Before using HTTP or SSE transports, Clients **MUST** verify the Agent's capabil
 }
 ```
 
-If `mcpCapabilities.http` is `false` or not present, the Agent does not support HTTP transport.
-If `mcpCapabilities.sse` is `false` or not present, the Agent does not support SSE transport.
+If `mcp.http` is `false` or not present, the Agent does not support HTTP transport.
+If `mcp.sse` is `false` or not present, the Agent does not support SSE transport.
 
 Agents **SHOULD** connect to all MCP servers specified by the Client.
 

--- a/docs/protocol/v2/session-setup.mdx
+++ b/docs/protocol/v2/session-setup.mdx
@@ -528,16 +528,17 @@ Before using HTTP or SSE transports, Clients **MUST** verify the Agent's capabil
     "protocolVersion": 2,
     "capabilities": {
       "mcp": {
-        "http": true,
-        "sse": true
+        "http": {},
+        "sse": {}
       }
     }
   }
 }
 ```
 
-If `mcp.http` is `false` or not present, the Agent does not support HTTP transport.
-If `mcp.sse` is `false` or not present, the Agent does not support SSE transport.
+If `mcp.http` is omitted or `null`, the Agent does not support HTTP transport.
+If `mcp.sse` is omitted or `null`, the Agent does not support SSE transport.
+Supplying `{}` means the Agent supports the corresponding transport.
 
 Agents **SHOULD** connect to all MCP servers specified by the Client.
 

--- a/docs/rfds/v2/overview.mdx
+++ b/docs/rfds/v2/overview.mdx
@@ -44,12 +44,17 @@ Other RFDs will progress separately and are not dependent on breaking changes (s
 - Make [plan variants](./plan-variants.mdx) the default v2 plan shape by replacing the old `plan` session update with item-based `plan_update`.
 - Require [message IDs](../message-id.mdx) on streamed message chunks.
 - Follow JSON-RPC 2.0 batch request and notification behavior.
+- Clean up capability naming and organization:
+  - Use a single `capabilities` field in both `initialize` params and results, replacing the v1-style `clientCapabilities` and `agentCapabilities` fields.
+  - Use concise capability group names such as `prompt`, `mcp`, `session`, and `auth`, replacing names like `promptCapabilities`, `mcpCapabilities`, and `sessionCapabilities`.
+  - Move `loadSession` into the session capability group as `session.load`.
+  - Represent support markers as capability objects instead of booleans. Supplying `{}` means supported, while omission or `null` means unsupported. Booleans remain appropriate for actual data or configuration inside an already-advertised capability.
 
 ### RFDs to be Written
 
 Changes under consideration that still need to be drafted or moved to draft:
 
-- Capabilities: clean up naming and organization, as well as make some more capabilities required.
+- Capabilities: decide whether any additional capability groups should become required.
 - Streaming/Non-streaming consistency: Offer both options for both messages and tool calls
   - Also Terminal Output type for streaming terminal output from an agent
   - Expand diff types (delete, move)
@@ -89,6 +94,7 @@ With the needed breaking changes, as much as possible I am targeting having a co
 
 ## Revision history
 
+- 2026-06-05: Recorded the v2 capability cleanup: unified initialize capability fields, shorter capability group names, `session.load`, and object-shaped support markers.
 - 2026-06-02: Recorded the v2 decision to follow JSON-RPC 2.0 batch request and notification behavior.
 - 2026-06-02: Recorded the v2 decision to remove Client filesystem and terminal execution capabilities, methods, and terminal tool-call content.
 - 2026-06-02: Added the v2 Plan Variants RFD to make item-based `plan_update` the default v2 plan shape.

--- a/schema/schema.v2.unstable.json
+++ b/schema/schema.v2.unstable.json
@@ -66,11 +66,6 @@
           "default": {},
           "description": "Authentication-related capabilities supported by the agent."
         },
-        "loadSession": {
-          "default": false,
-          "description": "Whether the agent supports `session/load`.",
-          "type": "boolean"
-        },
         "mcp": {
           "allOf": [
             {
@@ -1282,7 +1277,7 @@
                       "$ref": "#/$defs/LoadSessionRequest"
                     }
                   ],
-                  "description": "Loads an existing session to resume a previous conversation.\n\nThis method is only available if the agent advertises the `loadSession` capability.\n\nThe agent should:\n- Restore the session context and conversation history\n- Connect to the specified MCP servers\n- Stream the entire conversation history back to the client via notifications\n\nSee protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/session-setup#loading-sessions)",
+                  "description": "Loads an existing session to resume a previous conversation.\n\nThis method is only available if the agent advertises the `session.load` capability.\n\nThe agent should:\n- Restore the session context and conversation history\n- Connect to the specified MCP servers\n- Stream the entire conversation history back to the client via notifications\n\nSee protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/session-setup#loading-sessions)",
                   "title": "LoadSessionRequest"
                 },
                 {
@@ -1291,7 +1286,7 @@
                       "$ref": "#/$defs/ListSessionsRequest"
                     }
                   ],
-                  "description": "Lists existing sessions known to the agent.\n\nThis method is only available if the agent advertises the `sessionCapabilities.list` capability.\n\nThe agent should return metadata about sessions with optional filtering and pagination support.",
+                  "description": "Lists existing sessions known to the agent.\n\nThis method is only available if the agent advertises the `session.list` capability.\n\nThe agent should return metadata about sessions with optional filtering and pagination support.",
                   "title": "ListSessionsRequest"
                 },
                 {
@@ -1300,7 +1295,7 @@
                       "$ref": "#/$defs/DeleteSessionRequest"
                     }
                   ],
-                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nDeletes an existing session from `session/list`.\n\nThis method is only available if the agent advertises the `sessionCapabilities.delete` capability.",
+                  "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nDeletes an existing session from `session/list`.\n\nThis method is only available if the agent advertises the `session.delete` capability.",
                   "title": "DeleteSessionRequest"
                 },
                 {
@@ -1318,7 +1313,7 @@
                       "$ref": "#/$defs/ResumeSessionRequest"
                     }
                   ],
-                  "description": "Resumes an existing session without returning previous messages.\n\nThis method is only available if the agent advertises the `sessionCapabilities.resume` capability.\n\nThe agent should resume the session context, allowing the conversation to continue\nwithout replaying the message history (unlike `session/load`).",
+                  "description": "Resumes an existing session without returning previous messages.\n\nThis method is only available if the agent advertises the `session.resume` capability.\n\nThe agent should resume the session context, allowing the conversation to continue\nwithout replaying the message history (unlike `session/load`).",
                   "title": "ResumeSessionRequest"
                 },
                 {
@@ -1327,7 +1322,7 @@
                       "$ref": "#/$defs/CloseSessionRequest"
                     }
                   ],
-                  "description": "Closes an active session and frees up any resources associated with it.\n\nThis method is only available if the agent advertises the `sessionCapabilities.close` capability.\n\nThe agent must cancel any ongoing work (as if `session/cancel` was called)\nand then free up any resources associated with the session.",
+                  "description": "Closes an active session and frees up any resources associated with it.\n\nThis method is only available if the agent advertises the `session.close` capability.\n\nThe agent must cancel any ongoing work (as if `session/cancel` was called)\nand then free up any resources associated with the session.",
                   "title": "CloseSessionRequest"
                 },
                 {
@@ -1523,7 +1518,7 @@
       "x-side": "agent"
     },
     "CloseSessionRequest": {
-      "description": "Request parameters for closing an active session.\n\nIf supported, the agent **must** cancel any ongoing work related to the session\n(treat it as if `session/cancel` was called) and then free up any resources\nassociated with the session.\n\nOnly available if the Agent supports the `sessionCapabilities.close` capability.",
+      "description": "Request parameters for closing an active session.\n\nIf supported, the agent **must** cancel any ongoing work related to the session\n(treat it as if `session/cancel` was called) and then free up any resources\nassociated with the session.\n\nOnly available if the Agent supports the `session.close` capability.",
       "properties": {
         "_meta": {
           "additionalProperties": true,
@@ -1975,7 +1970,7 @@
       "x-side": "client"
     },
     "DeleteSessionRequest": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest parameters for deleting an existing session from `session/list`.\n\nOnly available if the Agent supports the `sessionCapabilities.delete` capability.",
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nRequest parameters for deleting an existing session from `session/list`.\n\nOnly available if the Agent supports the `session.delete` capability.",
       "properties": {
         "_meta": {
           "additionalProperties": true,
@@ -3059,7 +3054,6 @@
           ],
           "default": {
             "auth": {},
-            "loadSession": false,
             "mcp": {
               "acp": false,
               "http": false,
@@ -3154,7 +3148,7 @@
       "x-side": "agent"
     },
     "ListSessionsRequest": {
-      "description": "Request parameters for listing existing sessions.\n\nOnly available if the Agent supports the `sessionCapabilities.list` capability.",
+      "description": "Request parameters for listing existing sessions.\n\nOnly available if the Agent supports the `session.list` capability.",
       "properties": {
         "_meta": {
           "additionalProperties": true,
@@ -3237,7 +3231,7 @@
       "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWell-known API protocol identifiers for LLM providers.\n\nAgents and clients MUST handle unknown protocol identifiers gracefully.\n\nProtocol names beginning with `_` are free for custom use, like other ACP extension methods.\nProtocol names that do not begin with `_` are reserved for the ACP spec."
     },
     "LoadSessionRequest": {
-      "description": "Request parameters for loading an existing session.\n\nOnly available if the Agent supports the `loadSession` capability.\n\nSee protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/session-setup#loading-sessions)",
+      "description": "Request parameters for loading an existing session.\n\nOnly available if the Agent supports the `session.load` capability.\n\nSee protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/session-setup#loading-sessions)",
       "properties": {
         "_meta": {
           "additionalProperties": true,
@@ -5593,7 +5587,7 @@
       "type": "object"
     },
     "ResumeSessionRequest": {
-      "description": "Request parameters for resuming an existing session.\n\nResumes an existing session without returning previous messages (unlike `session/load`).\nThis is useful for agents that can resume sessions but don't implement full session loading.\n\nOnly available if the Agent supports the `sessionCapabilities.resume` capability.",
+      "description": "Request parameters for resuming an existing session.\n\nResumes an existing session without returning previous messages (unlike `session/load`).\nThis is useful for agents that can resume sessions but don't implement full session loading.\n\nOnly available if the Agent supports the `session.resume` capability.",
       "properties": {
         "_meta": {
           "additionalProperties": true,
@@ -5700,7 +5694,7 @@
       "type": "object"
     },
     "SessionCapabilities": {
-      "description": "Session capabilities supported by the agent.\n\nAs a baseline, all Agents **MUST** support `session/new`, `session/prompt`, `session/cancel`, and `session/update`.\n\nOptionally, they **MAY** support other session methods and notifications by specifying additional capabilities.\n\nNote: `session/load` is still handled by the top-level `load_session` capability. This will be unified in future versions of the protocol.\n\nSee protocol docs: [Session Capabilities](https://agentclientprotocol.com/protocol/initialization#session-capabilities)",
+      "description": "Session capabilities supported by the agent.\n\nAs a baseline, all Agents **MUST** support `session/new`, `session/prompt`, `session/cancel`, and `session/update`.\n\nOptionally, they **MAY** support other session methods and notifications by specifying additional capabilities.\n\nSee protocol docs: [Session Capabilities](https://agentclientprotocol.com/protocol/initialization#session-capabilities)",
       "properties": {
         "_meta": {
           "additionalProperties": true,
@@ -5765,6 +5759,18 @@
             }
           ],
           "description": "Whether the agent supports `session/list`.",
+          "x-deserialize-default-on-error": true
+        },
+        "load": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionLoadCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Whether the agent supports `session/load`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports loading sessions.",
           "x-deserialize-default-on-error": true
         },
         "resume": {
@@ -6146,6 +6152,17 @@
     },
     "SessionListCapabilities": {
       "description": "Capabilities for the `session/list` method.\n\nBy supplying `{}` it means that the agent supports listing of sessions.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        }
+      },
+      "type": "object"
+    },
+    "SessionLoadCapabilities": {
+      "description": "Capabilities for the `session/load` method.\n\nSupplying `{}` means the agent supports loading sessions.",
       "properties": {
         "_meta": {
           "additionalProperties": true,

--- a/schema/schema.v2.unstable.json
+++ b/schema/schema.v2.unstable.json
@@ -72,11 +72,7 @@
               "$ref": "#/$defs/McpCapabilities"
             }
           ],
-          "default": {
-            "acp": false,
-            "http": false,
-            "sse": false
-          },
+          "default": {},
           "description": "MCP capabilities supported by the agent."
         },
         "nes": {
@@ -109,11 +105,7 @@
               "$ref": "#/$defs/PromptCapabilities"
             }
           ],
-          "default": {
-            "audio": false,
-            "embeddedContext": false,
-            "image": false
-          },
+          "default": {},
           "description": "Prompt capabilities supported by the agent."
         },
         "providers": {
@@ -533,9 +525,16 @@
           "type": ["object", "null"]
         },
         "terminal": {
-          "default": false,
-          "description": "Whether the client supports `terminal` authentication methods.\n\nWhen `true`, the agent may include `terminal` entries in its authentication methods.",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TerminalAuthCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Whether the client supports `terminal` authentication methods.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means the agent may include `terminal` entries in its authentication methods.",
+          "x-deserialize-default-on-error": true
         }
       },
       "type": "object"
@@ -996,9 +995,7 @@
               "$ref": "#/$defs/AuthCapabilities"
             }
           ],
-          "default": {
-            "terminal": false
-          },
+          "default": {},
           "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAuthentication capabilities supported by the client.\nDetermines which authentication method types the agent may include\nin its `InitializeResponse`."
         },
         "elicitation": {
@@ -2984,9 +2981,7 @@
             }
           ],
           "default": {
-            "auth": {
-              "terminal": false
-            }
+            "auth": {}
           },
           "description": "Capabilities supported by the client."
         },
@@ -3054,16 +3049,8 @@
           ],
           "default": {
             "auth": {},
-            "mcp": {
-              "acp": false,
-              "http": false,
-              "sse": false
-            },
-            "prompt": {
-              "audio": false,
-              "embeddedContext": false,
-              "image": false
-            },
+            "mcp": {},
+            "prompt": {},
             "session": {}
           },
           "description": "Capabilities supported by the agent."
@@ -3329,6 +3316,17 @@
       "x-method": "logout",
       "x-side": "agent"
     },
+    "McpAcpCapabilities": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for ACP MCP server transports.\n\nSupplying `{}` means the agent supports ACP MCP server transports.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        }
+      },
+      "type": "object"
+    },
     "McpCapabilities": {
       "description": "MCP capabilities supported by the agent",
       "properties": {
@@ -3338,19 +3336,40 @@
           "type": ["object", "null"]
         },
         "acp": {
-          "default": false,
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAgent supports [`McpServer::Acp`].",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpAcpCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAgent supports [`McpServer::Acp`].\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports ACP MCP server transports.",
+          "x-deserialize-default-on-error": true
         },
         "http": {
-          "default": false,
-          "description": "Agent supports [`McpServer::Http`].",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpHttpCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Agent supports [`McpServer::Http`].\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports HTTP MCP server transports.",
+          "x-deserialize-default-on-error": true
         },
         "sse": {
-          "default": false,
-          "description": "Agent supports [`McpServer::Sse`].",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpSseCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Agent supports [`McpServer::Sse`].\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports SSE MCP server transports.",
+          "x-deserialize-default-on-error": true
         }
       },
       "type": "object"
@@ -3358,6 +3377,17 @@
     "McpConnectionId": {
       "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nA unique identifier for an active MCP-over-ACP connection.",
       "type": "string"
+    },
+    "McpHttpCapabilities": {
+      "description": "Capabilities for HTTP MCP server transports.\n\nSupplying `{}` means the agent supports HTTP MCP server transports.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        }
+      },
+      "type": "object"
     },
     "McpServer": {
       "anyOf": [
@@ -3367,7 +3397,7 @@
               "$ref": "#/$defs/McpServerHttp"
             }
           ],
-          "description": "HTTP transport configuration\n\nOnly available when the Agent capabilities indicate `mcp.http` is `true`.",
+          "description": "HTTP transport configuration\n\nOnly available when the Agent capabilities include `mcp.http`.",
           "properties": {
             "type": {
               "const": "http",
@@ -3383,7 +3413,7 @@
               "$ref": "#/$defs/McpServerSse"
             }
           ],
-          "description": "SSE transport configuration\n\nOnly available when the Agent capabilities indicate `mcp.sse` is `true`.",
+          "description": "SSE transport configuration\n\nOnly available when the Agent capabilities include `mcp.sse`.",
           "properties": {
             "type": {
               "const": "sse",
@@ -3399,7 +3429,7 @@
               "$ref": "#/$defs/McpServerAcp"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nACP transport configuration\n\nOnly available when the Agent capabilities indicate `mcp.acp` is `true`.\nThe MCP server is provided by an ACP component and communicates over the ACP channel.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nACP transport configuration\n\nOnly available when the Agent capabilities include `mcp.acp`.\nThe MCP server is provided by an ACP component and communicates over the ACP channel.",
           "properties": {
             "type": {
               "const": "acp",
@@ -3535,6 +3565,17 @@
         }
       },
       "required": ["name", "command", "args", "env"],
+      "type": "object"
+    },
+    "McpSseCapabilities": {
+      "description": "Capabilities for SSE MCP server transports.\n\nSupplying `{}` means the agent supports SSE MCP server transports.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        }
+      },
       "type": "object"
     },
     "MessageId": {
@@ -5174,6 +5215,17 @@
         }
       ]
     },
+    "PromptAudioCapabilities": {
+      "description": "Capabilities for audio content in prompt requests.\n\nSupplying `{}` means the agent supports audio content in prompts.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        }
+      },
+      "type": "object"
+    },
     "PromptCapabilities": {
       "description": "Prompt capabilities supported by the agent in `session/prompt` requests.\n\nBaseline agent functionality requires support for [`ContentBlock::Text`]\nand [`ContentBlock::ResourceLink`] in prompt requests.\n\nOther variants must be explicitly opted in to.\nCapabilities for different types of content in prompt requests.\n\nIndicates which content types beyond the baseline (text and resource links)\nthe agent can process.\n\nSee protocol docs: [Prompt Capabilities](https://agentclientprotocol.com/protocol/initialization#prompt-capabilities)",
       "properties": {
@@ -5183,19 +5235,62 @@
           "type": ["object", "null"]
         },
         "audio": {
-          "default": false,
-          "description": "Agent supports [`ContentBlock::Audio`].",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptAudioCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Agent supports [`ContentBlock::Audio`].\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports audio content in prompts.",
+          "x-deserialize-default-on-error": true
         },
         "embeddedContext": {
-          "default": false,
-          "description": "Agent supports embedded context in `session/prompt` requests.\n\nWhen enabled, the Client is allowed to include [`ContentBlock::Resource`]\nin prompt requests for pieces of context that are referenced in the message.",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptEmbeddedContextCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Agent supports embedded context in `session/prompt` requests.\n\nWhen enabled, the Client is allowed to include [`ContentBlock::Resource`]\nin prompt requests for pieces of context that are referenced in the message.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports embedded context in prompts.",
+          "x-deserialize-default-on-error": true
         },
         "image": {
-          "default": false,
-          "description": "Agent supports [`ContentBlock::Image`].",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptImageCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Agent supports [`ContentBlock::Image`].\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports image content in prompts.",
+          "x-deserialize-default-on-error": true
+        }
+      },
+      "type": "object"
+    },
+    "PromptEmbeddedContextCapabilities": {
+      "description": "Capabilities for embedded context in prompt requests.\n\nSupplying `{}` means the agent supports embedded context in prompts.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        }
+      },
+      "type": "object"
+    },
+    "PromptImageCapabilities": {
+      "description": "Capabilities for image content in prompt requests.\n\nSupplying `{}` means the agent supports image content in prompts.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
         }
       },
       "type": "object"
@@ -6937,6 +7032,17 @@
       "type": "object",
       "x-method": "nes/suggest",
       "x-side": "agent"
+    },
+    "TerminalAuthCapabilities": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for terminal authentication methods.\n\nSupplying `{}` means the client supports terminal authentication methods.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": true,
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"]
+        }
+      },
+      "type": "object"
     },
     "TextContent": {
       "description": "Text provided to or from an LLM.",

--- a/schema/schema.v2.unstable.json
+++ b/schema/schema.v2.unstable.json
@@ -71,7 +71,7 @@
           "description": "Whether the agent supports `session/load`.",
           "type": "boolean"
         },
-        "mcpCapabilities": {
+        "mcp": {
           "allOf": [
             {
               "$ref": "#/$defs/McpCapabilities"
@@ -108,7 +108,7 @@
           "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe position encoding selected by the agent from the client's supported encodings.",
           "x-deserialize-default-on-error": true
         },
-        "promptCapabilities": {
+        "prompt": {
           "allOf": [
             {
               "$ref": "#/$defs/PromptCapabilities"
@@ -133,7 +133,7 @@
           "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nProvider configuration capabilities supported by the agent.\n\nBy supplying `{}` it means that the agent supports provider configuration methods.",
           "x-deserialize-default-on-error": true
         },
-        "sessionCapabilities": {
+        "session": {
           "allOf": [
             {
               "$ref": "#/$defs/SessionCapabilities"
@@ -2982,7 +2982,7 @@
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": ["object", "null"]
         },
-        "clientCapabilities": {
+        "capabilities": {
           "allOf": [
             {
               "$ref": "#/$defs/ClientCapabilities"
@@ -3029,29 +3029,6 @@
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": ["object", "null"]
         },
-        "agentCapabilities": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/AgentCapabilities"
-            }
-          ],
-          "default": {
-            "auth": {},
-            "loadSession": false,
-            "mcpCapabilities": {
-              "acp": false,
-              "http": false,
-              "sse": false
-            },
-            "promptCapabilities": {
-              "audio": false,
-              "embeddedContext": false,
-              "image": false
-            },
-            "sessionCapabilities": {}
-          },
-          "description": "Capabilities supported by the agent."
-        },
         "agentInfo": {
           "anyOf": [
             {
@@ -3073,6 +3050,29 @@
           "type": "array",
           "x-deserialize-default-on-error": true,
           "x-deserialize-skip-invalid-items": true
+        },
+        "capabilities": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/AgentCapabilities"
+            }
+          ],
+          "default": {
+            "auth": {},
+            "loadSession": false,
+            "mcp": {
+              "acp": false,
+              "http": false,
+              "sse": false
+            },
+            "prompt": {
+              "audio": false,
+              "embeddedContext": false,
+              "image": false
+            },
+            "session": {}
+          },
+          "description": "Capabilities supported by the agent."
         },
         "protocolVersion": {
           "allOf": [
@@ -3373,7 +3373,7 @@
               "$ref": "#/$defs/McpServerHttp"
             }
           ],
-          "description": "HTTP transport configuration\n\nOnly available when the Agent capabilities indicate `mcp_capabilities.http` is `true`.",
+          "description": "HTTP transport configuration\n\nOnly available when the Agent capabilities indicate `mcp.http` is `true`.",
           "properties": {
             "type": {
               "const": "http",
@@ -3389,7 +3389,7 @@
               "$ref": "#/$defs/McpServerSse"
             }
           ],
-          "description": "SSE transport configuration\n\nOnly available when the Agent capabilities indicate `mcp_capabilities.sse` is `true`.",
+          "description": "SSE transport configuration\n\nOnly available when the Agent capabilities indicate `mcp.sse` is `true`.",
           "properties": {
             "type": {
               "const": "sse",
@@ -3405,7 +3405,7 @@
               "$ref": "#/$defs/McpServerAcp"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nACP transport configuration\n\nOnly available when the Agent capabilities indicate `mcp_capabilities.acp` is `true`.\nThe MCP server is provided by an ACP component and communicates over the ACP channel.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nACP transport configuration\n\nOnly available when the Agent capabilities indicate `mcp.acp` is `true`.\nThe MCP server is provided by an ACP component and communicates over the ACP channel.",
           "properties": {
             "type": {
               "const": "acp",

--- a/src/v2/agent.rs
+++ b/src/v2/agent.rs
@@ -1228,7 +1228,7 @@ impl NewSessionResponse {
 
 /// Request parameters for loading an existing session.
 ///
-/// Only available if the Agent supports the `loadSession` capability.
+/// Only available if the Agent supports the `session.load` capability.
 ///
 /// See protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/session-setup#loading-sessions)
 #[skip_serializing_none]
@@ -1498,7 +1498,7 @@ impl ForkSessionResponse {
 /// Resumes an existing session without returning previous messages (unlike `session/load`).
 /// This is useful for agents that can resume sessions but don't implement full session loading.
 ///
-/// Only available if the Agent supports the `sessionCapabilities.resume` capability.
+/// Only available if the Agent supports the `session.resume` capability.
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[schemars(extend("x-side" = "agent", "x-method" = SESSION_RESUME_METHOD_NAME))]
@@ -1625,7 +1625,7 @@ impl ResumeSessionResponse {
 /// (treat it as if `session/cancel` was called) and then free up any resources
 /// associated with the session.
 ///
-/// Only available if the Agent supports the `sessionCapabilities.close` capability.
+/// Only available if the Agent supports the `session.close` capability.
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[schemars(extend("x-side" = "agent", "x-method" = SESSION_CLOSE_METHOD_NAME))]
@@ -1702,7 +1702,7 @@ impl CloseSessionResponse {
 
 /// Request parameters for listing existing sessions.
 ///
-/// Only available if the Agent supports the `sessionCapabilities.list` capability.
+/// Only available if the Agent supports the `session.list` capability.
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[schemars(extend("x-side" = "agent", "x-method" = SESSION_LIST_METHOD_NAME))]
@@ -1814,7 +1814,7 @@ impl ListSessionsResponse {
 ///
 /// Request parameters for deleting an existing session from `session/list`.
 ///
-/// Only available if the Agent supports the `sessionCapabilities.delete` capability.
+/// Only available if the Agent supports the `session.delete` capability.
 #[cfg(feature = "unstable_session_delete")]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -3633,9 +3633,6 @@ impl DisableProviderResponse {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AgentCapabilities {
-    /// Whether the agent supports `session/load`.
-    #[serde(default)]
-    pub load_session: bool,
     /// Prompt capabilities supported by the agent.
     #[serde(default)]
     pub prompt: PromptCapabilities,
@@ -3692,13 +3689,6 @@ impl AgentCapabilities {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Whether the agent supports `session/load`.
-    #[must_use]
-    pub fn load_session(mut self, load_session: bool) -> Self {
-        self.load_session = load_session;
-        self
     }
 
     /// Prompt capabilities supported by the agent.
@@ -3824,8 +3814,6 @@ impl ProvidersCapabilities {
 ///
 /// Optionally, they **MAY** support other session methods and notifications by specifying additional capabilities.
 ///
-/// Note: `session/load` is still handled by the top-level `load_session` capability. This will be unified in future versions of the protocol.
-///
 /// See protocol docs: [Session Capabilities](https://agentclientprotocol.com/protocol/initialization#session-capabilities)
 #[serde_as]
 #[skip_serializing_none]
@@ -3833,6 +3821,14 @@ impl ProvidersCapabilities {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct SessionCapabilities {
+    /// Whether the agent supports `session/load`.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports loading sessions.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
+    #[serde(default)]
+    pub load: Option<SessionLoadCapabilities>,
     /// Whether the agent supports `session/list`.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
@@ -3895,6 +3891,16 @@ impl SessionCapabilities {
         Self::default()
     }
 
+    /// Whether the agent supports `session/load`.
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports loading sessions.
+    #[must_use]
+    pub fn load(mut self, load: impl IntoOption<SessionLoadCapabilities>) -> Self {
+        self.load = load.into_option();
+        self
+    }
+
     /// Whether the agent supports `session/list`.
     #[must_use]
     pub fn list(mut self, list: impl IntoOption<SessionListCapabilities>) -> Self {
@@ -3951,6 +3957,40 @@ impl SessionCapabilities {
     pub fn close(mut self, close: impl IntoOption<SessionCloseCapabilities>) -> Self {
         self.close = close.into_option();
         self
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// Capabilities for the `session/load` method.
+///
+/// Supplying `{}` means the agent supports loading sessions.
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SessionLoadCapabilities {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+impl SessionLoadCapabilities {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -4576,7 +4616,7 @@ pub enum ClientRequest {
     NewSessionRequest(NewSessionRequest),
     /// Loads an existing session to resume a previous conversation.
     ///
-    /// This method is only available if the agent advertises the `loadSession` capability.
+    /// This method is only available if the agent advertises the `session.load` capability.
     ///
     /// The agent should:
     /// - Restore the session context and conversation history
@@ -4587,7 +4627,7 @@ pub enum ClientRequest {
     LoadSessionRequest(LoadSessionRequest),
     /// Lists existing sessions known to the agent.
     ///
-    /// This method is only available if the agent advertises the `sessionCapabilities.list` capability.
+    /// This method is only available if the agent advertises the `session.list` capability.
     ///
     /// The agent should return metadata about sessions with optional filtering and pagination support.
     ListSessionsRequest(ListSessionsRequest),
@@ -4597,7 +4637,7 @@ pub enum ClientRequest {
     ///
     /// Deletes an existing session from `session/list`.
     ///
-    /// This method is only available if the agent advertises the `sessionCapabilities.delete` capability.
+    /// This method is only available if the agent advertises the `session.delete` capability.
     #[cfg(feature = "unstable_session_delete")]
     DeleteSessionRequest(DeleteSessionRequest),
     #[cfg(feature = "unstable_session_fork")]
@@ -4615,14 +4655,14 @@ pub enum ClientRequest {
     ForkSessionRequest(ForkSessionRequest),
     /// Resumes an existing session without returning previous messages.
     ///
-    /// This method is only available if the agent advertises the `sessionCapabilities.resume` capability.
+    /// This method is only available if the agent advertises the `session.resume` capability.
     ///
     /// The agent should resume the session context, allowing the conversation to continue
     /// without replaying the message history (unlike `session/load`).
     ResumeSessionRequest(ResumeSessionRequest),
     /// Closes an active session and frees up any resources associated with it.
     ///
-    /// This method is only available if the agent advertises the `sessionCapabilities.close` capability.
+    /// This method is only available if the agent advertises the `session.close` capability.
     ///
     /// The agent must cancel any ongoing work (as if `session/cancel` was called)
     /// and then free up any resources associated with the session.
@@ -5316,6 +5356,17 @@ mod test_serialization {
             Vec::<PathBuf>::new()
         );
     }
+    #[test]
+    fn test_session_load_capabilities_serialization() {
+        assert_eq!(
+            serde_json::to_value(SessionCapabilities::new().load(SessionLoadCapabilities::new()))
+                .unwrap(),
+            json!({
+                "load": {}
+            })
+        );
+    }
+
     #[test]
     fn test_session_additional_directories_capabilities_serialization() {
         assert_eq!(

--- a/src/v2/agent.rs
+++ b/src/v2/agent.rs
@@ -57,7 +57,7 @@ pub struct InitializeRequest {
     pub protocol_version: ProtocolVersion,
     /// Capabilities supported by the client.
     #[serde(default)]
-    pub client_capabilities: ClientCapabilities,
+    pub capabilities: ClientCapabilities,
     /// Information about the Client name and version sent to the Agent.
     ///
     /// Note: in future versions of the protocol, this will be required.
@@ -79,7 +79,7 @@ impl InitializeRequest {
     pub fn new(protocol_version: ProtocolVersion) -> Self {
         Self {
             protocol_version,
-            client_capabilities: ClientCapabilities::default(),
+            capabilities: ClientCapabilities::default(),
             client_info: None,
             meta: None,
         }
@@ -87,8 +87,8 @@ impl InitializeRequest {
 
     /// Capabilities supported by the client.
     #[must_use]
-    pub fn client_capabilities(mut self, client_capabilities: ClientCapabilities) -> Self {
-        self.client_capabilities = client_capabilities;
+    pub fn capabilities(mut self, capabilities: ClientCapabilities) -> Self {
+        self.capabilities = capabilities;
         self
     }
 
@@ -130,7 +130,7 @@ pub struct InitializeResponse {
     pub protocol_version: ProtocolVersion,
     /// Capabilities supported by the agent.
     #[serde(default)]
-    pub agent_capabilities: AgentCapabilities,
+    pub capabilities: AgentCapabilities,
     /// Authentication methods supported by the agent.
     #[serde_as(deserialize_as = "DefaultOnError<VecSkipError<_, SkipListener>>")]
     #[schemars(extend("x-deserialize-default-on-error" = true, "x-deserialize-skip-invalid-items" = true))]
@@ -157,7 +157,7 @@ impl InitializeResponse {
     pub fn new(protocol_version: ProtocolVersion) -> Self {
         Self {
             protocol_version,
-            agent_capabilities: AgentCapabilities::default(),
+            capabilities: AgentCapabilities::default(),
             auth_methods: vec![],
             agent_info: None,
             meta: None,
@@ -166,8 +166,8 @@ impl InitializeResponse {
 
     /// Capabilities supported by the agent.
     #[must_use]
-    pub fn agent_capabilities(mut self, agent_capabilities: AgentCapabilities) -> Self {
-        self.agent_capabilities = agent_capabilities;
+    pub fn capabilities(mut self, capabilities: AgentCapabilities) -> Self {
+        self.capabilities = capabilities;
         self
     }
 
@@ -2646,11 +2646,11 @@ impl SetSessionConfigOptionResponse {
 pub enum McpServer {
     /// HTTP transport configuration
     ///
-    /// Only available when the Agent capabilities indicate `mcp_capabilities.http` is `true`.
+    /// Only available when the Agent capabilities indicate `mcp.http` is `true`.
     Http(McpServerHttp),
     /// SSE transport configuration
     ///
-    /// Only available when the Agent capabilities indicate `mcp_capabilities.sse` is `true`.
+    /// Only available when the Agent capabilities indicate `mcp.sse` is `true`.
     Sse(McpServerSse),
     /// **UNSTABLE**
     ///
@@ -2658,7 +2658,7 @@ pub enum McpServer {
     ///
     /// ACP transport configuration
     ///
-    /// Only available when the Agent capabilities indicate `mcp_capabilities.acp` is `true`.
+    /// Only available when the Agent capabilities indicate `mcp.acp` is `true`.
     /// The MCP server is provided by an ACP component and communicates over the ACP channel.
     #[cfg(feature = "unstable_mcp_over_acp")]
     Acp(McpServerAcp),
@@ -3638,12 +3638,12 @@ pub struct AgentCapabilities {
     pub load_session: bool,
     /// Prompt capabilities supported by the agent.
     #[serde(default)]
-    pub prompt_capabilities: PromptCapabilities,
+    pub prompt: PromptCapabilities,
     /// MCP capabilities supported by the agent.
     #[serde(default)]
-    pub mcp_capabilities: McpCapabilities,
+    pub mcp: McpCapabilities,
     #[serde(default)]
-    pub session_capabilities: SessionCapabilities,
+    pub session: SessionCapabilities,
     /// Authentication-related capabilities supported by the agent.
     #[serde(default)]
     pub auth: AgentAuthCapabilities,
@@ -3703,22 +3703,22 @@ impl AgentCapabilities {
 
     /// Prompt capabilities supported by the agent.
     #[must_use]
-    pub fn prompt_capabilities(mut self, prompt_capabilities: PromptCapabilities) -> Self {
-        self.prompt_capabilities = prompt_capabilities;
+    pub fn prompt(mut self, prompt: PromptCapabilities) -> Self {
+        self.prompt = prompt;
         self
     }
 
     /// MCP capabilities supported by the agent.
     #[must_use]
-    pub fn mcp_capabilities(mut self, mcp_capabilities: McpCapabilities) -> Self {
-        self.mcp_capabilities = mcp_capabilities;
+    pub fn mcp(mut self, mcp: McpCapabilities) -> Self {
+        self.mcp = mcp;
         self
     }
 
     /// Session capabilities supported by the agent.
     #[must_use]
-    pub fn session_capabilities(mut self, session_capabilities: SessionCapabilities) -> Self {
-        self.session_capabilities = session_capabilities;
+    pub fn session(mut self, session: SessionCapabilities) -> Self {
+        self.session = session;
         self
     }
 

--- a/src/v2/agent.rs
+++ b/src/v2/agent.rs
@@ -2646,11 +2646,11 @@ impl SetSessionConfigOptionResponse {
 pub enum McpServer {
     /// HTTP transport configuration
     ///
-    /// Only available when the Agent capabilities indicate `mcp.http` is `true`.
+    /// Only available when the Agent capabilities include `mcp.http`.
     Http(McpServerHttp),
     /// SSE transport configuration
     ///
-    /// Only available when the Agent capabilities indicate `mcp.sse` is `true`.
+    /// Only available when the Agent capabilities include `mcp.sse`.
     Sse(McpServerSse),
     /// **UNSTABLE**
     ///
@@ -2658,7 +2658,7 @@ pub enum McpServer {
     ///
     /// ACP transport configuration
     ///
-    /// Only available when the Agent capabilities indicate `mcp.acp` is `true`.
+    /// Only available when the Agent capabilities include `mcp.acp`.
     /// The MCP server is provided by an ACP component and communicates over the ACP channel.
     #[cfg(feature = "unstable_mcp_over_acp")]
     Acp(McpServerAcp),
@@ -4236,23 +4236,39 @@ impl SessionCloseCapabilities {
 /// the agent can process.
 ///
 /// See protocol docs: [Prompt Capabilities](https://agentclientprotocol.com/protocol/initialization#prompt-capabilities)
+#[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct PromptCapabilities {
     /// Agent supports [`ContentBlock::Image`].
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports image content in prompts.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
-    pub image: bool,
+    pub image: Option<PromptImageCapabilities>,
     /// Agent supports [`ContentBlock::Audio`].
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports audio content in prompts.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
-    pub audio: bool,
+    pub audio: Option<PromptAudioCapabilities>,
     /// Agent supports embedded context in `session/prompt` requests.
     ///
     /// When enabled, the Client is allowed to include [`ContentBlock::Resource`]
     /// in prompt requests for pieces of context that are referenced in the message.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports embedded context in prompts.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
-    pub embedded_context: bool,
+    pub embedded_context: Option<PromptEmbeddedContextCapabilities>,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
     /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
     /// these keys.
@@ -4269,16 +4285,22 @@ impl PromptCapabilities {
     }
 
     /// Agent supports [`ContentBlock::Image`].
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports image content in prompts.
     #[must_use]
-    pub fn image(mut self, image: bool) -> Self {
-        self.image = image;
+    pub fn image(mut self, image: impl IntoOption<PromptImageCapabilities>) -> Self {
+        self.image = image.into_option();
         self
     }
 
     /// Agent supports [`ContentBlock::Audio`].
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports audio content in prompts.
     #[must_use]
-    pub fn audio(mut self, audio: bool) -> Self {
-        self.audio = audio;
+    pub fn audio(mut self, audio: impl IntoOption<PromptAudioCapabilities>) -> Self {
+        self.audio = audio.into_option();
         self
     }
 
@@ -4286,9 +4308,15 @@ impl PromptCapabilities {
     ///
     /// When enabled, the Client is allowed to include [`ContentBlock::Resource`]
     /// in prompt requests for pieces of context that are referenced in the message.
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports embedded context in prompts.
     #[must_use]
-    pub fn embedded_context(mut self, embedded_context: bool) -> Self {
-        self.embedded_context = embedded_context;
+    pub fn embedded_context(
+        mut self,
+        embedded_context: impl IntoOption<PromptEmbeddedContextCapabilities>,
+    ) -> Self {
+        self.embedded_context = embedded_context.into_option();
         self
     }
 
@@ -4304,26 +4332,144 @@ impl PromptCapabilities {
     }
 }
 
+/// Capabilities for image content in prompt requests.
+///
+/// Supplying `{}` means the agent supports image content in prompts.
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PromptImageCapabilities {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+impl PromptImageCapabilities {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// Capabilities for audio content in prompt requests.
+///
+/// Supplying `{}` means the agent supports audio content in prompts.
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PromptAudioCapabilities {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+impl PromptAudioCapabilities {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// Capabilities for embedded context in prompt requests.
+///
+/// Supplying `{}` means the agent supports embedded context in prompts.
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PromptEmbeddedContextCapabilities {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+impl PromptEmbeddedContextCapabilities {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
 /// MCP capabilities supported by the agent
+#[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct McpCapabilities {
     /// Agent supports [`McpServer::Http`].
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports HTTP MCP server transports.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
-    pub http: bool,
+    pub http: Option<McpHttpCapabilities>,
     /// Agent supports [`McpServer::Sse`].
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports SSE MCP server transports.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
-    pub sse: bool,
+    pub sse: Option<McpSseCapabilities>,
     /// **UNSTABLE**
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// Agent supports [`McpServer::Acp`].
     #[cfg(feature = "unstable_mcp_over_acp")]
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports ACP MCP server transports.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
-    pub acp: bool,
+    pub acp: Option<McpAcpCapabilities>,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
     /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
     /// these keys.
@@ -4340,16 +4486,22 @@ impl McpCapabilities {
     }
 
     /// Agent supports [`McpServer::Http`].
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports HTTP MCP server transports.
     #[must_use]
-    pub fn http(mut self, http: bool) -> Self {
-        self.http = http;
+    pub fn http(mut self, http: impl IntoOption<McpHttpCapabilities>) -> Self {
+        self.http = http.into_option();
         self
     }
 
     /// Agent supports [`McpServer::Sse`].
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports SSE MCP server transports.
     #[must_use]
-    pub fn sse(mut self, sse: bool) -> Self {
-        self.sse = sse;
+    pub fn sse(mut self, sse: impl IntoOption<McpSseCapabilities>) -> Self {
+        self.sse = sse.into_option();
         self
     }
 
@@ -4359,10 +4511,121 @@ impl McpCapabilities {
     ///
     /// Agent supports [`McpServer::Acp`].
     #[cfg(feature = "unstable_mcp_over_acp")]
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports ACP MCP server transports.
     #[must_use]
-    pub fn acp(mut self, acp: bool) -> Self {
-        self.acp = acp;
+    pub fn acp(mut self, acp: impl IntoOption<McpAcpCapabilities>) -> Self {
+        self.acp = acp.into_option();
         self
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// Capabilities for HTTP MCP server transports.
+///
+/// Supplying `{}` means the agent supports HTTP MCP server transports.
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct McpHttpCapabilities {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+impl McpHttpCapabilities {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// Capabilities for SSE MCP server transports.
+///
+/// Supplying `{}` means the agent supports SSE MCP server transports.
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct McpSseCapabilities {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+impl McpSseCapabilities {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// **UNSTABLE**
+///
+/// This capability is not part of the spec yet, and may be removed or changed at any point.
+///
+/// Capabilities for ACP MCP server transports.
+///
+/// Supplying `{}` means the agent supports ACP MCP server transports.
+#[cfg(feature = "unstable_mcp_over_acp")]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct McpAcpCapabilities {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+#[cfg(feature = "unstable_mcp_over_acp")]
+impl McpAcpCapabilities {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -6133,5 +6396,68 @@ mod test_serialization {
 
         let deserialized: AgentCapabilities = serde_json::from_value(json).unwrap();
         assert!(deserialized.providers.is_some());
+    }
+
+    #[test]
+    fn test_prompt_capabilities_serialize_supported_content_as_objects() {
+        let caps = PromptCapabilities::new()
+            .image(PromptImageCapabilities::new())
+            .audio(PromptAudioCapabilities::new())
+            .embedded_context(PromptEmbeddedContextCapabilities::new());
+
+        assert_eq!(
+            serde_json::to_value(&caps).unwrap(),
+            json!({
+                "image": {},
+                "audio": {},
+                "embeddedContext": {}
+            })
+        );
+
+        let deserialized: PromptCapabilities = serde_json::from_value(json!({
+            "image": null,
+            "audio": false,
+            "embeddedContext": {}
+        }))
+        .unwrap();
+        assert!(deserialized.image.is_none());
+        assert!(deserialized.audio.is_none());
+        assert!(deserialized.embedded_context.is_some());
+    }
+
+    #[test]
+    fn test_mcp_capabilities_serialize_supported_transports_as_objects() {
+        let caps = McpCapabilities::new()
+            .http(McpHttpCapabilities::new())
+            .sse(McpSseCapabilities::new());
+
+        assert_eq!(
+            serde_json::to_value(&caps).unwrap(),
+            json!({
+                "http": {},
+                "sse": {}
+            })
+        );
+
+        let deserialized: McpCapabilities = serde_json::from_value(json!({
+            "http": null,
+            "sse": false
+        }))
+        .unwrap();
+        assert!(deserialized.http.is_none());
+        assert!(deserialized.sse.is_none());
+    }
+
+    #[cfg(feature = "unstable_mcp_over_acp")]
+    #[test]
+    fn test_mcp_capabilities_serialize_acp_support_as_object() {
+        let caps = McpCapabilities::new().acp(McpAcpCapabilities::new());
+
+        assert_eq!(
+            serde_json::to_value(&caps).unwrap(),
+            json!({
+                "acp": {}
+            })
+        );
     }
 }

--- a/src/v2/client.rs
+++ b/src/v2/client.rs
@@ -1104,6 +1104,7 @@ impl ClientCapabilities {
 /// method types the client can handle. This governs opt-in types that require
 /// additional client-side support.
 #[cfg(feature = "unstable_auth_methods")]
+#[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -1111,9 +1112,12 @@ impl ClientCapabilities {
 pub struct AuthCapabilities {
     /// Whether the client supports `terminal` authentication methods.
     ///
-    /// When `true`, the agent may include `terminal` entries in its authentication methods.
+    /// Optional. Omitted or `null` both mean the client does not advertise support.
+    /// Supplying `{}` means the agent may include `terminal` entries in its authentication methods.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
-    pub terminal: bool,
+    pub terminal: Option<TerminalAuthCapabilities>,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
     /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
     /// these keys.
@@ -1132,12 +1136,52 @@ impl AuthCapabilities {
 
     /// Whether the client supports `terminal` authentication methods.
     ///
-    /// When `true`, the agent may include `AuthMethod::Terminal`
-    /// entries in its authentication methods.
+    /// Omitted or `null` both mean the client does not advertise support.
+    /// Supplying `{}` means the agent may include `AuthMethod::Terminal` entries in its authentication methods.
     #[must_use]
-    pub fn terminal(mut self, terminal: bool) -> Self {
-        self.terminal = terminal;
+    pub fn terminal(mut self, terminal: impl IntoOption<TerminalAuthCapabilities>) -> Self {
+        self.terminal = terminal.into_option();
         self
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// **UNSTABLE**
+///
+/// This capability is not part of the spec yet, and may be removed or changed at any point.
+///
+/// Capabilities for terminal authentication methods.
+///
+/// Supplying `{}` means the client supports terminal authentication methods.
+#[cfg(feature = "unstable_auth_methods")]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct TerminalAuthCapabilities {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+#[cfg(feature = "unstable_auth_methods")]
+impl TerminalAuthCapabilities {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -1642,5 +1686,26 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(request_with_null_params.params, None);
+    }
+
+    #[cfg(feature = "unstable_auth_methods")]
+    #[test]
+    fn test_auth_capabilities_serialize_terminal_support_as_object() {
+        use serde_json::json;
+
+        let capabilities = AuthCapabilities::new().terminal(TerminalAuthCapabilities::new());
+
+        assert_eq!(
+            serde_json::to_value(&capabilities).unwrap(),
+            json!({
+                "terminal": {}
+            })
+        );
+
+        let deserialized: AuthCapabilities = serde_json::from_value(json!({
+            "terminal": false
+        }))
+        .unwrap();
+        assert!(deserialized.terminal.is_none());
     }
 }

--- a/src/v2/conversion.rs
+++ b/src/v2/conversion.rs
@@ -2428,13 +2428,13 @@ impl IntoV1 for super::InitializeRequest {
     fn into_v1(self) -> Result<Self::Output> {
         let Self {
             protocol_version,
-            client_capabilities,
+            capabilities,
             client_info,
             meta,
         } = self;
         Ok(crate::v1::InitializeRequest {
             protocol_version: protocol_version.into_v1()?,
-            client_capabilities: client_capabilities.into_v1()?,
+            client_capabilities: capabilities.into_v1()?,
             client_info: client_info.into_v1()?,
             meta: meta.into_v1()?,
         })
@@ -2453,7 +2453,7 @@ impl IntoV2 for crate::v1::InitializeRequest {
         } = self;
         Ok(super::InitializeRequest {
             protocol_version: protocol_version.into_v2()?,
-            client_capabilities: client_capabilities.into_v2()?,
+            capabilities: client_capabilities.into_v2()?,
             client_info: client_info.into_v2()?,
             meta: meta.into_v2()?,
         })
@@ -2466,7 +2466,7 @@ impl IntoV1 for super::InitializeResponse {
     fn into_v1(self) -> Result<Self::Output> {
         let Self {
             protocol_version,
-            agent_capabilities,
+            capabilities: agent_capabilities,
             auth_methods,
             agent_info,
             meta,
@@ -2494,7 +2494,7 @@ impl IntoV2 for crate::v1::InitializeResponse {
         } = self;
         Ok(super::InitializeResponse {
             protocol_version: protocol_version.into_v2()?,
-            agent_capabilities: agent_capabilities.into_v2()?,
+            capabilities: agent_capabilities.into_v2()?,
             auth_methods: auth_methods.into_v2()?,
             agent_info: agent_info.into_v2()?,
             meta: meta.into_v2()?,
@@ -4499,9 +4499,9 @@ impl IntoV1 for super::AgentCapabilities {
     fn into_v1(self) -> Result<Self::Output> {
         let Self {
             load_session,
-            prompt_capabilities,
-            mcp_capabilities,
-            session_capabilities,
+            prompt,
+            mcp,
+            session,
             auth,
             #[cfg(feature = "unstable_llm_providers")]
             providers,
@@ -4513,9 +4513,9 @@ impl IntoV1 for super::AgentCapabilities {
         } = self;
         Ok(crate::v1::AgentCapabilities {
             load_session: load_session.into_v1()?,
-            prompt_capabilities: prompt_capabilities.into_v1()?,
-            mcp_capabilities: mcp_capabilities.into_v1()?,
-            session_capabilities: session_capabilities.into_v1()?,
+            prompt_capabilities: prompt.into_v1()?,
+            mcp_capabilities: mcp.into_v1()?,
+            session_capabilities: session.into_v1()?,
             auth: auth.into_v1()?,
             #[cfg(feature = "unstable_llm_providers")]
             providers: providers.into_v1()?,
@@ -4548,9 +4548,9 @@ impl IntoV2 for crate::v1::AgentCapabilities {
         } = self;
         Ok(super::AgentCapabilities {
             load_session: load_session.into_v2()?,
-            prompt_capabilities: prompt_capabilities.into_v2()?,
-            mcp_capabilities: mcp_capabilities.into_v2()?,
-            session_capabilities: session_capabilities.into_v2()?,
+            prompt: prompt_capabilities.into_v2()?,
+            mcp: mcp_capabilities.into_v2()?,
+            session: session_capabilities.into_v2()?,
             auth: auth.into_v2()?,
             #[cfg(feature = "unstable_llm_providers")]
             providers: providers.into_v2()?,
@@ -8648,7 +8648,7 @@ mod tests {
         let converted: v2::InitializeRequest =
             v1_to_v2(request).expect("v1 -> v2 conversion failed");
         let converted_capabilities =
-            serde_json::to_value(converted.client_capabilities).expect("v2 serialize");
+            serde_json::to_value(converted.capabilities).expect("v2 serialize");
         assert_eq!(converted_capabilities.get("fs"), None);
         assert_eq!(converted_capabilities.get("terminal"), None);
     }

--- a/src/v2/conversion.rs
+++ b/src/v2/conversion.rs
@@ -1719,7 +1719,7 @@ impl IntoV1 for super::AuthCapabilities {
     fn into_v1(self) -> Result<Self::Output> {
         let Self { terminal, meta } = self;
         Ok(crate::v1::AuthCapabilities {
-            terminal: terminal.into_v1()?,
+            terminal: terminal.is_some(),
             meta: meta.into_v1()?,
         })
     }
@@ -1732,7 +1732,7 @@ impl IntoV2 for crate::v1::AuthCapabilities {
     fn into_v2(self) -> Result<Self::Output> {
         let Self { terminal, meta } = self;
         Ok(super::AuthCapabilities {
-            terminal: terminal.into_v2()?,
+            terminal: terminal.then(super::TerminalAuthCapabilities::new),
             meta: meta.into_v2()?,
         })
     }
@@ -4796,9 +4796,9 @@ impl IntoV1 for super::PromptCapabilities {
             meta,
         } = self;
         Ok(crate::v1::PromptCapabilities {
-            image: image.into_v1()?,
-            audio: audio.into_v1()?,
-            embedded_context: embedded_context.into_v1()?,
+            image: image.is_some(),
+            audio: audio.is_some(),
+            embedded_context: embedded_context.is_some(),
             meta: meta.into_v1()?,
         })
     }
@@ -4815,9 +4815,9 @@ impl IntoV2 for crate::v1::PromptCapabilities {
             meta,
         } = self;
         Ok(super::PromptCapabilities {
-            image: image.into_v2()?,
-            audio: audio.into_v2()?,
-            embedded_context: embedded_context.into_v2()?,
+            image: image.then(super::PromptImageCapabilities::new),
+            audio: audio.then(super::PromptAudioCapabilities::new),
+            embedded_context: embedded_context.then(super::PromptEmbeddedContextCapabilities::new),
             meta: meta.into_v2()?,
         })
     }
@@ -4835,10 +4835,10 @@ impl IntoV1 for super::McpCapabilities {
             meta,
         } = self;
         Ok(crate::v1::McpCapabilities {
-            http: http.into_v1()?,
-            sse: sse.into_v1()?,
+            http: http.is_some(),
+            sse: sse.is_some(),
             #[cfg(feature = "unstable_mcp_over_acp")]
-            acp: acp.into_v1()?,
+            acp: acp.is_some(),
             meta: meta.into_v1()?,
         })
     }
@@ -4856,10 +4856,10 @@ impl IntoV2 for crate::v1::McpCapabilities {
             meta,
         } = self;
         Ok(super::McpCapabilities {
-            http: http.into_v2()?,
-            sse: sse.into_v2()?,
+            http: http.then(super::McpHttpCapabilities::new),
+            sse: sse.then(super::McpSseCapabilities::new),
             #[cfg(feature = "unstable_mcp_over_acp")]
-            acp: acp.into_v2()?,
+            acp: acp.then(super::McpAcpCapabilities::new),
             meta: meta.into_v2()?,
         })
     }
@@ -8688,6 +8688,74 @@ mod tests {
         let v1_after: v1::AgentCapabilities =
             v2_to_v1(v2_capabilities).expect("v2 -> v1 conversion");
         assert!(v1_after.load_session);
+    }
+
+    #[test]
+    fn v1_prompt_capability_bools_convert_to_v2_objects() {
+        let v1_capabilities = v1::PromptCapabilities::new()
+            .image(true)
+            .audio(true)
+            .embedded_context(true);
+
+        let v2_capabilities: v2::PromptCapabilities =
+            v1_to_v2(v1_capabilities).expect("v1 -> v2 conversion");
+        let v2_json = serde_json::to_value(&v2_capabilities).expect("v2 serialize");
+        assert_eq!(v2_json.pointer("/image"), Some(&serde_json::json!({})));
+        assert_eq!(v2_json.pointer("/audio"), Some(&serde_json::json!({})));
+        assert_eq!(
+            v2_json.pointer("/embeddedContext"),
+            Some(&serde_json::json!({}))
+        );
+
+        let v1_after: v1::PromptCapabilities =
+            v2_to_v1(v2_capabilities).expect("v2 -> v1 conversion");
+        assert!(v1_after.image);
+        assert!(v1_after.audio);
+        assert!(v1_after.embedded_context);
+    }
+
+    #[test]
+    fn v1_mcp_capability_bools_convert_to_v2_objects() {
+        let v1_capabilities = v1::McpCapabilities::new().http(true).sse(true);
+
+        let v2_capabilities: v2::McpCapabilities =
+            v1_to_v2(v1_capabilities).expect("v1 -> v2 conversion");
+        let v2_json = serde_json::to_value(&v2_capabilities).expect("v2 serialize");
+        assert_eq!(v2_json.pointer("/http"), Some(&serde_json::json!({})));
+        assert_eq!(v2_json.pointer("/sse"), Some(&serde_json::json!({})));
+
+        let v1_after: v1::McpCapabilities = v2_to_v1(v2_capabilities).expect("v2 -> v1 conversion");
+        assert!(v1_after.http);
+        assert!(v1_after.sse);
+    }
+
+    #[cfg(feature = "unstable_mcp_over_acp")]
+    #[test]
+    fn v1_mcp_acp_capability_bool_converts_to_v2_object() {
+        let v1_capabilities = v1::McpCapabilities::new().acp(true);
+
+        let v2_capabilities: v2::McpCapabilities =
+            v1_to_v2(v1_capabilities).expect("v1 -> v2 conversion");
+        let v2_json = serde_json::to_value(&v2_capabilities).expect("v2 serialize");
+        assert_eq!(v2_json.pointer("/acp"), Some(&serde_json::json!({})));
+
+        let v1_after: v1::McpCapabilities = v2_to_v1(v2_capabilities).expect("v2 -> v1 conversion");
+        assert!(v1_after.acp);
+    }
+
+    #[cfg(feature = "unstable_auth_methods")]
+    #[test]
+    fn v1_auth_terminal_capability_bool_converts_to_v2_object() {
+        let v1_capabilities = v1::AuthCapabilities::new().terminal(true);
+
+        let v2_capabilities: v2::AuthCapabilities =
+            v1_to_v2(v1_capabilities).expect("v1 -> v2 conversion");
+        let v2_json = serde_json::to_value(&v2_capabilities).expect("v2 serialize");
+        assert_eq!(v2_json.pointer("/terminal"), Some(&serde_json::json!({})));
+
+        let v1_after: v1::AuthCapabilities =
+            v2_to_v1(v2_capabilities).expect("v2 -> v1 conversion");
+        assert!(v1_after.terminal);
     }
 
     #[test]

--- a/src/v2/conversion.rs
+++ b/src/v2/conversion.rs
@@ -4498,7 +4498,6 @@ impl IntoV1 for super::AgentCapabilities {
 
     fn into_v1(self) -> Result<Self::Output> {
         let Self {
-            load_session,
             prompt,
             mcp,
             session,
@@ -4511,6 +4510,7 @@ impl IntoV1 for super::AgentCapabilities {
             position_encoding,
             meta,
         } = self;
+        let load_session = session.load.is_some();
         Ok(crate::v1::AgentCapabilities {
             load_session: load_session.into_v1()?,
             prompt_capabilities: prompt.into_v1()?,
@@ -4546,11 +4546,14 @@ impl IntoV2 for crate::v1::AgentCapabilities {
             position_encoding,
             meta,
         } = self;
+        let mut session = session_capabilities.into_v2()?;
+        if load_session {
+            session.load = Some(super::SessionLoadCapabilities::new());
+        }
         Ok(super::AgentCapabilities {
-            load_session: load_session.into_v2()?,
             prompt: prompt_capabilities.into_v2()?,
             mcp: mcp_capabilities.into_v2()?,
-            session: session_capabilities.into_v2()?,
+            session,
             auth: auth.into_v2()?,
             #[cfg(feature = "unstable_llm_providers")]
             providers: providers.into_v2()?,
@@ -4592,6 +4595,7 @@ impl IntoV1 for super::SessionCapabilities {
 
     fn into_v1(self) -> Result<Self::Output> {
         let Self {
+            load: _,
             list,
             #[cfg(feature = "unstable_session_delete")]
             delete,
@@ -4632,6 +4636,7 @@ impl IntoV2 for crate::v1::SessionCapabilities {
             meta,
         } = self;
         Ok(super::SessionCapabilities {
+            load: None,
             list: list.into_v2()?,
             #[cfg(feature = "unstable_session_delete")]
             delete: delete.into_v2()?,
@@ -8658,7 +8663,31 @@ mod tests {
         let response = v1::InitializeResponse::new(ProtocolVersion::V1)
             .agent_info(v1::Implementation::new("test-agent", "2.0.0").title("Test Agent"));
         assert_v1_round_trip::<v1::InitializeResponse, v2::InitializeResponse>(response.clone());
-        assert_json_eq_after_v1_to_v2::<v1::InitializeResponse, v2::InitializeResponse>(response);
+        let converted: v2::InitializeResponse =
+            v1_to_v2(response).expect("v1 -> v2 conversion failed");
+        let converted_json = serde_json::to_value(&converted).expect("v2 serialize");
+        assert_eq!(converted_json.get("agentCapabilities"), None);
+        assert!(converted_json.get("capabilities").is_some());
+        assert_eq!(converted_json.pointer("/capabilities/loadSession"), None);
+    }
+
+    #[test]
+    fn agent_load_session_capability_moves_between_v1_and_v2() {
+        let v1_capabilities = v1::AgentCapabilities::new().load_session(true);
+
+        let v2_capabilities: v2::AgentCapabilities =
+            v1_to_v2(v1_capabilities).expect("v1 -> v2 conversion");
+        assert!(v2_capabilities.session.load.is_some());
+        let v2_json = serde_json::to_value(&v2_capabilities).expect("v2 serialize");
+        assert_eq!(v2_json.get("loadSession"), None);
+        assert_eq!(
+            v2_json.pointer("/session/load"),
+            Some(&serde_json::json!({}))
+        );
+
+        let v1_after: v1::AgentCapabilities =
+            v2_to_v1(v2_capabilities).expect("v2 -> v1 conversion");
+        assert!(v1_after.load_session);
     }
 
     #[test]


### PR DESCRIPTION
Makes naming and types consistent across how we use capablities.

- **Cleanup capability field names**
- **Move load_session into session capabilities**
- **Use capability objects for v2 support markers**
