### PR TITLE
docs: add Codeg to Desktop and Web clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -37,6 +37,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [AionUi](https://github.com/iOfficeAI/AionUi)
 - [aizen](https://aizen.win)
 - [Braide](https://braide.dev) - Parallel sessions, worktrees, personas and interactive agent responses (supports macOS, Windows, Linux)
+- [Codeg](https://github.com/xintaofei/codeg) — collaborative multi-agent coding workbench that unifies ACP agents (Claude Code, Codex, Gemini CLI, OpenCode, and more) with session aggregation; desktop app, self-hosted server, or Docker (macOS, Windows, Linux, Web)
 - [DeepChat](https://github.com/ThinkInAIXYZ/deepchat)
 - [Devin Desktop](https://devin.ai/desktop)
 - [fabriqa.ai](https://fabriqa.ai)


### PR DESCRIPTION
Adds [Codeg](https://github.com/xintaofei/codeg) to the **Desktop and Web** section of the clients list.

Codeg is a collaborative multi-agent coding workbench that acts as an ACP client: it connects to ACP agents (Claude Code, Codex, Gemini CLI, OpenCode, and others) and aggregates their sessions into a single workspace. It runs as a Tauri desktop app, a self-hosted server, or via Docker (macOS, Windows, Linux, Web).

- Repo: https://github.com/xintaofei/codeg
- Category: Desktop and Web (inserted alphabetically, between Braide and DeepChat)

Docs-only change — `prettier --check` and `typos` both pass locally.
