### PR TITLE
fix(unstable-v2): make mcpServers optional in new sessions

### DIFF
--- a/agent-client-protocol-schema/src/v1/agent.rs
+++ b/agent-client-protocol-schema/src/v1/agent.rs
@@ -918,6 +918,7 @@ impl AuthMethodTerminal {
 /// Request parameters for creating a new session.
 ///
 /// See protocol docs: [Creating a Session](https://agentclientprotocol.com/protocol/session-setup#creating-a-session)
+#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[schemars(extend("x-side" = "agent", "x-method" = SESSION_NEW_METHOD_NAME))]
@@ -931,9 +932,13 @@ pub struct NewSessionRequest {
     /// These expand the session's filesystem scope without changing `cwd`, which
     /// remains the base for relative paths. When omitted or empty, no
     /// additional roots are activated for the new session.
+    #[serde_as(deserialize_as = "DefaultOnError<VecSkipError<_, SkipListener>>")]
+    #[schemars(extend("x-deserialize-default-on-error" = true, "x-deserialize-skip-invalid-items" = true))]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_directories: Vec<PathBuf>,
     /// List of MCP (Model Context Protocol) servers the agent should connect to.
+    #[serde_as(deserialize_as = "DefaultOnError<VecSkipError<_, SkipListener>>")]
+    #[schemars(extend("x-deserialize-default-on-error" = true, "x-deserialize-skip-invalid-items" = true))]
     pub mcp_servers: Vec<McpServer>,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
     /// metadata to their interactions. Implementations MUST NOT make assumptions about values at

--- a/agent-client-protocol-schema/src/v2/agent.rs
+++ b/agent-client-protocol-schema/src/v2/agent.rs
@@ -5655,7 +5655,6 @@ mod test_serialization {
             serde_json::to_value(NewSessionRequest::new("/home/user/project")).unwrap(),
             json!({
                 "cwd": "/home/user/project",
-                "mcpServers": []
             })
         );
         assert_eq!(
@@ -5672,7 +5671,6 @@ mod test_serialization {
                     "/home/user/shared-lib",
                     "/home/user/product-docs"
                 ],
-                "mcpServers": []
             })
         );
         assert_eq!(

--- a/agent-client-protocol-schema/src/v2/agent.rs
+++ b/agent-client-protocol-schema/src/v2/agent.rs
@@ -1015,6 +1015,7 @@ pub struct NewSessionRequest {
     /// List of MCP (Model Context Protocol) servers the agent should connect to.
     #[serde_as(deserialize_as = "DefaultOnError<VecSkipError<_, SkipListener>>")]
     #[schemars(extend("x-deserialize-default-on-error" = true, "x-deserialize-skip-invalid-items" = true))]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub mcp_servers: Vec<McpServer>,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
     /// metadata to their interactions. Implementations MUST NOT make assumptions about values at

--- a/agent-client-protocol-schema/src/v2/agent.rs
+++ b/agent-client-protocol-schema/src/v2/agent.rs
@@ -994,6 +994,7 @@ impl AuthMethodTerminal {
 /// Request parameters for creating a new session.
 ///
 /// See protocol docs: [Creating a Session](https://agentclientprotocol.com/protocol/session-setup#creating-a-session)
+#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[schemars(extend("x-side" = "agent", "x-method" = SESSION_NEW_METHOD_NAME))]
@@ -1007,9 +1008,13 @@ pub struct NewSessionRequest {
     /// These expand the session's workspace scope without changing `cwd`, which
     /// remains the base for relative paths. When omitted or empty, no
     /// additional roots are activated for the new session.
+    #[serde_as(deserialize_as = "DefaultOnError<VecSkipError<_, SkipListener>>")]
+    #[schemars(extend("x-deserialize-default-on-error" = true, "x-deserialize-skip-invalid-items" = true))]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_directories: Vec<PathBuf>,
     /// List of MCP (Model Context Protocol) servers the agent should connect to.
+    #[serde_as(deserialize_as = "DefaultOnError<VecSkipError<_, SkipListener>>")]
+    #[schemars(extend("x-deserialize-default-on-error" = true, "x-deserialize-skip-invalid-items" = true))]
     pub mcp_servers: Vec<McpServer>,
     /// The _meta property is reserved by ACP to allow clients and agents to attach additional
     /// metadata to their interactions. Implementations MUST NOT make assumptions about values at

--- a/docs/protocol/v2/draft/schema.mdx
+++ b/docs/protocol/v2/draft/schema.mdx
@@ -1278,7 +1278,7 @@ additional roots are activated for the new session.
 <ResponseField name="cwd" type={"string"} required>
   The working directory for this session. Must be an absolute path.
 </ResponseField>
-<ResponseField name="mcpServers" type={<a href="#mcpserver">McpServer[]</a>} required>
+<ResponseField name="mcpServers" type={<a href="#mcpserver">McpServer[]</a>} >
   List of MCP (Model Context Protocol) servers the agent should connect to.
 </ResponseField>
 

--- a/docs/protocol/v2/schema.mdx
+++ b/docs/protocol/v2/schema.mdx
@@ -520,7 +520,7 @@ additional roots are activated for the new session.
 <ResponseField name="cwd" type={"string"} required>
   The working directory for this session. Must be an absolute path.
 </ResponseField>
-<ResponseField name="mcpServers" type={<a href="#mcpserver">McpServer[]</a>} required>
+<ResponseField name="mcpServers" type={<a href="#mcpserver">McpServer[]</a>} >
   List of MCP (Model Context Protocol) servers the agent should connect to.
 </ResponseField>
 

--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -3456,14 +3456,18 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "mcpServers": {
           "description": "List of MCP (Model Context Protocol) servers the agent should connect to.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/McpServer"
-          }
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "_meta": {
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",

--- a/schema/v1/schema.unstable.json
+++ b/schema/v1/schema.unstable.json
@@ -6289,14 +6289,18 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "mcpServers": {
           "description": "List of MCP (Model Context Protocol) servers the agent should connect to.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/McpServer"
-          }
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "_meta": {
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",

--- a/schema/v2/schema.json
+++ b/schema/v2/schema.json
@@ -4036,14 +4036,18 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "mcpServers": {
           "description": "List of MCP (Model Context Protocol) servers the agent should connect to.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/McpServer"
-          }
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "_meta": {
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",

--- a/schema/v2/schema.json
+++ b/schema/v2/schema.json
@@ -4055,7 +4055,7 @@
           "additionalProperties": true
         }
       },
-      "required": ["cwd", "mcpServers"],
+      "required": ["cwd"],
       "x-side": "agent",
       "x-method": "session/new"
     },

--- a/schema/v2/schema.unstable.json
+++ b/schema/v2/schema.unstable.json
@@ -6949,14 +6949,18 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "mcpServers": {
           "description": "List of MCP (Model Context Protocol) servers the agent should connect to.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/McpServer"
-          }
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
         },
         "_meta": {
           "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)",

--- a/schema/v2/schema.unstable.json
+++ b/schema/v2/schema.unstable.json
@@ -6968,7 +6968,7 @@
           "additionalProperties": true
         }
       },
-      "required": ["cwd", "mcpServers"],
+      "required": ["cwd"],
       "x-side": "agent",
       "x-method": "session/new"
     },


### PR DESCRIPTION
- **fix(schema): tolerate invalid items in new session lists**
- **fix(unstable-v2): make mcpServers optional in new sessions**
