### PR TITLE
docs: add ACP Inspector to Desktop and Web clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -52,6 +52,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Web Browser with AI SDK](https://github.com/mcpc-tech/ai-elements-remix-template) (powered by [@mcpc/acp-ai-provider](https://github.com/mcpc-tech/mcpc/tree/main/packages/acp-ai-provider))
 - [Kangaroo](https://github.com/dbkangaroo/kangaroo) — database IDE with Agent Client Protocol support
 - [ACP Components](https://github.com/zvzuola/acp-components) - A universal frontend component library for building AI Agent interfaces based on the ACP
+- [ACP Inspector](https://github.com/newioapp/acp-inspector) — desktop debugger/inspector for the ACP protocol (macOS, Linux)
 
 ## Notebook and data tools
 


### PR DESCRIPTION
ACP Inspector is an open-source Electron app (macOS, Linux) for debugging and inspecting the ACP protocol.