### PR TITLE
docs(libraries): add Acp.Net to the .NET community libraries

### DIFF
--- a/docs/libraries/community.mdx
+++ b/docs/libraries/community.mdx
@@ -14,6 +14,7 @@ description: "Community managed libraries for the Agent Client Protocol"
 ## .NET
 
 - [acp-csharp](https://github.com/nuskey8/acp-csharp)
+- [Acp.Net](https://github.com/MertBasar0/acp-net)
 
 ## Emacs
 


### PR DESCRIPTION
Adds **Acp.Net** to the .NET section of the community libraries.

Acp.Net is a process/runtime + testing layer for ACP agents in .NET. Rather than modeling the protocol, it handles the platform plumbing that protocol SDKs leave to the consumer: launching the agent process, the Windows↔WSL runtime bridge and path mapping, environment/PATH shaping, executable preflight, raw stdio transcripts, machine-readable run artifacts, and a deterministic fake ACP agent for tests. It is protocol-package-agnostic, so it complements (rather than competes with) the existing `acp-csharp` entry and any other ACP protocol SDK.

- Repo: https://github.com/MertBasar0/acp-net
- NuGet: `Acp.Net.Process`, `Acp.Net.Testing` (Apache-2.0)
