### PR TITLE
feat(unstable): Add boolean config option capabilities

### DIFF
--- a/agent-client-protocol-schema/src/v1/client.rs
+++ b/agent-client-protocol-schema/src/v1/client.rs
@@ -1595,6 +1595,16 @@ pub struct ClientCapabilities {
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
+    /// Session-related capabilities supported by the client.
+    #[cfg(feature = "unstable_boolean_config")]
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
+    #[serde(default)]
+    pub session: Option<ClientSessionCapabilities>,
+    /// **UNSTABLE**
+    ///
+    /// This capability is not part of the spec yet, and may be removed or changed at any point.
+    ///
     /// Whether the client supports `plan_update` and `plan_removed` session updates.
     ///
     /// Optional. Omitted means the client does not advertise support.
@@ -1681,6 +1691,18 @@ impl ClientCapabilities {
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
+    /// Session-related capabilities supported by the client.
+    #[cfg(feature = "unstable_boolean_config")]
+    #[must_use]
+    pub fn session(mut self, session: impl IntoOption<ClientSessionCapabilities>) -> Self {
+        self.session = session.into_option();
+        self
+    }
+
+    /// **UNSTABLE**
+    ///
+    /// This capability is not part of the spec yet, and may be removed or changed at any point.
+    ///
     /// Whether the client supports `plan_update` and `plan_removed` session updates.
     ///
     /// Omitted means the client does not advertise support.
@@ -1737,6 +1759,172 @@ impl ClientCapabilities {
     pub fn position_encodings(mut self, position_encodings: Vec<PositionEncodingKind>) -> Self {
         self.position_encodings = position_encodings;
         self
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// **UNSTABLE**
+///
+/// This capability is not part of the spec yet, and may be removed or changed at any point.
+///
+/// Session-related capabilities supported by the client.
+#[cfg(feature = "unstable_boolean_config")]
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct ClientSessionCapabilities {
+    /// Config option capabilities supported by the client.
+    ///
+    /// Omitted or `null` means the client does not advertise support for any
+    /// config option extensions.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
+    #[serde(default)]
+    pub config_options: Option<SessionConfigOptionsCapabilities>,
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+#[cfg(feature = "unstable_boolean_config")]
+impl ClientSessionCapabilities {
+    /// Builds an empty [`ClientSessionCapabilities`]; use builder methods to advertise supported sub-capabilities.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Config option capabilities supported by the client.
+    ///
+    /// Omitted or `null` means the client does not advertise support for any
+    /// config option extensions.
+    #[must_use]
+    pub fn config_options(
+        mut self,
+        config_options: impl IntoOption<SessionConfigOptionsCapabilities>,
+    ) -> Self {
+        self.config_options = config_options.into_option();
+        self
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// **UNSTABLE**
+///
+/// This capability is not part of the spec yet, and may be removed or changed at any point.
+///
+/// Session configuration option capabilities supported by the client.
+#[cfg(feature = "unstable_boolean_config")]
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct SessionConfigOptionsCapabilities {
+    /// Whether the client supports boolean session configuration options.
+    ///
+    /// Omitted or `null` means the client does not advertise support.
+    /// Supplying `{}` means agents may include `type: "boolean"` entries in
+    /// `configOptions`, and the client may send `session/set_config_option`
+    /// requests with `type: "boolean"` and a boolean `value`.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[schemars(extend("x-deserialize-default-on-error" = true))]
+    #[serde(default)]
+    pub boolean: Option<BooleanConfigOptionCapabilities>,
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+#[cfg(feature = "unstable_boolean_config")]
+impl SessionConfigOptionsCapabilities {
+    /// Builds an empty [`SessionConfigOptionsCapabilities`]; use builder methods to advertise supported sub-capabilities.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the client supports boolean session configuration options.
+    ///
+    /// Omitted or `null` means the client does not advertise support.
+    /// Supplying `{}` means agents may include `type: "boolean"` entries in
+    /// `configOptions`, and the client may send `session/set_config_option`
+    /// requests with `type: "boolean"` and a boolean `value`.
+    #[must_use]
+    pub fn boolean(mut self, boolean: impl IntoOption<BooleanConfigOptionCapabilities>) -> Self {
+        self.boolean = boolean.into_option();
+        self
+    }
+
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[must_use]
+    pub fn meta(mut self, meta: impl IntoOption<Meta>) -> Self {
+        self.meta = meta.into_option();
+        self
+    }
+}
+
+/// **UNSTABLE**
+///
+/// This capability is not part of the spec yet, and may be removed or changed at any point.
+///
+/// Capabilities for boolean session configuration options.
+///
+/// Supplying `{}` means the client supports boolean session configuration options.
+#[cfg(feature = "unstable_boolean_config")]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct BooleanConfigOptionCapabilities {
+    /// The _meta property is reserved by ACP to allow clients and agents to attach additional
+    /// metadata to their interactions. Implementations MUST NOT make assumptions about values at
+    /// these keys.
+    ///
+    /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
+    #[serde(rename = "_meta")]
+    pub meta: Option<Meta>,
+}
+
+#[cfg(feature = "unstable_boolean_config")]
+impl BooleanConfigOptionCapabilities {
+    /// Builds an empty [`BooleanConfigOptionCapabilities`]; use builder methods to advertise supported sub-capabilities.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
@@ -2382,6 +2570,60 @@ mod tests {
         let json = serde_json::to_value(&capabilities).unwrap();
 
         assert_eq!(json["positionEncodings"], json!(["utf-32", "utf-16"]));
+    }
+
+    #[cfg(feature = "unstable_boolean_config")]
+    #[test]
+    fn test_client_capabilities_boolean_config_options_serialization() {
+        use serde_json::json;
+
+        let capabilities = ClientCapabilities::new().session(
+            ClientSessionCapabilities::new().config_options(
+                SessionConfigOptionsCapabilities::new()
+                    .boolean(BooleanConfigOptionCapabilities::new()),
+            ),
+        );
+        let json = serde_json::to_value(&capabilities).unwrap();
+
+        assert_eq!(json["session"]["configOptions"]["boolean"], json!({}));
+
+        let omitted: ClientCapabilities = serde_json::from_value(json!({})).unwrap();
+        assert!(omitted.session.is_none());
+
+        let null_session: ClientCapabilities = serde_json::from_value(json!({
+            "session": null
+        }))
+        .unwrap();
+        assert!(null_session.session.is_none());
+
+        let null_config_options: ClientCapabilities = serde_json::from_value(json!({
+            "session": {
+                "configOptions": null
+            }
+        }))
+        .unwrap();
+        assert!(
+            null_config_options
+                .session
+                .and_then(|session| session.config_options)
+                .is_none()
+        );
+
+        let null_boolean: ClientCapabilities = serde_json::from_value(json!({
+            "session": {
+                "configOptions": {
+                    "boolean": null
+                }
+            }
+        }))
+        .unwrap();
+        assert!(
+            null_boolean
+                .session
+                .and_then(|session| session.config_options)
+                .and_then(|config_options| config_options.boolean)
+                .is_none()
+        );
     }
 
     #[cfg(feature = "unstable_plan_operations")]

--- a/agent-client-protocol-schema/src/v2/conversion.rs
+++ b/agent-client-protocol-schema/src/v2/conversion.rs
@@ -1897,6 +1897,13 @@ impl IntoV1 for super::ClientCapabilities {
         Ok(crate::v1::ClientCapabilities {
             fs: crate::v1::FileSystemCapabilities::default(),
             terminal: false,
+            #[cfg(feature = "unstable_boolean_config")]
+            session: Some(
+                crate::v1::ClientSessionCapabilities::new().config_options(
+                    crate::v1::SessionConfigOptionsCapabilities::new()
+                        .boolean(crate::v1::BooleanConfigOptionCapabilities::new()),
+                ),
+            ),
             #[cfg(feature = "unstable_plan_operations")]
             plan: None,
             #[cfg(feature = "unstable_auth_methods")]
@@ -1919,6 +1926,8 @@ impl IntoV2 for crate::v1::ClientCapabilities {
         let Self {
             fs: _,
             terminal: _,
+            #[cfg(feature = "unstable_boolean_config")]
+                session: _,
             #[cfg(feature = "unstable_plan_operations")]
                 plan: _,
             #[cfg(feature = "unstable_auth_methods")]
@@ -9062,7 +9071,16 @@ mod tests {
 
     #[test]
     fn round_trips_initialize_request() {
-        let client_capabilities = v1::ClientCapabilities::new();
+        let mut client_capabilities = v1::ClientCapabilities::new();
+        #[cfg(feature = "unstable_boolean_config")]
+        {
+            client_capabilities = client_capabilities.session(
+                v1::ClientSessionCapabilities::new().config_options(
+                    v1::SessionConfigOptionsCapabilities::new()
+                        .boolean(v1::BooleanConfigOptionCapabilities::new()),
+                ),
+            );
+        }
 
         let request = v1::InitializeRequest::new(ProtocolVersion::V1)
             .client_capabilities(client_capabilities)
@@ -9235,6 +9253,23 @@ mod tests {
         assert!(!v1_after.fs.read_text_file);
         assert!(!v1_after.fs.write_text_file);
         assert!(!v1_after.terminal);
+    }
+
+    #[cfg(feature = "unstable_boolean_config")]
+    #[test]
+    fn v2_client_capabilities_default_to_v1_boolean_config_option_support() {
+        let v2_capabilities = v2::ClientCapabilities::new();
+
+        let v1_capabilities: v1::ClientCapabilities =
+            v2_to_v1(v2_capabilities).expect("v2 -> v1 conversion");
+
+        assert!(
+            v1_capabilities
+                .session
+                .and_then(|session| session.config_options)
+                .and_then(|config_options| config_options.boolean)
+                .is_some()
+        );
     }
 
     #[test]

--- a/docs/protocol/v1/draft/initialization.mdx
+++ b/docs/protocol/v1/draft/initialization.mdx
@@ -142,6 +142,25 @@ The Client **SHOULD** specify whether it supports the following capabilities:
   Learn more about Terminals
 </Card>
 
+#### Boolean Config Options
+
+<ParamField
+  path="session.configOptions.boolean"
+  type="BooleanConfigOptionCapabilities Object"
+>
+  The Client supports `boolean` session configuration options. Omitted or `null`
+  at any level means the Client does not advertise support. Supplying `{}` means
+  Agents may include `type: "boolean"` options in v1 `configOptions` payloads.
+</ParamField>
+
+<Card
+  icon="sliders-horizontal"
+  horizontal
+  href="/protocol/v1/draft/session-config-options"
+>
+  Learn more about Session Config Options
+</Card>
+
 ### Agent Capabilities
 
 The Agent **SHOULD** specify whether it supports the following capabilities:

--- a/docs/protocol/v1/draft/schema.mdx
+++ b/docs/protocol/v1/draft/schema.mdx
@@ -3162,6 +3162,29 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
   URI associated with this resource or media payload.
 </ResponseField>
 
+## <span class="font-mono">BooleanConfigOptionCapabilities</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Capabilities for boolean session configuration options.
+
+Supplying `\{\}` means the client supports boolean session configuration options.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/draft/extensibility)
+
+</ResponseField>
+
 ## <span class="font-mono">BooleanPropertySchema</span>
 
 Schema for boolean properties in an elicitation form.
@@ -3264,6 +3287,14 @@ This capability is not part of the spec yet, and may be removed or changed at an
 The position encodings supported by the client, in order of preference.
 
 </ResponseField>
+<ResponseField name="session" type={<><span><a href="#clientsessioncapabilities">ClientSessionCapabilities</a></span><span> | null</span></>} >
+  **UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Session-related capabilities supported by the client.
+
+</ResponseField>
 <ResponseField name="terminal" type={"boolean"} >
   Whether the Client support all `terminal/*` methods.
 
@@ -3295,6 +3326,34 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
 </ResponseField>
 <ResponseField name="searchAndReplace" type={<><span><a href="#nessearchandreplacecapabilities">NesSearchAndReplaceCapabilities</a></span><span> | null</span></>} >
   Whether the client supports the `searchAndReplace` suggestion kind.
+</ResponseField>
+
+## <span class="font-mono">ClientSessionCapabilities</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Session-related capabilities supported by the client.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/draft/extensibility)
+
+</ResponseField>
+<ResponseField name="configOptions" type={<><span><a href="#sessionconfigoptionscapabilities">SessionConfigOptionsCapabilities</a></span><span> | null</span></>} >
+  Config option capabilities supported by the client.
+
+Omitted or `null` means the client does not advertise support for any
+config option extensions.
+
 </ResponseField>
 
 ## <span class="font-mono">ConfigOptionUpdate</span>
@@ -7090,6 +7149,36 @@ Model-related configuration parameter.
 
 <ResponseField name="other" type="string">
   Unknown / uncategorized selector.
+</ResponseField>
+
+## <span class="font-mono">SessionConfigOptionsCapabilities</span>
+
+**UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
+
+Session configuration option capabilities supported by the client.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="_meta" type={"object | null"} >
+  The _meta property is reserved by ACP to allow clients and agents to attach additional
+metadata to their interactions. Implementations MUST NOT make assumptions about values at
+these keys.
+
+See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/draft/extensibility)
+
+</ResponseField>
+<ResponseField name="boolean" type={<><span><a href="#booleanconfigoptioncapabilities">BooleanConfigOptionCapabilities</a></span><span> | null</span></>} >
+  Whether the client supports boolean session configuration options.
+
+Omitted or `null` means the client does not advertise support.
+Supplying `\{\}` means agents may include `type: "boolean"` entries in
+`configOptions`, and the client may send `session/set_config_option`
+requests with `type: "boolean"` and a boolean `value`.
+
 </ResponseField>
 
 ## <span class="font-mono">SessionConfigSelect</span>

--- a/docs/protocol/v1/draft/session-config-options.mdx
+++ b/docs/protocol/v1/draft/session-config-options.mdx
@@ -110,15 +110,19 @@ During [Session Setup](/protocol/v1/draft/session-setup) the Agent **MAY** retur
 </ResponseField>
 
 <ResponseField name="type" type="ConfigOptionType" required>
-  The type of input control. Currently only `select` is supported.
+  The type of input control. `select` is supported by default. `boolean` is only
+  supported when the Client advertises `session.configOptions.boolean: {}` in
+  `clientCapabilities`.
 </ResponseField>
 
-<ResponseField name="currentValue" type="string" required>
-  The currently selected value for this option
+<ResponseField name="currentValue" type="string | boolean" required>
+  The current value for this option. For `select` options this is a string value
+  ID. For `boolean` options this is a boolean.
 </ResponseField>
 
-<ResponseField name="options" type="ConfigOptionValue[]" required>
-  The available values for this option
+<ResponseField name="options" type="ConfigOptionValue[]">
+  The available values for a `select` option. Required when `type` is `"select"`
+  and omitted when `type` is `"boolean"`.
 </ResponseField>
 
 ### ConfigOptionValue
@@ -134,6 +138,43 @@ During [Session Setup](/protocol/v1/draft/session-setup) the Agent **MAY** retur
 <ResponseField name="description" type="string">
   Optional description of what this value does
 </ResponseField>
+
+### Boolean Config Options
+
+Agents **MAY** include boolean config options only after the Client advertises
+support during initialization:
+
+```json
+{
+  "clientCapabilities": {
+    "session": {
+      "configOptions": {
+        "boolean": {}
+      }
+    }
+  }
+}
+```
+
+Omitting `session`, `configOptions`, or `boolean` means the Client does not
+advertise support.
+
+When support is advertised, a boolean option uses `type: "boolean"` and a
+boolean `currentValue`:
+
+```json
+{
+  "id": "brave_mode",
+  "name": "Brave Mode",
+  "description": "Skip confirmation prompts and act autonomously",
+  "type": "boolean",
+  "currentValue": true
+}
+```
+
+Agents **MUST NOT** include `type: "boolean"` options in `configOptions`
+payloads unless the Client advertised support. Agents that need to support
+older Clients should omit the boolean option or provide a `select` fallback.
 
 ## Option Categories
 
@@ -206,10 +247,27 @@ Clients can change a config option value by calling the `session/set_config_opti
   The `id` of the configuration option to change
 </ParamField>
 
-<ParamField path="value" type="string" required>
-  The new value to set. Must be one of the values listed in the option's
-  `options` array.
+<ParamField path="value" type="string | boolean" required>
+  The new value to set. For `select` options, this must be one of the values
+  listed in the option's `options` array. For `boolean` options, this must be a
+  boolean.
 </ParamField>
+
+For boolean options, Clients send `type: "boolean"` with a boolean `value`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "session/set_config_option",
+  "params": {
+    "sessionId": "sess_abc123def456",
+    "configId": "brave_mode",
+    "type": "boolean",
+    "value": true
+  }
+}
+```
 
 The Agent **MUST** respond with the complete list of all configuration options and their current values:
 

--- a/docs/protocol/v2/draft/session-config-options.mdx
+++ b/docs/protocol/v2/draft/session-config-options.mdx
@@ -71,6 +71,13 @@ During [Session Setup](/protocol/v2/draft/session-setup) the Agent **MAY** retur
             "name": "1M"
           }
         ]
+      },
+      {
+        "id": "brave_mode",
+        "name": "Brave Mode",
+        "description": "Skip confirmation prompts and act autonomously",
+        "type": "boolean",
+        "currentValue": false
       }
     ]
   }
@@ -103,15 +110,18 @@ During [Session Setup](/protocol/v2/draft/session-setup) the Agent **MAY** retur
 </ResponseField>
 
 <ResponseField name="type" type="ConfigOptionType" required>
-  The type of input control. Currently only `select` is supported.
+  The type of input control. `select` is supported by default. The draft boolean
+  config option extension also defines `boolean`.
 </ResponseField>
 
-<ResponseField name="currentValue" type="string" required>
-  The currently selected value for this option
+<ResponseField name="currentValue" type="string | boolean" required>
+  The current value for this option. For `select` options this is a string value
+  ID. For `boolean` options this is a boolean.
 </ResponseField>
 
-<ResponseField name="options" type="ConfigOptionValue[]" required>
-  The available values for this option
+<ResponseField name="options" type="ConfigOptionValue[]">
+  The available values for a `select` option. Required when `type` is `"select"`
+  and omitted when `type` is `"boolean"`.
 </ResponseField>
 
 ### ConfigOptionValue
@@ -127,6 +137,21 @@ During [Session Setup](/protocol/v2/draft/session-setup) the Agent **MAY** retur
 <ResponseField name="description" type="string">
   Optional description of what this value does
 </ResponseField>
+
+### Boolean Config Options
+
+The draft boolean config option extension defines `type: "boolean"` for simple
+on/off toggles:
+
+```json
+{
+  "id": "brave_mode",
+  "name": "Brave Mode",
+  "description": "Skip confirmation prompts and act autonomously",
+  "type": "boolean",
+  "currentValue": true
+}
+```
 
 ## Option Categories
 
@@ -199,10 +224,27 @@ Clients can change a config option value by calling the `session/set_config_opti
   The `id` of the configuration option to change
 </ParamField>
 
-<ParamField path="value" type="string" required>
-  The new value to set. Must be one of the values listed in the option's
-  `options` array.
+<ParamField path="value" type="string | boolean" required>
+  The new value to set. For `select` options, this must be one of the values
+  listed in the option's `options` array. For `boolean` options, this must be a
+  boolean.
 </ParamField>
+
+For boolean options, Clients send `type: "boolean"` with a boolean `value`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "session/set_config_option",
+  "params": {
+    "sessionId": "sess_abc123def456",
+    "configId": "brave_mode",
+    "type": "boolean",
+    "value": true
+  }
+}
+```
 
 The Agent **MUST** respond with the complete list of all configuration options and their current values:
 

--- a/docs/rfds/boolean-config-option.mdx
+++ b/docs/rfds/boolean-config-option.mdx
@@ -20,6 +20,7 @@ However, there is no native way to represent a simple boolean on/off toggle. To 
 - Add a `SessionConfigBoolean` struct with a `current_value: bool` field
 - Add a `Boolean(SessionConfigBoolean)` variant to the `SessionConfigKind` enum, discriminated by `"type": "boolean"`
 - Add a `SessionConfigOptionValue` internally-tagged enum so that `SetSessionConfigOptionRequest` can carry both string values (for `select`) and boolean values (for `boolean`) with an explicit `type` discriminator
+- Add a v1 `session.configOptions.boolean` client capability so Agents only send boolean config options to Clients that explicitly opt in
 - Provide convenience constructors and `From` impls for ergonomic usage
 - Update documentation and regenerate schema files
 
@@ -28,6 +29,34 @@ However, there is no native way to represent a simple boolean on/off toggle. To 
 Clients can natively render boolean config options as toggle switches or checkboxes, without any custom logic. Agents can expose options like "Brave Mode", "Produce Report", or "Read Only" in a standardized way that any ACP-compliant client understands out of the box.
 
 ## Implementation details and plan
+
+### Client capability
+
+In v1, Clients opt in by setting `session.configOptions.boolean` in `initialize`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": 1,
+    "clientCapabilities": {
+      "session": {
+        "configOptions": {
+          "boolean": {}
+        }
+      }
+    }
+  }
+}
+```
+
+Omitting `session`, `configOptions`, or `boolean` means the Client does not advertise support. `null` at any of those levels is equivalent to omission.
+
+Agents **MUST NOT** include `type: "boolean"` config options in v1 `configOptions` payloads unless the Client advertised `session.configOptions.boolean: {}`. This applies to `session/new`, `session/load`, `session/update`, and `session/set_config_option` responses. Agents that need to support older Clients should omit the boolean option or provide a `select` fallback.
+
+Protocol v2 does not add an equivalent capability field for this extension. When the unstable boolean config option extension is enabled, v2 peers are boolean-aware by construction; compatibility layers that down-convert v2 client capabilities to v1 advertise `session.configOptions.boolean: {}` by default.
 
 ### Wire format: declaring a boolean option
 
@@ -135,12 +164,12 @@ Key changes:
    - `ValueId { value: SessionConfigValueId }` — untagged fallback when `type` is absent or unrecognised
 4. `SessionConfigOptionValue` is flattened (`#[serde(flatten)]`) onto `SetSessionConfigOptionRequest`, producing top-level `type` and `value` fields on the wire
 5. The `value` field type change in `SetSessionConfigOptionRequest` is gated behind `#[cfg(feature = "unstable_boolean_config")]` — without the feature the field remains `SessionConfigValueId`
-6. `From` impls (`&str`, `SessionConfigValueId`, `bool`) ensure ergonomic construction
-7. Wire-level backward compatible: existing JSON payloads without a `type` field remain valid via the untagged fallback
+6. The v1 `ClientCapabilities.session.config_options.boolean` field path serializes as `session.configOptions.boolean`
+7. Existing JSON payloads without a `type` field remain valid via the untagged fallback
 
 ### Client capabilities
 
-Per the existing protocol design, clients that receive a config option with an unrecognized `type` should ignore it. Since the agent is required to have a default value for every option, the agent can function correctly even if the client doesn't render or interact with the boolean option. No new client capability negotiation is needed.
+Clients that receive a config option with an unrecognized `type` should still ignore it. However, boolean config options also change the `session/set_config_option` request shape from the v1 string-only `value` convention to a boolean-valued payload. To avoid breaking Clients or SDKs that do not tolerate that shape, v1 Agents must treat boolean config options as capability-gated and only send them after the Client advertises `session.configOptions.boolean: {}`.
 
 ## Frequently asked questions
 
@@ -150,9 +179,14 @@ We considered reusing the existing `select` type with a convention (e.g., option
 
 ### Is this a breaking change?
 
-On the wire/JSON level: no. When `type` is absent the value is treated as a `SessionConfigValueId`, so existing payloads deserialize correctly. On the Rust API level: the type of `SetSessionConfigOptionRequest.value` changes, but this is gated behind `unstable_boolean_config`. Without the feature flag the stable API is unchanged. With the feature flag, `From` impls ensure source compatibility for users of the `new()` constructor.
+For v1 peers that do not advertise support, Agents must not send boolean config options, so the existing string-only config option behavior is preserved. When `type` is absent, `session/set_config_option.value` is still treated as a `SessionConfigValueId`, so existing select payloads deserialize correctly.
+
+For peers that opt in with `session.configOptions.boolean: {}`, boolean options introduce a new `type: "boolean"` setter shape with a boolean `value`.
+
+While no one would set a value of type boolean that doesn't support it, there is an issue with possible string deserialization causing the entire session/new or other response to fail deserialization. Most SDKs would process this gracefully, but if popular agents start using it, they could break existing clients.
 
 ## Revision history
 
 - 2026-02-24: Initial proposal
 - 2026-03-05: Updated to reflect final implementation — `flag` renamed to `boolean`, value type changed from untagged `String | Bool` enum to internally-tagged enum with `type` discriminator and untagged `ValueId` fallback, feature-gated behind `unstable_boolean_config`
+- 2026-06-22: Added the v1 `session.configOptions.boolean` client capability gate so boolean config options are only sent to Clients that explicitly opt in, and made v2-to-v1 compatibility conversion advertise the capability by default

--- a/schema/v1/schema.unstable.json
+++ b/schema/v1/schema.unstable.json
@@ -5856,6 +5856,18 @@
           "type": "boolean",
           "default": false
         },
+        "session": {
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nSession-related capabilities supported by the client.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ClientSessionCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
         "plan": {
           "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the client supports `plan_update` and `plan_removed` session updates.\n\nOptional. Omitted means the client does not advertise support.\nSupplying `{}` means the client can receive both update types.",
           "anyOf": [
@@ -5933,6 +5945,63 @@
           "type": "boolean",
           "default": false
         },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"],
+          "additionalProperties": true
+        }
+      }
+    },
+    "ClientSessionCapabilities": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nSession-related capabilities supported by the client.",
+      "type": "object",
+      "properties": {
+        "configOptions": {
+          "description": "Config option capabilities supported by the client.\n\nOmitted or `null` means the client does not advertise support for any\nconfig option extensions.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionConfigOptionsCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"],
+          "additionalProperties": true
+        }
+      }
+    },
+    "SessionConfigOptionsCapabilities": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nSession configuration option capabilities supported by the client.",
+      "type": "object",
+      "properties": {
+        "boolean": {
+          "description": "Whether the client supports boolean session configuration options.\n\nOmitted or `null` means the client does not advertise support.\nSupplying `{}` means agents may include `type: \"boolean\"` entries in\n`configOptions`, and the client may send `session/set_config_option`\nrequests with `type: \"boolean\"` and a boolean `value`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BooleanConfigOptionCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
+          "type": ["object", "null"],
+          "additionalProperties": true
+        }
+      }
+    },
+    "BooleanConfigOptionCapabilities": {
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for boolean session configuration options.\n\nSupplying `{}` means the client supports boolean session configuration options.",
+      "type": "object",
+      "properties": {
         "_meta": {
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",
           "type": ["object", "null"],


### PR DESCRIPTION
Thinking about this more with a mind towards stabilizing, I am a bit
worried about deserialization errors causing extreme breakage.

If a client or SDK does not gracefully skip options it doesn't
recognize, it may fail the whole response, which would break
session/new, session/load, session/resume, etc. While no one would call
set_config_option without understanding the option, the deserialization
part, because it is on the main path and not a new notification that can
be ignored, has me concerned.

Given an agent can always fallback to providing a select with values
"true" and "false" I think this should be a reasonable compromise.
