### PR TITLE
docs: add Hash to CLI and TUI clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -24,6 +24,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 ## CLI and TUI
 
 - [acpx (CLI)](https://github.com/openclaw/acpx)
+- [Hash (shell)](https://github.com/tfcace/hash)
 - [Nori CLI](https://github.com/tilework-tech/nori-cli)
 - [pool](https://github.com/poolsideai/pool)
 - [Toad](https://www.batrachian.ai/)


### PR DESCRIPTION
Adds [Hash](https://github.com/tfcace/hash), an open-source POSIX shell (Go, MIT) that acts as an ACP client: typing `??` anywhere in a command line opens a turn against any ACP agent (tested with claude-agent-acp and Gemini CLI), with per-tool-call permission prompts. Docs: https://runhash.dev