### PR TITLE
feat(unstable-v2): Nest session-scoped capabilities under session

### DIFF
--- a/docs/protocol/v2/draft/initialization.mdx
+++ b/docs/protocol/v2/draft/initialization.mdx
@@ -57,16 +57,16 @@ The Agent **MUST** respond with the chosen [protocol version](#protocol-version)
     "protocolVersion": 2,
     "capabilities": {
       "session": {
+        "prompt": {
+          "image": {},
+          "audio": {},
+          "embeddedContext": {}
+        },
+        "mcp": {
+          "stdio": {},
+          "http": {}
+        },
         "load": {}
-      },
-      "prompt": {
-        "image": {},
-        "audio": {},
-        "embeddedContext": {}
-      },
-      "mcp": {
-        "stdio": {},
-        "http": {}
       }
     },
     "agentInfo": {
@@ -103,7 +103,8 @@ All capabilities included in the `initialize` request are **OPTIONAL**. Clients 
 
 The introduction of new capabilities is not considered a breaking change. Therefore, Clients and Agents **MUST** treat all capabilities omitted in the `initialize` request as **UNSUPPORTED**.
 
-Capabilities are high-level and are not attached to a specific base protocol concept.
+Capabilities may advertise top-level method surfaces or nested features that
+only apply within a supported surface.
 
 Capabilities may specify the availability of protocol methods, notifications, or a subset of their parameters. They may also signal behaviors of the Agent or Client implementation.
 
@@ -118,18 +119,66 @@ Omitted fields mean unsupported.
 
 The Agent **SHOULD** specify whether it supports the following capabilities:
 
-<ResponseField name="prompt" type="PromptCapabilities Object">
-  Object indicating the different types of [content](/protocol/v2/draft/content)
-  that may be included in `session/prompt` requests.
+<ResponseField name="session" type="SessionCapabilities Object">
+  The Agent supports the `session/*` method surface. Omitted or `null` means the
+  Agent does not support session methods. Supplying `{}` means the Agent
+  supports the baseline session methods: `session/new`, `session/prompt`,
+  `session/cancel`, and `session/update`.
+</ResponseField>
+
+<ResponseField name="nes" type="NesCapabilities Object">
+  The Agent supports the `nes/*` method surface. Omitted or `null` means the
+  Agent does not support NES methods. Supplying `{}` means the Agent supports
+  NES sessions. NES can be advertised independently from `session`.
 </ResponseField>
 
 <ResponseField name="auth" type="AgentAuthCapabilities Object">
   Authentication-related capabilities supported by the Agent.
 </ResponseField>
 
-#### Prompt capabilities
+#### Session Capabilities
 
-As a baseline, all Agents **MUST** support `ContentBlock::Text` and `ContentBlock::ResourceLink` in `session/prompt` requests.
+Supplying `session: {}` means the Agent supports `session/new`, `session/prompt`, `session/cancel`, and `session/update`.
+
+Optionally, Agents **MAY** support prompt extensions, MCP server transports, and additional session methods by specifying nested capabilities.
+
+<ResponseField name="prompt" type="PromptCapabilities Object">
+  Object indicating the different types of [content](/protocol/v2/draft/content)
+  that may be included in `session/prompt` requests. Omitted or `null` means the
+  Agent does not advertise any prompt extensions beyond the baseline text and
+  resource-link content required by `session/prompt`.
+</ResponseField>
+
+<ResponseField name="mcp" type="McpCapabilities Object">
+  Object indicating the MCP server transports that may be included in session
+  lifecycle requests. Omitted or `null` means the Agent does not advertise MCP
+  server transport support for sessions.
+</ResponseField>
+
+<ResponseField name="load" type="SessionLoadCapabilities Object">
+  The [`session/load`](/protocol/v2/draft/session-setup#loading-sessions) method
+  is available. Omitted or `null` means the Agent does not advertise support.
+  Supplying `{}` means the Agent supports loading sessions.
+</ResponseField>
+
+<ResponseField name="delete" type="SessionDeleteCapabilities Object">
+  The [`session/delete`](/protocol/v2/draft/session-delete) method is available.
+  Omitted or `null` means the Agent does not advertise support. Supplying `{}`
+  means the Agent supports deleting sessions from `session/list`.
+</ResponseField>
+
+<ResponseField
+  name="additionalDirectories"
+  type="SessionAdditionalDirectoriesCapabilities Object"
+>
+  The Agent supports `additionalDirectories` on supported session lifecycle
+  requests. Omitted or `null` means the Agent does not advertise support.
+  Supplying `{}` means the Agent supports additional workspace roots.
+</ResponseField>
+
+#### Session Prompt Capabilities
+
+As a baseline, Agents that advertise `session` **MUST** support `ContentBlock::Text` and `ContentBlock::ResourceLink` in `session/prompt` requests.
 
 Optionally, they **MAY** support richer types of [content](/protocol/v2/draft/content) by specifying the following capabilities:
 
@@ -154,7 +203,7 @@ Optionally, they **MAY** support richer types of [content](/protocol/v2/draft/co
   embedded context in prompts.
 </ResponseField>
 
-#### MCP capabilities
+#### Session MCP Capabilities
 
 <ResponseField name="stdio" type="McpStdioCapabilities Object">
   The Agent supports connecting to MCP servers over stdio. Omitted or `null`
@@ -178,33 +227,6 @@ Optionally, they **MAY** support richer types of [content](/protocol/v2/draft/co
 <Card icon="shield-check" horizontal href="/protocol/v2/draft/authentication">
   Learn more about Authentication
 </Card>
-
-#### Session Capabilities
-
-As a baseline, all Agents **MUST** support `session/new`, `session/prompt`, `session/cancel`, and `session/update`.
-
-Optionally, they **MAY** support other session methods and notifications by specifying additional capabilities.
-
-<ResponseField name="load" type="SessionLoadCapabilities Object">
-  The [`session/load`](/protocol/v2/draft/session-setup#loading-sessions) method
-  is available. Omitted or `null` means the Agent does not advertise support.
-  Supplying `{}` means the Agent supports loading sessions.
-</ResponseField>
-
-<ResponseField name="delete" type="SessionDeleteCapabilities Object">
-  The [`session/delete`](/protocol/v2/draft/session-delete) method is available.
-  Omitted or `null` means the Agent does not advertise support. Supplying `{}`
-  means the Agent supports deleting sessions from `session/list`.
-</ResponseField>
-
-<ResponseField
-  name="additionalDirectories"
-  type="SessionAdditionalDirectoriesCapabilities Object"
->
-  The Agent supports `additionalDirectories` on supported session lifecycle
-  requests. Omitted or `null` means the Agent does not advertise support.
-  Supplying `{}` means the Agent supports additional workspace roots.
-</ResponseField>
 
 ## Implementation Information
 

--- a/docs/protocol/v2/draft/schema.mdx
+++ b/docs/protocol/v2/draft/schema.mdx
@@ -327,7 +327,7 @@ Note: in future versions of the protocol, this will be required.
 <ResponseField name="capabilities" type={<a href="#agentcapabilities">AgentCapabilities</a>} >
   Capabilities supported by the agent.
 
-    - Default: `{"auth":{},"mcp":{},"prompt":{},"session":{}}`
+    - Default: `{"auth":{}}`
 
 </ResponseField>
 <ResponseField name="protocolVersion" type={<a href="#protocolversion">ProtocolVersion</a>} required>
@@ -2151,12 +2151,6 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
     - Default: `{}`
 
 </ResponseField>
-<ResponseField name="mcp" type={<a href="#mcpcapabilities">McpCapabilities</a>} >
-  MCP capabilities supported by the agent.
-
-    - Default: `{}`
-
-</ResponseField>
 <ResponseField name="nes" type={<><span><a href="#nescapabilities">NesCapabilities</a></span><span> | null</span></>} >
   **UNSTABLE**
 
@@ -2173,12 +2167,6 @@ This capability is not part of the spec yet, and may be removed or changed at an
 The position encoding selected by the agent from the client's supported encodings.
 
 </ResponseField>
-<ResponseField name="prompt" type={<a href="#promptcapabilities">PromptCapabilities</a>} >
-  Prompt capabilities supported by the agent.
-
-    - Default: `{}`
-
-</ResponseField>
 <ResponseField name="providers" type={<><span><a href="#providerscapabilities">ProvidersCapabilities</a></span><span> | null</span></>} >
   **UNSTABLE**
 
@@ -2189,9 +2177,13 @@ Provider configuration capabilities supported by the agent.
 By supplying `\{\}` it means that the agent supports provider configuration methods.
 
 </ResponseField>
-<ResponseField name="session" type={<a href="#sessioncapabilities">SessionCapabilities</a>} >
+<ResponseField name="session" type={<><span><a href="#sessioncapabilities">SessionCapabilities</a></span><span> | null</span></>} >
+  Session capabilities supported by the agent.
 
-    - Default: `{}`
+Optional. Omitted or `null` both mean the agent does not support the
+`session/*` method surface. Supplying `\{\}` means the agent supports the
+baseline session methods: `session/new`, `session/prompt`,
+`session/cancel`, and `session/update`.
 
 </ResponseField>
 
@@ -4062,7 +4054,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 
 ## <span class="font-mono">McpCapabilities</span>
 
-MCP capabilities supported by the agent
+MCP capabilities supported by the agent for session lifecycle requests.
 
 **Type:** Object
 
@@ -4145,7 +4137,7 @@ See protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/v2/dra
 <ResponseField name="http" type="object">
 HTTP transport configuration
 
-Only available when the Agent capabilities include `mcp.http`.
+Only available when the Agent capabilities include `session.mcp.http`.
 
 <Expandable title="Properties">
 
@@ -4180,7 +4172,7 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 ACP transport configuration
 
-Only available when the Agent capabilities include `mcp.acp`.
+Only available when the Agent capabilities include `session.mcp.acp`.
 The MCP server is provided by an ACP component and communicates over the ACP channel.
 
 <Expandable title="Properties">
@@ -4213,7 +4205,7 @@ on the same ACP connection.
 <ResponseField name="stdio" type="object">
 Stdio transport configuration
 
-Only available when the Agent capabilities include `mcp.stdio`.
+Only available when the Agent capabilities include `session.mcp.stdio`.
 
 <Expandable title="Properties">
 
@@ -4483,6 +4475,9 @@ Schema for multi-select (array) properties in an elicitation form.
 ## <span class="font-mono">NesCapabilities</span>
 
 NES capabilities advertised by the agent during initialization.
+
+Supplying `\{\}` means the agent supports the NES method surface. Omitted or
+`null` both mean the agent does not advertise support for `nes/*` methods.
 
 **Type:** Object
 
@@ -6261,9 +6256,12 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 
 Session capabilities supported by the agent.
 
-As a baseline, all Agents **MUST** support `session/new`, `session/prompt`, `session/cancel`, and `session/update`.
+Supplying `\{\}` means the agent supports the baseline session methods:
+`session/new`, `session/prompt`, `session/cancel`, and `session/update`.
 
-Optionally, they **MAY** support other session methods and notifications by specifying additional capabilities.
+Agents that support sessions **MAY** support additional session methods,
+prompt content types, and MCP transports by specifying additional
+capabilities.
 
 See protocol docs: [Session Capabilities](https://agentclientprotocol.com/protocol/v2/draft/initialization#session-capabilities)
 
@@ -6313,6 +6311,21 @@ Whether the agent supports `session/fork`.
 
 Optional. Omitted or `null` both mean the agent does not advertise support.
 Supplying `\{\}` means the agent supports loading sessions.
+
+</ResponseField>
+<ResponseField name="mcp" type={<><span><a href="#mcpcapabilities">McpCapabilities</a></span><span> | null</span></>} >
+  MCP capabilities supported by the agent for session lifecycle requests.
+
+Optional. Omitted or `null` both mean the agent does not advertise MCP
+server transport support for sessions.
+
+</ResponseField>
+<ResponseField name="prompt" type={<><span><a href="#promptcapabilities">PromptCapabilities</a></span><span> | null</span></>} >
+  Prompt capabilities supported by the agent in `session/prompt` requests.
+
+Optional. Omitted or `null` both mean the agent does not advertise any
+prompt extensions beyond the baseline text and resource-link content
+required by `session/prompt`.
 
 </ResponseField>
 <ResponseField name="resume" type={<><span><a href="#sessionresumecapabilities">SessionResumeCapabilities</a></span><span> | null</span></>} >

--- a/docs/protocol/v2/draft/session-setup.mdx
+++ b/docs/protocol/v2/draft/session-setup.mdx
@@ -400,7 +400,7 @@ When `session.additionalDirectories` is in use, the session's effective root set
 
 The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) allows Agents to access external tools and data sources. When creating a session, Clients **MAY** include connection details for MCP servers that the Agent should connect to.
 
-MCP servers can be connected to using different transports. Agents advertise supported transports during initialization using `mcp.stdio`, `mcp.http`, and any extension-specific transport capabilities.
+MCP servers can be connected to using different transports. Agents advertise supported transports during initialization using `session.mcp.stdio`, `session.mcp.http`, and any extension-specific transport capabilities.
 
 ### Transport Types
 
@@ -408,7 +408,7 @@ Every MCP server object has a `type` discriminator that identifies its transport
 
 #### Stdio Transport
 
-When the Agent supports `mcp.stdio`, Clients can specify MCP servers configurations using the stdio transport.
+When the Agent supports `session.mcp.stdio`, Clients can specify MCP servers configurations using the stdio transport.
 
 <ParamField path="type" type="string" required>
   Must be `"stdio"` to indicate stdio transport
@@ -458,7 +458,7 @@ Example stdio transport configuration:
 
 #### HTTP Transport
 
-When the Agent supports `mcp.http`, Clients can specify MCP servers configurations using the HTTP transport.
+When the Agent supports `session.mcp.http`, Clients can specify MCP servers configurations using the HTTP transport.
 
 <ParamField path="type" type="string" required>
   Must be `"http"` to indicate HTTP transport
@@ -516,17 +516,19 @@ Before using stdio or HTTP transports, Clients **MUST** verify the Agent's capab
   "result": {
     "protocolVersion": 2,
     "capabilities": {
-      "mcp": {
-        "stdio": {},
-        "http": {}
+      "session": {
+        "mcp": {
+          "stdio": {},
+          "http": {}
+        }
       }
     }
   }
 }
 ```
 
-If `mcp.stdio` is omitted or `null`, the Agent does not support stdio transport.
-If `mcp.http` is omitted or `null`, the Agent does not support HTTP transport.
+If `session.mcp.stdio` is omitted or `null`, the Agent does not support stdio transport.
+If `session.mcp.http` is omitted or `null`, the Agent does not support HTTP transport.
 Supplying `{}` means the Agent supports the corresponding transport.
 
 Agents **SHOULD** connect to all MCP servers specified by the Client.

--- a/docs/protocol/v2/initialization.mdx
+++ b/docs/protocol/v2/initialization.mdx
@@ -57,16 +57,16 @@ The Agent **MUST** respond with the chosen [protocol version](#protocol-version)
     "protocolVersion": 2,
     "capabilities": {
       "session": {
+        "prompt": {
+          "image": {},
+          "audio": {},
+          "embeddedContext": {}
+        },
+        "mcp": {
+          "stdio": {},
+          "http": {}
+        },
         "load": {}
-      },
-      "prompt": {
-        "image": {},
-        "audio": {},
-        "embeddedContext": {}
-      },
-      "mcp": {
-        "stdio": {},
-        "http": {}
       }
     },
     "agentInfo": {
@@ -103,7 +103,8 @@ All capabilities included in the `initialize` request are **OPTIONAL**. Clients 
 
 The introduction of new capabilities is not considered a breaking change. Therefore, Clients and Agents **MUST** treat all capabilities omitted in the `initialize` request as **UNSUPPORTED**.
 
-Capabilities are high-level and are not attached to a specific base protocol concept.
+Capabilities may advertise top-level method surfaces or nested features that
+only apply within a supported surface.
 
 Capabilities may specify the availability of protocol methods, notifications, or a subset of their parameters. They may also signal behaviors of the Agent or Client implementation.
 
@@ -119,18 +120,60 @@ Omitted fields mean unsupported. Extension-specific capabilities belong in
 
 The Agent **SHOULD** specify whether it supports the following capabilities:
 
-<ResponseField name="prompt" type="PromptCapabilities Object">
-  Object indicating the different types of [content](/protocol/v2/content) that
-  may be included in `session/prompt` requests.
+<ResponseField name="session" type="SessionCapabilities Object">
+  The Agent supports the `session/*` method surface. Omitted or `null` means the
+  Agent does not support session methods. Supplying `{}` means the Agent
+  supports the baseline session methods: `session/new`, `session/prompt`,
+  `session/cancel`, and `session/update`.
 </ResponseField>
 
 <ResponseField name="auth" type="AgentAuthCapabilities Object">
   Authentication-related capabilities supported by the Agent.
 </ResponseField>
 
-#### Prompt capabilities
+#### Session Capabilities
 
-As a baseline, all Agents **MUST** support `ContentBlock::Text` and `ContentBlock::ResourceLink` in `session/prompt` requests.
+Supplying `session: {}` means the Agent supports `session/new`, `session/prompt`, `session/cancel`, and `session/update`.
+
+Optionally, Agents **MAY** support prompt extensions, MCP server transports, and additional session methods by specifying nested capabilities.
+
+<ResponseField name="prompt" type="PromptCapabilities Object">
+  Object indicating the different types of [content](/protocol/v2/content) that
+  may be included in `session/prompt` requests. Omitted or `null` means the
+  Agent does not advertise any prompt extensions beyond the baseline text and
+  resource-link content required by `session/prompt`.
+</ResponseField>
+
+<ResponseField name="mcp" type="McpCapabilities Object">
+  Object indicating the MCP server transports that may be included in session
+  lifecycle requests. Omitted or `null` means the Agent does not advertise MCP
+  server transport support for sessions.
+</ResponseField>
+
+<ResponseField name="load" type="SessionLoadCapabilities Object">
+  The [`session/load`](/protocol/v2/session-setup#loading-sessions) method is
+  available. Omitted or `null` means the Agent does not advertise support.
+  Supplying `{}` means the Agent supports loading sessions.
+</ResponseField>
+
+<ResponseField name="delete" type="SessionDeleteCapabilities Object">
+  The [`session/delete`](/protocol/v2/session-delete) method is available.
+  Omitted or `null` means the Agent does not advertise support. Supplying `{}`
+  means the Agent supports deleting sessions from `session/list`.
+</ResponseField>
+
+<ResponseField
+  name="additionalDirectories"
+  type="SessionAdditionalDirectoriesCapabilities Object"
+>
+  The Agent supports `additionalDirectories` on supported session lifecycle
+  requests. Omitted or `null` means the Agent does not advertise support.
+  Supplying `{}` means the Agent supports additional workspace roots.
+</ResponseField>
+
+#### Session Prompt Capabilities
+
+As a baseline, Agents that advertise `session` **MUST** support `ContentBlock::Text` and `ContentBlock::ResourceLink` in `session/prompt` requests.
 
 Optionally, they **MAY** support richer types of [content](/protocol/v2/content) by specifying the following capabilities:
 
@@ -155,7 +198,7 @@ Optionally, they **MAY** support richer types of [content](/protocol/v2/content)
   embedded context in prompts.
 </ResponseField>
 
-#### MCP capabilities
+#### Session MCP Capabilities
 
 <ResponseField name="stdio" type="McpStdioCapabilities Object">
   The Agent supports connecting to MCP servers over stdio. Omitted or `null`
@@ -178,33 +221,6 @@ Optionally, they **MAY** support richer types of [content](/protocol/v2/content)
 <Card icon="shield-check" horizontal href="/protocol/v2/authentication">
   Learn more about Authentication
 </Card>
-
-#### Session Capabilities
-
-As a baseline, all Agents **MUST** support `session/new`, `session/prompt`, `session/cancel`, and `session/update`.
-
-Optionally, they **MAY** support other session methods and notifications by specifying additional capabilities.
-
-<ResponseField name="load" type="SessionLoadCapabilities Object">
-  The [`session/load`](/protocol/v2/session-setup#loading-sessions) method is
-  available. Omitted or `null` means the Agent does not advertise support.
-  Supplying `{}` means the Agent supports loading sessions.
-</ResponseField>
-
-<ResponseField name="delete" type="SessionDeleteCapabilities Object">
-  The [`session/delete`](/protocol/v2/session-delete) method is available.
-  Omitted or `null` means the Agent does not advertise support. Supplying `{}`
-  means the Agent supports deleting sessions from `session/list`.
-</ResponseField>
-
-<ResponseField
-  name="additionalDirectories"
-  type="SessionAdditionalDirectoriesCapabilities Object"
->
-  The Agent supports `additionalDirectories` on supported session lifecycle
-  requests. Omitted or `null` means the Agent does not advertise support.
-  Supplying `{}` means the Agent supports additional workspace roots.
-</ResponseField>
 
 ## Implementation Information
 

--- a/docs/protocol/v2/schema.mdx
+++ b/docs/protocol/v2/schema.mdx
@@ -152,7 +152,7 @@ Note: in future versions of the protocol, this will be required.
 <ResponseField name="capabilities" type={<a href="#agentcapabilities">AgentCapabilities</a>} >
   Capabilities supported by the agent.
 
-    - Default: `{"auth":{},"mcp":{},"prompt":{},"session":{}}`
+    - Default: `{"auth":{}}`
 
 </ResponseField>
 <ResponseField name="protocolVersion" type={<a href="#protocolversion">ProtocolVersion</a>} required>
@@ -916,21 +916,13 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
     - Default: `{}`
 
 </ResponseField>
-<ResponseField name="mcp" type={<a href="#mcpcapabilities">McpCapabilities</a>} >
-  MCP capabilities supported by the agent.
+<ResponseField name="session" type={<><span><a href="#sessioncapabilities">SessionCapabilities</a></span><span> | null</span></>} >
+  Session capabilities supported by the agent.
 
-    - Default: `{}`
-
-</ResponseField>
-<ResponseField name="prompt" type={<a href="#promptcapabilities">PromptCapabilities</a>} >
-  Prompt capabilities supported by the agent.
-
-    - Default: `{}`
-
-</ResponseField>
-<ResponseField name="session" type={<a href="#sessioncapabilities">SessionCapabilities</a>} >
-
-    - Default: `{}`
+Optional. Omitted or `null` both mean the agent does not support the
+`session/*` method surface. Supplying `\{\}` means the agent supports the
+baseline session methods: `session/new`, `session/prompt`,
+`session/cancel`, and `session/update`.
 
 </ResponseField>
 
@@ -1830,7 +1822,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 
 ## <span class="font-mono">McpCapabilities</span>
 
-MCP capabilities supported by the agent
+MCP capabilities supported by the agent for session lifecycle requests.
 
 **Type:** Object
 
@@ -1892,7 +1884,7 @@ See protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/v2/ses
 <ResponseField name="http" type="object">
 HTTP transport configuration
 
-Only available when the Agent capabilities include `mcp.http`.
+Only available when the Agent capabilities include `session.mcp.http`.
 
 <Expandable title="Properties">
 
@@ -1923,7 +1915,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 <ResponseField name="stdio" type="object">
 Stdio transport configuration
 
-Only available when the Agent capabilities include `mcp.stdio`.
+Only available when the Agent capabilities include `session.mcp.stdio`.
 
 <Expandable title="Properties">
 
@@ -2625,9 +2617,12 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 
 Session capabilities supported by the agent.
 
-As a baseline, all Agents **MUST** support `session/new`, `session/prompt`, `session/cancel`, and `session/update`.
+Supplying `\{\}` means the agent supports the baseline session methods:
+`session/new`, `session/prompt`, `session/cancel`, and `session/update`.
 
-Optionally, they **MAY** support other session methods and notifications by specifying additional capabilities.
+Agents that support sessions **MAY** support additional session methods,
+prompt content types, and MCP transports by specifying additional
+capabilities.
 
 See protocol docs: [Session Capabilities](https://agentclientprotocol.com/protocol/v2/initialization#session-capabilities)
 
@@ -2669,6 +2664,21 @@ Supplying `\{\}` means the agent supports deleting sessions from `session/list`.
 
 Optional. Omitted or `null` both mean the agent does not advertise support.
 Supplying `\{\}` means the agent supports loading sessions.
+
+</ResponseField>
+<ResponseField name="mcp" type={<><span><a href="#mcpcapabilities">McpCapabilities</a></span><span> | null</span></>} >
+  MCP capabilities supported by the agent for session lifecycle requests.
+
+Optional. Omitted or `null` both mean the agent does not advertise MCP
+server transport support for sessions.
+
+</ResponseField>
+<ResponseField name="prompt" type={<><span><a href="#promptcapabilities">PromptCapabilities</a></span><span> | null</span></>} >
+  Prompt capabilities supported by the agent in `session/prompt` requests.
+
+Optional. Omitted or `null` both mean the agent does not advertise any
+prompt extensions beyond the baseline text and resource-link content
+required by `session/prompt`.
 
 </ResponseField>
 <ResponseField name="resume" type={<><span><a href="#sessionresumecapabilities">SessionResumeCapabilities</a></span><span> | null</span></>} >

--- a/docs/protocol/v2/session-setup.mdx
+++ b/docs/protocol/v2/session-setup.mdx
@@ -376,7 +376,7 @@ When `session.additionalDirectories` is in use, the session's effective root set
 
 The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) allows Agents to access external tools and data sources. When creating a session, Clients **MAY** include connection details for MCP servers that the Agent should connect to.
 
-MCP servers can be connected to using different transports. Agents advertise supported transports during initialization using `mcp.stdio`, `mcp.http`, and any extension-specific transport capabilities.
+MCP servers can be connected to using different transports. Agents advertise supported transports during initialization using `session.mcp.stdio`, `session.mcp.http`, and any extension-specific transport capabilities.
 
 ### Transport Types
 
@@ -384,7 +384,7 @@ Every MCP server object has a `type` discriminator that identifies its transport
 
 #### Stdio Transport
 
-When the Agent supports `mcp.stdio`, Clients can specify MCP servers configurations using the stdio transport.
+When the Agent supports `session.mcp.stdio`, Clients can specify MCP servers configurations using the stdio transport.
 
 <ParamField path="type" type="string" required>
   Must be `"stdio"` to indicate stdio transport
@@ -434,7 +434,7 @@ Example stdio transport configuration:
 
 #### HTTP Transport
 
-When the Agent supports `mcp.http`, Clients can specify MCP servers configurations using the HTTP transport.
+When the Agent supports `session.mcp.http`, Clients can specify MCP servers configurations using the HTTP transport.
 
 <ParamField path="type" type="string" required>
   Must be `"http"` to indicate HTTP transport
@@ -492,17 +492,19 @@ Before using stdio or HTTP transports, Clients **MUST** verify the Agent's capab
   "result": {
     "protocolVersion": 2,
     "capabilities": {
-      "mcp": {
-        "stdio": {},
-        "http": {}
+      "session": {
+        "mcp": {
+          "stdio": {},
+          "http": {}
+        }
       }
     }
   }
 }
 ```
 
-If `mcp.stdio` is omitted or `null`, the Agent does not support stdio transport.
-If `mcp.http` is omitted or `null`, the Agent does not support HTTP transport.
+If `session.mcp.stdio` is omitted or `null`, the Agent does not support stdio transport.
+If `session.mcp.http` is omitted or `null`, the Agent does not support HTTP transport.
 Supplying `{}` means the Agent supports the corresponding transport.
 
 Agents **SHOULD** connect to all MCP servers specified by the Client.

--- a/docs/rfds/v2/overview.mdx
+++ b/docs/rfds/v2/overview.mdx
@@ -46,12 +46,13 @@ Other RFDs will progress separately and are not dependent on breaking changes (s
 - Follow JSON-RPC 2.0 batch request and notification behavior.
 - Clean up capability naming and organization:
   - Use a single `capabilities` field in both `initialize` params and results, replacing the v1-style `clientCapabilities` and `agentCapabilities` fields.
-  - Use concise capability group names such as `prompt`, `mcp`, `session`, and `auth`, replacing names like `promptCapabilities`, `mcpCapabilities`, and `sessionCapabilities`.
-  - Move `loadSession` into the session capability group as `session.load`.
+  - Use concise capability group names such as `session` and `auth`, replacing names like `sessionCapabilities`.
+  - Make `session` optional so non-session agents, such as NES-only agents, can omit it.
+  - Move session-scoped capability groups under `session`, including `prompt`, `mcp`, and `loadSession` as `session.prompt`, `session.mcp`, and `session.load`.
   - Represent support markers as capability objects instead of booleans. Supplying `{}` means supported, while omission or `null` means unsupported. Booleans remain appropriate for actual data or configuration inside an already-advertised capability.
 - Align MCP server transports with the current MCP transport model:
   - Remove the deprecated HTTP+SSE MCP transport from v2.
-  - Make stdio an explicit `mcp.stdio` capability so Agents that cannot launch local subprocesses can opt out.
+  - Make stdio an explicit `session.mcp.stdio` capability so Agents that cannot launch local subprocesses can opt out.
   - Require MCP server configurations to include a `type` discriminator, including `type: "stdio"`, so unknown future transports can be preserved as extension/future variants.
   - Keep HTTP as the remote MCP server transport capability.
 
@@ -100,7 +101,7 @@ With the needed breaking changes, as much as possible I am targeting having a co
 
 ## Revision history
 
-- 2026-06-05: Recorded the v2 capability cleanup: unified initialize capability fields, shorter capability group names, `session.load`, object-shaped support markers, explicit `mcp.stdio`, removal of deprecated MCP SSE transport, and tagged MCP server transport configs.
+- 2026-06-05: Recorded the v2 capability cleanup: unified initialize capability fields, optional `session` support for NES-only agents, session-scoped `prompt`, `mcp`, and `loadSession` capabilities, object-shaped support markers, explicit `session.mcp.stdio`, removal of deprecated MCP SSE transport, and tagged MCP server transport configs.
 - 2026-06-02: Recorded the v2 decision to follow JSON-RPC 2.0 batch request and notification behavior.
 - 2026-06-02: Recorded the v2 decision to remove Client filesystem and terminal execution capabilities, methods, and terminal tool-call content.
 - 2026-06-02: Added the v2 Plan Variants RFD to make item-based `plan_update` the default v2 plan shape.

--- a/schema/schema.v2.unstable.json
+++ b/schema/schema.v2.unstable.json
@@ -66,15 +66,6 @@
           "default": {},
           "description": "Authentication-related capabilities supported by the agent."
         },
-        "mcp": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/McpCapabilities"
-            }
-          ],
-          "default": {},
-          "description": "MCP capabilities supported by the agent."
-        },
         "nes": {
           "anyOf": [
             {
@@ -99,15 +90,6 @@
           "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nThe position encoding selected by the agent from the client's supported encodings.",
           "x-deserialize-default-on-error": true
         },
-        "prompt": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/PromptCapabilities"
-            }
-          ],
-          "default": {},
-          "description": "Prompt capabilities supported by the agent."
-        },
         "providers": {
           "anyOf": [
             {
@@ -121,12 +103,16 @@
           "x-deserialize-default-on-error": true
         },
         "session": {
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/$defs/SessionCapabilities"
+            },
+            {
+              "type": "null"
             }
           ],
-          "default": {}
+          "description": "Session capabilities supported by the agent.\n\nOptional. Omitted or `null` both mean the agent does not support the\n`session/*` method surface. Supplying `{}` means the agent supports the\nbaseline session methods: `session/new`, `session/prompt`,\n`session/cancel`, and `session/update`.",
+          "x-deserialize-default-on-error": true
         }
       },
       "type": "object"
@@ -3048,10 +3034,7 @@
             }
           ],
           "default": {
-            "auth": {},
-            "mcp": {},
-            "prompt": {},
-            "session": {}
+            "auth": {}
           },
           "description": "Capabilities supported by the agent."
         },
@@ -3328,7 +3311,7 @@
       "type": "object"
     },
     "McpCapabilities": {
-      "description": "MCP capabilities supported by the agent",
+      "description": "MCP capabilities supported by the agent for session lifecycle requests.",
       "properties": {
         "_meta": {
           "additionalProperties": true,
@@ -3397,7 +3380,7 @@
               "$ref": "#/$defs/McpServerHttp"
             }
           ],
-          "description": "HTTP transport configuration\n\nOnly available when the Agent capabilities include `mcp.http`.",
+          "description": "HTTP transport configuration\n\nOnly available when the Agent capabilities include `session.mcp.http`.",
           "properties": {
             "type": {
               "const": "http",
@@ -3413,7 +3396,7 @@
               "$ref": "#/$defs/McpServerAcp"
             }
           ],
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nACP transport configuration\n\nOnly available when the Agent capabilities include `mcp.acp`.\nThe MCP server is provided by an ACP component and communicates over the ACP channel.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nACP transport configuration\n\nOnly available when the Agent capabilities include `session.mcp.acp`.\nThe MCP server is provided by an ACP component and communicates over the ACP channel.",
           "properties": {
             "type": {
               "const": "acp",
@@ -3429,7 +3412,7 @@
               "$ref": "#/$defs/McpServerStdio"
             }
           ],
-          "description": "Stdio transport configuration\n\nOnly available when the Agent capabilities include `mcp.stdio`.",
+          "description": "Stdio transport configuration\n\nOnly available when the Agent capabilities include `session.mcp.stdio`.",
           "properties": {
             "type": {
               "const": "stdio",
@@ -3729,7 +3712,7 @@
       "type": "object"
     },
     "NesCapabilities": {
-      "description": "NES capabilities advertised by the agent during initialization.",
+      "description": "NES capabilities advertised by the agent during initialization.\n\nSupplying `{}` means the agent supports the NES method surface. Omitted or\n`null` both mean the agent does not advertise support for `nes/*` methods.",
       "properties": {
         "_meta": {
           "additionalProperties": true,
@@ -5803,7 +5786,7 @@
       "type": "object"
     },
     "SessionCapabilities": {
-      "description": "Session capabilities supported by the agent.\n\nAs a baseline, all Agents **MUST** support `session/new`, `session/prompt`, `session/cancel`, and `session/update`.\n\nOptionally, they **MAY** support other session methods and notifications by specifying additional capabilities.\n\nSee protocol docs: [Session Capabilities](https://agentclientprotocol.com/protocol/initialization#session-capabilities)",
+      "description": "Session capabilities supported by the agent.\n\nSupplying `{}` means the agent supports the baseline session methods:\n`session/new`, `session/prompt`, `session/cancel`, and `session/update`.\n\nAgents that support sessions **MAY** support additional session methods,\nprompt content types, and MCP transports by specifying additional\ncapabilities.\n\nSee protocol docs: [Session Capabilities](https://agentclientprotocol.com/protocol/initialization#session-capabilities)",
       "properties": {
         "_meta": {
           "additionalProperties": true,
@@ -5880,6 +5863,30 @@
             }
           ],
           "description": "Whether the agent supports `session/load`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports loading sessions.",
+          "x-deserialize-default-on-error": true
+        },
+        "mcp": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "MCP capabilities supported by the agent for session lifecycle requests.\n\nOptional. Omitted or `null` both mean the agent does not advertise MCP\nserver transport support for sessions.",
+          "x-deserialize-default-on-error": true
+        },
+        "prompt": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Prompt capabilities supported by the agent in `session/prompt` requests.\n\nOptional. Omitted or `null` both mean the agent does not advertise any\nprompt extensions beyond the baseline text and resource-link content\nrequired by `session/prompt`.",
           "x-deserialize-default-on-error": true
         },
         "resume": {

--- a/src/v2/agent.rs
+++ b/src/v2/agent.rs
@@ -2635,7 +2635,7 @@ impl SetSessionConfigOptionResponse {
 pub enum McpServer {
     /// HTTP transport configuration
     ///
-    /// Only available when the Agent capabilities include `mcp.http`.
+    /// Only available when the Agent capabilities include `session.mcp.http`.
     Http(McpServerHttp),
     /// **UNSTABLE**
     ///
@@ -2643,13 +2643,13 @@ pub enum McpServer {
     ///
     /// ACP transport configuration
     ///
-    /// Only available when the Agent capabilities include `mcp.acp`.
+    /// Only available when the Agent capabilities include `session.mcp.acp`.
     /// The MCP server is provided by an ACP component and communicates over the ACP channel.
     #[cfg(feature = "unstable_mcp_over_acp")]
     Acp(McpServerAcp),
     /// Stdio transport configuration
     ///
-    /// Only available when the Agent capabilities include `mcp.stdio`.
+    /// Only available when the Agent capabilities include `session.mcp.stdio`.
     Stdio(McpServerStdio),
     /// Custom or future MCP server transport configuration.
     ///
@@ -3652,14 +3652,16 @@ impl DisableProviderResponse {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AgentCapabilities {
-    /// Prompt capabilities supported by the agent.
+    /// Session capabilities supported by the agent.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not support the
+    /// `session/*` method surface. Supplying `{}` means the agent supports the
+    /// baseline session methods: `session/new`, `session/prompt`,
+    /// `session/cancel`, and `session/update`.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
-    pub prompt: PromptCapabilities,
-    /// MCP capabilities supported by the agent.
-    #[serde(default)]
-    pub mcp: McpCapabilities,
-    #[serde(default)]
-    pub session: SessionCapabilities,
+    pub session: Option<SessionCapabilities>,
     /// Authentication-related capabilities supported by the agent.
     #[serde(default)]
     pub auth: AgentAuthCapabilities,
@@ -3710,24 +3712,15 @@ impl AgentCapabilities {
         Self::default()
     }
 
-    /// Prompt capabilities supported by the agent.
-    #[must_use]
-    pub fn prompt(mut self, prompt: PromptCapabilities) -> Self {
-        self.prompt = prompt;
-        self
-    }
-
-    /// MCP capabilities supported by the agent.
-    #[must_use]
-    pub fn mcp(mut self, mcp: McpCapabilities) -> Self {
-        self.mcp = mcp;
-        self
-    }
-
     /// Session capabilities supported by the agent.
+    ///
+    /// Omitted or `null` both mean the agent does not support the `session/*`
+    /// method surface. Supplying `{}` means the agent supports the baseline
+    /// session methods: `session/new`, `session/prompt`, `session/cancel`, and
+    /// `session/update`.
     #[must_use]
-    pub fn session(mut self, session: SessionCapabilities) -> Self {
-        self.session = session;
+    pub fn session(mut self, session: impl IntoOption<SessionCapabilities>) -> Self {
+        self.session = session.into_option();
         self
     }
 
@@ -3829,9 +3822,12 @@ impl ProvidersCapabilities {
 
 /// Session capabilities supported by the agent.
 ///
-/// As a baseline, all Agents **MUST** support `session/new`, `session/prompt`, `session/cancel`, and `session/update`.
+/// Supplying `{}` means the agent supports the baseline session methods:
+/// `session/new`, `session/prompt`, `session/cancel`, and `session/update`.
 ///
-/// Optionally, they **MAY** support other session methods and notifications by specifying additional capabilities.
+/// Agents that support sessions **MAY** support additional session methods,
+/// prompt content types, and MCP transports by specifying additional
+/// capabilities.
 ///
 /// See protocol docs: [Session Capabilities](https://agentclientprotocol.com/protocol/initialization#session-capabilities)
 #[serde_as]
@@ -3840,6 +3836,23 @@ impl ProvidersCapabilities {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct SessionCapabilities {
+    /// Prompt capabilities supported by the agent in `session/prompt` requests.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise any
+    /// prompt extensions beyond the baseline text and resource-link content
+    /// required by `session/prompt`.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
+    #[serde(default)]
+    pub prompt: Option<PromptCapabilities>,
+    /// MCP capabilities supported by the agent for session lifecycle requests.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise MCP
+    /// server transport support for sessions.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
+    #[serde(default)]
+    pub mcp: Option<McpCapabilities>,
     /// Whether the agent supports `session/load`.
     ///
     /// Optional. Omitted or `null` both mean the agent does not advertise support.
@@ -3903,6 +3916,27 @@ impl SessionCapabilities {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Prompt capabilities supported by the agent in `session/prompt` requests.
+    ///
+    /// Omitted or `null` both mean the agent does not advertise any prompt
+    /// extensions beyond the baseline text and resource-link content required by
+    /// `session/prompt`.
+    #[must_use]
+    pub fn prompt(mut self, prompt: impl IntoOption<PromptCapabilities>) -> Self {
+        self.prompt = prompt.into_option();
+        self
+    }
+
+    /// MCP capabilities supported by the agent for session lifecycle requests.
+    ///
+    /// Omitted or `null` both mean the agent does not advertise MCP server
+    /// transport support for sessions.
+    #[must_use]
+    pub fn mcp(mut self, mcp: impl IntoOption<McpCapabilities>) -> Self {
+        self.mcp = mcp.into_option();
+        self
     }
 
     /// Whether the agent supports `session/load`.
@@ -4437,7 +4471,7 @@ impl PromptEmbeddedContextCapabilities {
     }
 }
 
-/// MCP capabilities supported by the agent
+/// MCP capabilities supported by the agent for session lifecycle requests.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -6393,6 +6427,41 @@ mod test_serialization {
 
         let deserialized: AgentCapabilities = serde_json::from_value(json).unwrap();
         assert!(deserialized.providers.is_some());
+    }
+
+    #[test]
+    fn test_agent_capabilities_session_is_explicit() {
+        let json = serde_json::to_value(AgentCapabilities::new()).unwrap();
+        assert!(json.get("session").is_none());
+
+        let caps = AgentCapabilities::new().session(
+            SessionCapabilities::new()
+                .prompt(PromptCapabilities::new().image(PromptImageCapabilities::new()))
+                .mcp(McpCapabilities::new().stdio(McpStdioCapabilities::new()))
+                .load(SessionLoadCapabilities::new()),
+        );
+
+        assert_eq!(
+            serde_json::to_value(&caps).unwrap(),
+            json!({
+                "auth": {},
+                "session": {
+                    "prompt": {
+                        "image": {}
+                    },
+                    "mcp": {
+                        "stdio": {}
+                    },
+                    "load": {}
+                }
+            })
+        );
+
+        let deserialized: AgentCapabilities = serde_json::from_value(json!({
+            "session": false
+        }))
+        .unwrap();
+        assert!(deserialized.session.is_none());
     }
 
     #[test]

--- a/src/v2/conversion.rs
+++ b/src/v2/conversion.rs
@@ -4434,8 +4434,6 @@ impl IntoV1 for super::AgentCapabilities {
 
     fn into_v1(self) -> Result<Self::Output> {
         let Self {
-            prompt,
-            mcp,
             session,
             auth,
             #[cfg(feature = "unstable_llm_providers")]
@@ -4446,7 +4444,16 @@ impl IntoV1 for super::AgentCapabilities {
             position_encoding,
             meta,
         } = self;
+        let Some(mut session) = session else {
+            return Err(ProtocolConversionError::new(
+                "v2 AgentCapabilities without `session` cannot be represented in v1",
+            ));
+        };
+
         let load_session = session.load.is_some();
+        let prompt = session.prompt.take().unwrap_or_default();
+        let mcp = session.mcp.take().unwrap_or_default();
+
         Ok(crate::v1::AgentCapabilities {
             load_session: load_session.into_v1()?,
             prompt_capabilities: prompt.into_v1()?,
@@ -4486,10 +4493,11 @@ impl IntoV2 for crate::v1::AgentCapabilities {
         if load_session {
             session.load = Some(super::SessionLoadCapabilities::new());
         }
+        session.prompt = Some(prompt_capabilities.into_v2()?);
+        session.mcp = Some(mcp_capabilities.into_v2()?);
+
         Ok(super::AgentCapabilities {
-            prompt: prompt_capabilities.into_v2()?,
-            mcp: mcp_capabilities.into_v2()?,
-            session,
+            session: Some(session),
             auth: auth.into_v2()?,
             #[cfg(feature = "unstable_llm_providers")]
             providers: providers.into_v2()?,
@@ -4531,6 +4539,8 @@ impl IntoV1 for super::SessionCapabilities {
 
     fn into_v1(self) -> Result<Self::Output> {
         let Self {
+            prompt: _,
+            mcp: _,
             load: _,
             list,
             delete,
@@ -4569,6 +4579,8 @@ impl IntoV2 for crate::v1::SessionCapabilities {
             meta,
         } = self;
         Ok(super::SessionCapabilities {
+            prompt: None,
+            mcp: None,
             load: None,
             list: list.into_v2()?,
             delete: delete.into_v2()?,
@@ -8603,7 +8615,11 @@ mod tests {
 
         let v2_capabilities: v2::AgentCapabilities =
             v1_to_v2(v1_capabilities).expect("v1 -> v2 conversion");
-        assert!(v2_capabilities.session.load.is_some());
+        let session = v2_capabilities
+            .session
+            .as_ref()
+            .expect("v1 capabilities imply v2 session support");
+        assert!(session.load.is_some());
         let v2_json = serde_json::to_value(&v2_capabilities).expect("v2 serialize");
         assert_eq!(v2_json.get("loadSession"), None);
         assert_eq!(
@@ -8614,6 +8630,15 @@ mod tests {
         let v1_after: v1::AgentCapabilities =
             v2_to_v1(v2_capabilities).expect("v2 -> v1 conversion");
         assert!(v1_after.load_session);
+    }
+
+    #[test]
+    fn v2_agent_capabilities_without_session_do_not_convert_to_v1() {
+        let error = v2::AgentCapabilities::new().into_v1().unwrap_err();
+        assert_eq!(
+            error.message(),
+            "v2 AgentCapabilities without `session` cannot be represented in v1"
+        );
     }
 
     #[test]

--- a/src/v2/conversion.rs
+++ b/src/v2/conversion.rs
@@ -4444,21 +4444,23 @@ impl IntoV1 for super::AgentCapabilities {
             position_encoding,
             meta,
         } = self;
-        let Some(mut session) = session else {
+        let Some(session) = session else {
             return Err(ProtocolConversionError::new(
                 "v2 AgentCapabilities without `session` cannot be represented in v1",
             ));
         };
-
-        let load_session = session.load.is_some();
-        let prompt = session.prompt.take().unwrap_or_default();
-        let mcp = session.mcp.take().unwrap_or_default();
+        let V1SessionCapabilityParts {
+            session_capabilities,
+            prompt_capabilities,
+            load_session,
+            mcp_capabilities,
+        } = session.into_v1()?;
 
         Ok(crate::v1::AgentCapabilities {
             load_session: load_session.into_v1()?,
-            prompt_capabilities: prompt.into_v1()?,
-            mcp_capabilities: mcp.into_v1()?,
-            session_capabilities: session.into_v1()?,
+            prompt_capabilities,
+            mcp_capabilities,
+            session_capabilities,
             auth: auth.into_v1()?,
             #[cfg(feature = "unstable_llm_providers")]
             providers: providers.into_v1()?,
@@ -4489,12 +4491,12 @@ impl IntoV2 for crate::v1::AgentCapabilities {
             position_encoding,
             meta,
         } = self;
-        let mut session = session_capabilities.into_v2()?;
-        if load_session {
-            session.load = Some(super::SessionLoadCapabilities::new());
-        }
-        session.prompt = Some(prompt_capabilities.into_v2()?);
-        session.mcp = Some(mcp_capabilities.into_v2()?);
+        let session = super::SessionCapabilities::from_v1(
+            session_capabilities,
+            prompt_capabilities,
+            load_session,
+            mcp_capabilities,
+        )?;
 
         Ok(super::AgentCapabilities {
             session: Some(session),
@@ -4534,41 +4536,33 @@ impl IntoV2 for crate::v1::ProvidersCapabilities {
     }
 }
 
-impl IntoV1 for super::SessionCapabilities {
-    type Output = crate::v1::SessionCapabilities;
-
-    fn into_v1(self) -> Result<Self::Output> {
-        let Self {
-            prompt: _,
-            mcp: _,
-            load: _,
-            list,
-            delete,
-            additional_directories,
-            #[cfg(feature = "unstable_session_fork")]
-            fork,
-            resume,
-            close,
-            meta,
-        } = self;
-        Ok(crate::v1::SessionCapabilities {
-            list: list.into_v1()?,
-            delete: delete.into_v1()?,
-            additional_directories: additional_directories.into_v1()?,
-            #[cfg(feature = "unstable_session_fork")]
-            fork: fork.into_v1()?,
-            resume: resume.into_v1()?,
-            close: close.into_v1()?,
-            meta: meta.into_v1()?,
-        })
-    }
+/// The v1 capability fields represented by v2 `SessionCapabilities`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct V1SessionCapabilityParts {
+    /// Session-specific v1 capabilities.
+    pub session_capabilities: crate::v1::SessionCapabilities,
+    /// Prompt capabilities for v1 `session/prompt` requests.
+    pub prompt_capabilities: crate::v1::PromptCapabilities,
+    /// Whether v1 `session/load` is supported.
+    pub load_session: bool,
+    /// MCP capabilities for v1 session lifecycle requests.
+    pub mcp_capabilities: crate::v1::McpCapabilities,
 }
 
-impl IntoV2 for crate::v1::SessionCapabilities {
-    type Output = super::SessionCapabilities;
-
-    fn into_v2(self) -> Result<Self::Output> {
+impl super::SessionCapabilities {
+    /// Converts these v2 draft session capabilities into the v1 capability
+    /// fields they represent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProtocolConversionError`] when any contained capability field
+    /// cannot be represented in v1.
+    pub fn into_v1(self) -> Result<V1SessionCapabilityParts> {
         let Self {
+            prompt,
+            mcp,
+            load,
             list,
             delete,
             additional_directories,
@@ -4578,10 +4572,52 @@ impl IntoV2 for crate::v1::SessionCapabilities {
             close,
             meta,
         } = self;
+
+        Ok(V1SessionCapabilityParts {
+            session_capabilities: crate::v1::SessionCapabilities {
+                list: list.into_v1()?,
+                delete: delete.into_v1()?,
+                additional_directories: additional_directories.into_v1()?,
+                #[cfg(feature = "unstable_session_fork")]
+                fork: fork.into_v1()?,
+                resume: resume.into_v1()?,
+                close: close.into_v1()?,
+                meta: meta.into_v1()?,
+            },
+            prompt_capabilities: prompt.unwrap_or_default().into_v1()?,
+            load_session: load.is_some(),
+            mcp_capabilities: mcp.unwrap_or_default().into_v1()?,
+        })
+    }
+
+    /// Builds v2 draft session capabilities from the v1 agent capability fields
+    /// that now live under `session` in v2.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProtocolConversionError`] when any of the supplied v1
+    /// capability fields cannot be represented in v2.
+    pub fn from_v1(
+        session_capabilities: crate::v1::SessionCapabilities,
+        prompt_capabilities: crate::v1::PromptCapabilities,
+        load_session: bool,
+        mcp_capabilities: crate::v1::McpCapabilities,
+    ) -> Result<Self> {
+        let crate::v1::SessionCapabilities {
+            list,
+            delete,
+            additional_directories,
+            #[cfg(feature = "unstable_session_fork")]
+            fork,
+            resume,
+            close,
+            meta,
+        } = session_capabilities;
+
         Ok(super::SessionCapabilities {
-            prompt: None,
-            mcp: None,
-            load: None,
+            prompt: Some(prompt_capabilities.into_v2()?),
+            mcp: Some(mcp_capabilities.into_v2()?),
+            load: load_session.then(super::SessionLoadCapabilities::new),
             list: list.into_v2()?,
             delete: delete.into_v2()?,
             additional_directories: additional_directories.into_v2()?,
@@ -8639,6 +8675,22 @@ mod tests {
             error.message(),
             "v2 AgentCapabilities without `session` cannot be represented in v1"
         );
+    }
+
+    #[test]
+    fn v2_session_capabilities_convert_to_v1_agent_capability_parts() {
+        let parts = v2::SessionCapabilities::new()
+            .load(v2::SessionLoadCapabilities::new())
+            .prompt(v2::PromptCapabilities::new().image(v2::PromptImageCapabilities::new()))
+            .mcp(v2::McpCapabilities::new().http(v2::McpHttpCapabilities::new()))
+            .list(v2::SessionListCapabilities::new())
+            .into_v1()
+            .expect("v2 session capabilities -> v1 parts");
+
+        assert!(parts.session_capabilities.list.is_some());
+        assert!(parts.prompt_capabilities.image);
+        assert!(parts.load_session);
+        assert!(parts.mcp_capabilities.http);
     }
 
     #[test]

--- a/src/v2/nes.rs
+++ b/src/v2/nes.rs
@@ -96,6 +96,9 @@ impl Range {
 // Agent NES capabilities
 
 /// NES capabilities advertised by the agent during initialization.
+///
+/// Supplying `{}` means the agent supports the NES method surface. Omitted or
+/// `null` both mean the agent does not advertise support for `nes/*` methods.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]


### PR DESCRIPTION
Also allows session capabilities to be optional for nes only agents (or
other forms of agents in the future) without requiring it to implement
all types.
