### PR TITLE
docs: add ACP Pro extension for IDE and Editor client

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -19,6 +19,8 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Unity ACP Client](https://github.com/3DLabInstruments/UnityACPClient)(Unity plugin)
 - [Unity Agent Client](https://github.com/nuskey8/UnityAgentClient) (Unity editor)
 - Visual Studio Code — through the [ACP Client](https://github.com/formulahendry/vscode-acp) extension
+- Microsoft VS Code: [ACP Pro Extension](https://marketplace.visualstudio.com/items?itemName=duclvz.acp-pro)
+- VS Code–compatible IDEs (Cursor, Windsurf, Trae,..): [ACP Pro Extension](https://open-vsx.org/extension/duclvz/acp-pro)
 - [Zed](https://zed.dev/docs/ai/external-agents)
 
 ## CLI and TUI

--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -18,9 +18,10 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Obsidian](https://obsidian.md) — through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
 - [Unity ACP Client](https://github.com/3DLabInstruments/UnityACPClient)(Unity plugin)
 - [Unity Agent Client](https://github.com/nuskey8/UnityAgentClient) (Unity editor)
-- Visual Studio Code — through the [ACP Client](https://github.com/formulahendry/vscode-acp) extension
-- Microsoft VS Code: [ACP Pro Extension](https://marketplace.visualstudio.com/items?itemName=duclvz.acp-pro)
-- VS Code–compatible IDEs (Cursor, Windsurf, Trae,..): [ACP Pro Extension](https://open-vsx.org/extension/duclvz/acp-pro)
+- Visual Studio Code
+  - [ACP Client](https://github.com/formulahendry/vscode-acp) extension
+  - [ACP Pro Extension](https://marketplace.visualstudio.com/items?itemName=duclvz.acp-pro)
+    - VS Code–compatible IDEs (Cursor, Windsurf, Trae,..): [ACP Pro Extension](https://open-vsx.org/extension/duclvz/acp-pro)
 - [Zed](https://zed.dev/docs/ai/external-agents)
 
 ## CLI and TUI


### PR DESCRIPTION
ACP Pro is a unified chat interface for AI coding agents in VS Code and all VS Code–compatible IDEs (Cursor, Windsurf, Trae,..). Run multiple agent sessions side-by-side in tabs, stream tool calls and inline diffs, and share live sessions with teammates over a built-in bridge.