### PR TITLE
[codex] Add Braide to ACP clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -36,6 +36,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [AgentRQ](https://github.com/agentrq/agentrq) — Human-in-the-loop realtime task management and collaboration (Web)
 - [AionUi](https://github.com/iOfficeAI/AionUi)
 - [aizen](https://aizen.win)
+- [Braide](https://braide.dev) - Parallel sessions, worktrees, personas and interactive agent responses (supports macOS, Windows, Linux)
 - [DeepChat](https://github.com/ThinkInAIXYZ/deepchat)
 - [Devin Desktop](https://devin.ai/desktop)
 - [fabriqa.ai](https://fabriqa.ai)


### PR DESCRIPTION
## Summary

Adds Braide to the list of projects that implement or integrate with ACP in the getting started client documentation.

## Impact

Readers can discover Braide alongside the other ACP clients, with a short description of its parallel sessions, worktrees, personas, interactive agent responses, and supported platforms.

## Validation

- npx prettier --check docs/get-started/clients.mdx
- npm run check was attempted but could not run in this environment because cargo is not installed.