### PR TITLE
Add acp.cr (crystal library) to community libraries

### DIFF
--- a/docs/libraries/community.mdx
+++ b/docs/libraries/community.mdx
@@ -3,6 +3,10 @@ title: "Community"
 description: "Community managed libraries for the Agent Client Protocol"
 ---
 
+## Crystal
+
+- [acp.cr](https://github.com/hahwul/acp.cr)
+
 ## Dart
 
 - [acp_dart](https://github.com/SkrOYC/acp-dart)


### PR DESCRIPTION
Hi there!
I'd like to add [acp.cr](https://github.com/hahwul/acp.cr), a Crystal implementation of the Agent Client Protocol that I built for Crystal applications, to the community libraries page. What do you think? Is it okay to include it?

*FYI, this library is already being used in the [OWASP Noir](https://github.com/owasp-noir/noir) project*