### PR TITLE
refactor(rust): Box v2 protocol enum variants

### DIFF
--- a/agent-client-protocol-schema/src/v2/agent.rs
+++ b/agent-client-protocol-schema/src/v2/agent.rs
@@ -5357,14 +5357,14 @@ pub enum ClientRequest {
     /// `new_session` without receiving an `auth_required` error.
     ///
     /// See protocol docs: [Initialization](https://agentclientprotocol.com/protocol/initialization)
-    LoginAuthRequest(LoginAuthRequest),
+    LoginAuthRequest(Box<LoginAuthRequest>),
     /// **UNSTABLE**
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// Lists providers that can be configured by the client.
     #[cfg(feature = "unstable_llm_providers")]
-    ListProvidersRequest(ListProvidersRequest),
+    ListProvidersRequest(Box<ListProvidersRequest>),
     /// **UNSTABLE**
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
@@ -5378,12 +5378,12 @@ pub enum ClientRequest {
     ///
     /// Disables a provider.
     #[cfg(feature = "unstable_llm_providers")]
-    DisableProviderRequest(DisableProviderRequest),
+    DisableProviderRequest(Box<DisableProviderRequest>),
     /// Logs out of the current authenticated state.
     ///
     /// After a successful logout, all new sessions will require authentication.
     /// There is no guarantee about the behavior of already running sessions.
-    LogoutAuthRequest(LogoutAuthRequest),
+    LogoutAuthRequest(Box<LogoutAuthRequest>),
     /// Creates a new conversation session with the agent.
     ///
     /// Sessions represent independent conversation contexts with their own history and state.
@@ -5396,7 +5396,7 @@ pub enum ClientRequest {
     /// May return an `auth_required` error if the agent requires authentication.
     ///
     /// See protocol docs: [Session Setup](https://agentclientprotocol.com/protocol/session-setup)
-    NewSessionRequest(NewSessionRequest),
+    NewSessionRequest(Box<NewSessionRequest>),
     /// Loads an existing session to resume a previous conversation.
     ///
     /// This method is only available if the agent advertises the `session.load` capability.
@@ -5407,17 +5407,17 @@ pub enum ClientRequest {
     /// - Stream the entire conversation history back to the client via notifications
     ///
     /// See protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/session-setup#loading-sessions)
-    LoadSessionRequest(LoadSessionRequest),
+    LoadSessionRequest(Box<LoadSessionRequest>),
     /// Lists existing sessions known to the agent.
     ///
     /// This method is only available if the agent advertises the `session.list` capability.
     ///
     /// The agent should return metadata about sessions with optional filtering and pagination support.
-    ListSessionsRequest(ListSessionsRequest),
+    ListSessionsRequest(Box<ListSessionsRequest>),
     /// Deletes an existing session from `session/list`.
     ///
     /// This method is only available if the agent advertises the `session.delete` capability.
-    DeleteSessionRequest(DeleteSessionRequest),
+    DeleteSessionRequest(Box<DeleteSessionRequest>),
     #[cfg(feature = "unstable_session_fork")]
     /// **UNSTABLE**
     ///
@@ -5430,23 +5430,23 @@ pub enum ClientRequest {
     /// The agent should create a new session with the same conversation context as the
     /// original, allowing operations like generating summaries without affecting the
     /// original session's history.
-    ForkSessionRequest(ForkSessionRequest),
+    ForkSessionRequest(Box<ForkSessionRequest>),
     /// Resumes an existing session without returning previous messages.
     ///
     /// This method is only available if the agent advertises the `session.resume` capability.
     ///
     /// The agent should resume the session context, allowing the conversation to continue
     /// without replaying the message history (unlike `session/load`).
-    ResumeSessionRequest(ResumeSessionRequest),
+    ResumeSessionRequest(Box<ResumeSessionRequest>),
     /// Closes an active session and frees up any resources associated with it.
     ///
     /// This method is only available if the agent advertises the `session.close` capability.
     ///
     /// The agent must cancel any ongoing work (as if `session/cancel` was called)
     /// and then free up any resources associated with the session.
-    CloseSessionRequest(CloseSessionRequest),
+    CloseSessionRequest(Box<CloseSessionRequest>),
     /// Sets the current value for a session configuration option.
-    SetSessionConfigOptionRequest(SetSessionConfigOptionRequest),
+    SetSessionConfigOptionRequest(Box<SetSessionConfigOptionRequest>),
     /// Processes a user prompt within a session.
     ///
     /// This request accepts the prompt:
@@ -5458,7 +5458,7 @@ pub enum ClientRequest {
     /// `session/update` notifications.
     ///
     /// See protocol docs: [Prompt Lifecycle](https://agentclientprotocol.com/protocol/prompt-lifecycle)
-    PromptRequest(PromptRequest),
+    PromptRequest(Box<PromptRequest>),
     #[cfg(feature = "unstable_nes")]
     /// **UNSTABLE**
     ///
@@ -5482,21 +5482,21 @@ pub enum ClientRequest {
     ///
     /// The agent must cancel any ongoing work and then free up any resources
     /// associated with the NES session.
-    CloseNesRequest(CloseNesRequest),
+    CloseNesRequest(Box<CloseNesRequest>),
     /// **UNSTABLE**
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// Exchanges an MCP-over-ACP message.
     #[cfg(feature = "unstable_mcp_over_acp")]
-    MessageMcpRequest(MessageMcpRequest),
+    MessageMcpRequest(Box<MessageMcpRequest>),
     /// Handles extension method requests from the client.
     ///
     /// Extension methods provide a way to add custom functionality while maintaining
     /// protocol compatibility.
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    ExtMethodRequest(ExtRequest),
+    ExtMethodRequest(Box<ExtRequest>),
 }
 
 impl ClientRequest {
@@ -5550,51 +5550,51 @@ pub enum AgentResponse {
     /// Successful result returned for a `initialize` request.
     InitializeResponse(Box<InitializeResponse>),
     /// Successful result returned for an `auth/login` request.
-    LoginAuthResponse(#[serde(default)] LoginAuthResponse),
+    LoginAuthResponse(#[serde(default)] Box<LoginAuthResponse>),
     /// Successful result returned for a `providers/list` request.
     #[cfg(feature = "unstable_llm_providers")]
-    ListProvidersResponse(ListProvidersResponse),
+    ListProvidersResponse(Box<ListProvidersResponse>),
     /// Successful result returned for a `providers/set` request.
     #[cfg(feature = "unstable_llm_providers")]
-    SetProviderResponse(#[serde(default)] SetProviderResponse),
+    SetProviderResponse(#[serde(default)] Box<SetProviderResponse>),
     /// Successful result returned for a `providers/disable` request.
     #[cfg(feature = "unstable_llm_providers")]
-    DisableProviderResponse(#[serde(default)] DisableProviderResponse),
+    DisableProviderResponse(#[serde(default)] Box<DisableProviderResponse>),
     /// Successful result returned for an `auth/logout` request.
-    LogoutAuthResponse(#[serde(default)] LogoutAuthResponse),
+    LogoutAuthResponse(#[serde(default)] Box<LogoutAuthResponse>),
     /// Successful result returned for a `session/new` request.
-    NewSessionResponse(NewSessionResponse),
+    NewSessionResponse(Box<NewSessionResponse>),
     /// Successful result returned for a `session/load` request.
-    LoadSessionResponse(#[serde(default)] LoadSessionResponse),
+    LoadSessionResponse(#[serde(default)] Box<LoadSessionResponse>),
     /// Successful result returned for a `session/list` request.
-    ListSessionsResponse(ListSessionsResponse),
+    ListSessionsResponse(Box<ListSessionsResponse>),
     /// Successful result returned for a `session/delete` request.
-    DeleteSessionResponse(#[serde(default)] DeleteSessionResponse),
+    DeleteSessionResponse(#[serde(default)] Box<DeleteSessionResponse>),
     /// Successful result returned for a `session/fork` request.
     #[cfg(feature = "unstable_session_fork")]
-    ForkSessionResponse(ForkSessionResponse),
+    ForkSessionResponse(Box<ForkSessionResponse>),
     /// Successful result returned for a `session/resume` request.
-    ResumeSessionResponse(#[serde(default)] ResumeSessionResponse),
+    ResumeSessionResponse(#[serde(default)] Box<ResumeSessionResponse>),
     /// Successful result returned for a `session/close` request.
-    CloseSessionResponse(#[serde(default)] CloseSessionResponse),
+    CloseSessionResponse(#[serde(default)] Box<CloseSessionResponse>),
     /// Successful result returned for a `session/set_config_option` request.
-    SetSessionConfigOptionResponse(SetSessionConfigOptionResponse),
+    SetSessionConfigOptionResponse(Box<SetSessionConfigOptionResponse>),
     /// Successful result returned for a `session/prompt` request.
-    PromptResponse(PromptResponse),
+    PromptResponse(Box<PromptResponse>),
     /// Successful result returned for a `nes/start` request.
     #[cfg(feature = "unstable_nes")]
-    StartNesResponse(StartNesResponse),
+    StartNesResponse(Box<StartNesResponse>),
     /// Successful result returned for a `nes/suggest` request.
     #[cfg(feature = "unstable_nes")]
-    SuggestNesResponse(SuggestNesResponse),
+    SuggestNesResponse(Box<SuggestNesResponse>),
     /// Successful result returned for a `nes/close` request.
     #[cfg(feature = "unstable_nes")]
-    CloseNesResponse(#[serde(default)] CloseNesResponse),
+    CloseNesResponse(#[serde(default)] Box<CloseNesResponse>),
     /// Successful result returned by an extension method outside the core ACP method set.
-    ExtMethodResponse(ExtResponse),
+    ExtMethodResponse(Box<ExtResponse>),
     /// Successful result returned by an MCP-over-ACP `mcp/message` request.
     #[cfg(feature = "unstable_mcp_over_acp")]
-    MessageMcpResponse(MessageMcpResponse),
+    MessageMcpResponse(Box<MessageMcpResponse>),
 }
 
 /// All possible notifications that a client can send to an agent.
@@ -5621,27 +5621,27 @@ pub enum ClientNotification {
     ///   cancellation succeeds
     ///
     /// See protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/prompt-lifecycle#cancellation)
-    CancelSessionNotification(CancelSessionNotification),
+    CancelSessionNotification(Box<CancelSessionNotification>),
     #[cfg(feature = "unstable_nes")]
     /// **UNSTABLE**
     ///
     /// Notification sent when a file is opened in the editor.
-    DidOpenDocumentNotification(DidOpenDocumentNotification),
+    DidOpenDocumentNotification(Box<DidOpenDocumentNotification>),
     #[cfg(feature = "unstable_nes")]
     /// **UNSTABLE**
     ///
     /// Notification sent when a file is edited.
-    DidChangeDocumentNotification(DidChangeDocumentNotification),
+    DidChangeDocumentNotification(Box<DidChangeDocumentNotification>),
     #[cfg(feature = "unstable_nes")]
     /// **UNSTABLE**
     ///
     /// Notification sent when a file is closed.
-    DidCloseDocumentNotification(DidCloseDocumentNotification),
+    DidCloseDocumentNotification(Box<DidCloseDocumentNotification>),
     #[cfg(feature = "unstable_nes")]
     /// **UNSTABLE**
     ///
     /// Notification sent when a file is saved.
-    DidSaveDocumentNotification(DidSaveDocumentNotification),
+    DidSaveDocumentNotification(Box<DidSaveDocumentNotification>),
     #[cfg(feature = "unstable_nes")]
     /// **UNSTABLE**
     ///
@@ -5651,26 +5651,26 @@ pub enum ClientNotification {
     /// **UNSTABLE**
     ///
     /// Notification sent when a suggestion is accepted.
-    AcceptNesNotification(AcceptNesNotification),
+    AcceptNesNotification(Box<AcceptNesNotification>),
     #[cfg(feature = "unstable_nes")]
     /// **UNSTABLE**
     ///
     /// Notification sent when a suggestion is rejected.
-    RejectNesNotification(RejectNesNotification),
+    RejectNesNotification(Box<RejectNesNotification>),
     /// **UNSTABLE**
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// Sends an MCP-over-ACP notification.
     #[cfg(feature = "unstable_mcp_over_acp")]
-    MessageMcpNotification(MessageMcpNotification),
+    MessageMcpNotification(Box<MessageMcpNotification>),
     /// Handles extension notifications from the client.
     ///
     /// Extension notifications provide a way to send one-way messages for custom functionality
     /// while maintaining protocol compatibility.
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    ExtNotification(ExtNotification),
+    ExtNotification(Box<ExtNotification>),
 }
 
 impl ClientNotification {
@@ -5898,15 +5898,18 @@ mod test_serialization {
         assert_eq!(AGENT_METHOD_NAMES.mcp_message, "mcp/message");
 
         assert_eq!(
-            ClientRequest::MessageMcpRequest(MessageMcpRequest::new("conn-1", "tools/list"))
-                .method(),
+            ClientRequest::MessageMcpRequest(Box::new(MessageMcpRequest::new(
+                "conn-1",
+                "tools/list"
+            )))
+            .method(),
             "mcp/message"
         );
         assert_eq!(
-            ClientNotification::MessageMcpNotification(MessageMcpNotification::new(
+            ClientNotification::MessageMcpNotification(Box::new(MessageMcpNotification::new(
                 "conn-1",
                 "notifications/progress"
-            ))
+            )))
             .method(),
             "mcp/message"
         );
@@ -5918,11 +5921,12 @@ mod test_serialization {
         assert_eq!(AGENT_METHOD_NAMES.auth_logout, "auth/logout");
 
         assert_eq!(
-            ClientRequest::LoginAuthRequest(LoginAuthRequest::new("agent-login")).method(),
+            ClientRequest::LoginAuthRequest(Box::new(LoginAuthRequest::new("agent-login")))
+                .method(),
             "auth/login"
         );
         assert_eq!(
-            ClientRequest::LogoutAuthRequest(LogoutAuthRequest::new()).method(),
+            ClientRequest::LogoutAuthRequest(Box::new(LogoutAuthRequest::new())).method(),
             "auth/logout"
         );
     }
@@ -6200,7 +6204,8 @@ mod test_serialization {
     fn test_session_delete_serialization() {
         assert_eq!(AGENT_METHOD_NAMES.session_delete, "session/delete");
         assert_eq!(
-            ClientRequest::DeleteSessionRequest(DeleteSessionRequest::new("sess_abc123")).method(),
+            ClientRequest::DeleteSessionRequest(Box::new(DeleteSessionRequest::new("sess_abc123")))
+                .method(),
             "session/delete"
         );
         assert_eq!(

--- a/agent-client-protocol-schema/src/v2/client.rs
+++ b/agent-client-protocol-schema/src/v2/client.rs
@@ -1852,28 +1852,28 @@ pub enum AgentRequest {
     ///
     /// Requests structured user input via a form or URL.
     #[cfg(feature = "unstable_elicitation")]
-    CreateElicitationRequest(CreateElicitationRequest),
+    CreateElicitationRequest(Box<CreateElicitationRequest>),
     /// **UNSTABLE**
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// Opens an MCP-over-ACP connection.
     #[cfg(feature = "unstable_mcp_over_acp")]
-    ConnectMcpRequest(ConnectMcpRequest),
+    ConnectMcpRequest(Box<ConnectMcpRequest>),
     /// **UNSTABLE**
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// Exchanges an MCP-over-ACP message.
     #[cfg(feature = "unstable_mcp_over_acp")]
-    MessageMcpRequest(MessageMcpRequest),
+    MessageMcpRequest(Box<MessageMcpRequest>),
     /// **UNSTABLE**
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// Closes an MCP-over-ACP connection.
     #[cfg(feature = "unstable_mcp_over_acp")]
-    DisconnectMcpRequest(DisconnectMcpRequest),
+    DisconnectMcpRequest(Box<DisconnectMcpRequest>),
     /// Handles extension method requests from the agent.
     ///
     /// Allows the Agent to send an arbitrary request that is not part of the ACP spec.
@@ -1881,7 +1881,7 @@ pub enum AgentRequest {
     /// protocol compatibility.
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    ExtMethodRequest(ExtRequest),
+    ExtMethodRequest(Box<ExtRequest>),
 }
 
 impl AgentRequest {
@@ -1915,21 +1915,21 @@ impl AgentRequest {
 #[non_exhaustive]
 pub enum ClientResponse {
     /// Successful result returned for a `session/request_permission` request.
-    RequestPermissionResponse(RequestPermissionResponse),
+    RequestPermissionResponse(Box<RequestPermissionResponse>),
     /// Successful result returned for a `elicitation/create` request.
     #[cfg(feature = "unstable_elicitation")]
-    CreateElicitationResponse(CreateElicitationResponse),
+    CreateElicitationResponse(Box<CreateElicitationResponse>),
     /// Successful result returned for a `mcp/connect` request.
     #[cfg(feature = "unstable_mcp_over_acp")]
-    ConnectMcpResponse(ConnectMcpResponse),
+    ConnectMcpResponse(Box<ConnectMcpResponse>),
     /// Successful result returned for a `mcp/disconnect` request.
     #[cfg(feature = "unstable_mcp_over_acp")]
-    DisconnectMcpResponse(#[serde(default)] DisconnectMcpResponse),
+    DisconnectMcpResponse(#[serde(default)] Box<DisconnectMcpResponse>),
     /// Successful result returned by an MCP-over-ACP `mcp/message` request.
     #[cfg(feature = "unstable_mcp_over_acp")]
-    MessageMcpResponse(MessageMcpResponse),
+    MessageMcpResponse(Box<MessageMcpResponse>),
     /// Successful result returned by an extension method outside the core ACP method set.
-    ExtMethodResponse(ExtResponse),
+    ExtMethodResponse(Box<ExtResponse>),
 }
 
 /// All possible notifications that an agent can send to a client.
@@ -1962,14 +1962,14 @@ pub enum AgentNotification {
     ///
     /// Notification that a URL-based elicitation has completed.
     #[cfg(feature = "unstable_elicitation")]
-    CompleteElicitationNotification(CompleteElicitationNotification),
+    CompleteElicitationNotification(Box<CompleteElicitationNotification>),
     /// **UNSTABLE**
     ///
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// Receives an MCP-over-ACP notification.
     #[cfg(feature = "unstable_mcp_over_acp")]
-    MessageMcpNotification(MessageMcpNotification),
+    MessageMcpNotification(Box<MessageMcpNotification>),
     /// Handles extension notifications from the agent.
     ///
     /// Allows the Agent to send an arbitrary notification that is not part of the ACP spec.
@@ -1977,7 +1977,7 @@ pub enum AgentNotification {
     /// while maintaining protocol compatibility.
     ///
     /// See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/extensibility)
-    ExtNotification(ExtNotification),
+    ExtNotification(Box<ExtNotification>),
 }
 
 impl AgentNotification {
@@ -2546,23 +2546,27 @@ mod tests {
         assert_eq!(CLIENT_METHOD_NAMES.mcp_disconnect, "mcp/disconnect");
 
         assert_eq!(
-            AgentRequest::ConnectMcpRequest(ConnectMcpRequest::new("server-1")).method(),
+            AgentRequest::ConnectMcpRequest(Box::new(ConnectMcpRequest::new("server-1"))).method(),
             "mcp/connect"
         );
         assert_eq!(
-            AgentRequest::MessageMcpRequest(MessageMcpRequest::new("conn-1", "tools/list"))
-                .method(),
+            AgentRequest::MessageMcpRequest(Box::new(MessageMcpRequest::new(
+                "conn-1",
+                "tools/list"
+            )))
+            .method(),
             "mcp/message"
         );
         assert_eq!(
-            AgentRequest::DisconnectMcpRequest(DisconnectMcpRequest::new("conn-1")).method(),
+            AgentRequest::DisconnectMcpRequest(Box::new(DisconnectMcpRequest::new("conn-1")))
+                .method(),
             "mcp/disconnect"
         );
         assert_eq!(
-            AgentNotification::MessageMcpNotification(MessageMcpNotification::new(
+            AgentNotification::MessageMcpNotification(Box::new(MessageMcpNotification::new(
                 "conn-1",
                 "notifications/progress"
-            ))
+            )))
             .method(),
             "mcp/message"
         );

--- a/agent-client-protocol-schema/src/v2/conversion.rs
+++ b/agent-client-protocol-schema/src/v2/conversion.rs
@@ -2051,22 +2051,22 @@ impl IntoV2 for crate::v1::AgentRequest {
             }
             #[cfg(feature = "unstable_elicitation")]
             Self::CreateElicitationRequest(value) => {
-                super::AgentRequest::CreateElicitationRequest(value.into_v2()?)
+                super::AgentRequest::CreateElicitationRequest(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_mcp_over_acp")]
             Self::ConnectMcpRequest(value) => {
-                super::AgentRequest::ConnectMcpRequest(value.into_v2()?)
+                super::AgentRequest::ConnectMcpRequest(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_mcp_over_acp")]
             Self::MessageMcpRequest(value) => {
-                super::AgentRequest::MessageMcpRequest(value.into_v2()?)
+                super::AgentRequest::MessageMcpRequest(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_mcp_over_acp")]
             Self::DisconnectMcpRequest(value) => {
-                super::AgentRequest::DisconnectMcpRequest(value.into_v2()?)
+                super::AgentRequest::DisconnectMcpRequest(Box::new(value.into_v2()?))
             }
             Self::ExtMethodRequest(value) => {
-                super::AgentRequest::ExtMethodRequest(value.into_v2()?)
+                super::AgentRequest::ExtMethodRequest(Box::new(value.into_v2()?))
             }
         })
     }
@@ -2121,7 +2121,7 @@ impl IntoV2 for crate::v1::ClientResponse {
                 ));
             }
             Self::RequestPermissionResponse(value) => {
-                super::ClientResponse::RequestPermissionResponse(value.into_v2()?)
+                super::ClientResponse::RequestPermissionResponse(Box::new(value.into_v2()?))
             }
             Self::CreateTerminalResponse(_) => {
                 return Err(removed_v1_enum_variant("ClientResponse", "terminal/create"));
@@ -2146,22 +2146,22 @@ impl IntoV2 for crate::v1::ClientResponse {
             }
             #[cfg(feature = "unstable_elicitation")]
             Self::CreateElicitationResponse(value) => {
-                super::ClientResponse::CreateElicitationResponse(value.into_v2()?)
+                super::ClientResponse::CreateElicitationResponse(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_mcp_over_acp")]
             Self::ConnectMcpResponse(value) => {
-                super::ClientResponse::ConnectMcpResponse(value.into_v2()?)
+                super::ClientResponse::ConnectMcpResponse(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_mcp_over_acp")]
             Self::MessageMcpResponse(value) => {
-                super::ClientResponse::MessageMcpResponse(value.into_v2()?)
+                super::ClientResponse::MessageMcpResponse(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_mcp_over_acp")]
             Self::DisconnectMcpResponse(value) => {
-                super::ClientResponse::DisconnectMcpResponse(value.into_v2()?)
+                super::ClientResponse::DisconnectMcpResponse(Box::new(value.into_v2()?))
             }
             Self::ExtMethodResponse(value) => {
-                super::ClientResponse::ExtMethodResponse(value.into_v2()?)
+                super::ClientResponse::ExtMethodResponse(Box::new(value.into_v2()?))
             }
         })
     }
@@ -2210,14 +2210,16 @@ impl IntoV2 for crate::v1::AgentNotification {
             }
             #[cfg(feature = "unstable_elicitation")]
             Self::CompleteElicitationNotification(value) => {
-                super::AgentNotification::CompleteElicitationNotification(value.into_v2()?)
+                super::AgentNotification::CompleteElicitationNotification(Box::new(
+                    value.into_v2()?,
+                ))
             }
             #[cfg(feature = "unstable_mcp_over_acp")]
             Self::MessageMcpNotification(value) => {
-                super::AgentNotification::MessageMcpNotification(value.into_v2()?)
+                super::AgentNotification::MessageMcpNotification(Box::new(value.into_v2()?))
             }
             Self::ExtNotification(value) => {
-                super::AgentNotification::ExtNotification(value.into_v2()?)
+                super::AgentNotification::ExtNotification(Box::new(value.into_v2()?))
             }
         })
     }
@@ -5242,11 +5244,11 @@ impl IntoV2 for crate::v1::ClientRequest {
                 super::ClientRequest::InitializeRequest(Box::new(value.into_v2()?))
             }
             Self::AuthenticateRequest(value) => {
-                super::ClientRequest::LoginAuthRequest(value.into_v2()?)
+                super::ClientRequest::LoginAuthRequest(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_llm_providers")]
             Self::ListProvidersRequest(value) => {
-                super::ClientRequest::ListProvidersRequest(value.into_v2()?)
+                super::ClientRequest::ListProvidersRequest(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_llm_providers")]
             Self::SetProviderRequest(value) => {
@@ -5254,38 +5256,42 @@ impl IntoV2 for crate::v1::ClientRequest {
             }
             #[cfg(feature = "unstable_llm_providers")]
             Self::DisableProviderRequest(value) => {
-                super::ClientRequest::DisableProviderRequest(value.into_v2()?)
+                super::ClientRequest::DisableProviderRequest(Box::new(value.into_v2()?))
             }
-            Self::LogoutRequest(value) => super::ClientRequest::LogoutAuthRequest(value.into_v2()?),
+            Self::LogoutRequest(value) => {
+                super::ClientRequest::LogoutAuthRequest(Box::new(value.into_v2()?))
+            }
             Self::NewSessionRequest(value) => {
-                super::ClientRequest::NewSessionRequest(value.into_v2()?)
+                super::ClientRequest::NewSessionRequest(Box::new(value.into_v2()?))
             }
             Self::LoadSessionRequest(value) => {
-                super::ClientRequest::LoadSessionRequest(value.into_v2()?)
+                super::ClientRequest::LoadSessionRequest(Box::new(value.into_v2()?))
             }
             Self::ListSessionsRequest(value) => {
-                super::ClientRequest::ListSessionsRequest(value.into_v2()?)
+                super::ClientRequest::ListSessionsRequest(Box::new(value.into_v2()?))
             }
             Self::DeleteSessionRequest(value) => {
-                super::ClientRequest::DeleteSessionRequest(value.into_v2()?)
+                super::ClientRequest::DeleteSessionRequest(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_session_fork")]
             Self::ForkSessionRequest(value) => {
-                super::ClientRequest::ForkSessionRequest(value.into_v2()?)
+                super::ClientRequest::ForkSessionRequest(Box::new(value.into_v2()?))
             }
             Self::ResumeSessionRequest(value) => {
-                super::ClientRequest::ResumeSessionRequest(value.into_v2()?)
+                super::ClientRequest::ResumeSessionRequest(Box::new(value.into_v2()?))
             }
             Self::CloseSessionRequest(value) => {
-                super::ClientRequest::CloseSessionRequest(value.into_v2()?)
+                super::ClientRequest::CloseSessionRequest(Box::new(value.into_v2()?))
             }
             Self::SetSessionModeRequest(_) => {
                 return Err(removed_v1_enum_variant("ClientRequest", "session/set_mode"));
             }
             Self::SetSessionConfigOptionRequest(value) => {
-                super::ClientRequest::SetSessionConfigOptionRequest(value.into_v2()?)
+                super::ClientRequest::SetSessionConfigOptionRequest(Box::new(value.into_v2()?))
             }
-            Self::PromptRequest(value) => super::ClientRequest::PromptRequest(value.into_v2()?),
+            Self::PromptRequest(value) => {
+                super::ClientRequest::PromptRequest(Box::new(value.into_v2()?))
+            }
             #[cfg(feature = "unstable_nes")]
             Self::StartNesRequest(value) => {
                 super::ClientRequest::StartNesRequest(Box::new(value.into_v2()?))
@@ -5295,13 +5301,15 @@ impl IntoV2 for crate::v1::ClientRequest {
                 super::ClientRequest::SuggestNesRequest(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_nes")]
-            Self::CloseNesRequest(value) => super::ClientRequest::CloseNesRequest(value.into_v2()?),
+            Self::CloseNesRequest(value) => {
+                super::ClientRequest::CloseNesRequest(Box::new(value.into_v2()?))
+            }
             #[cfg(feature = "unstable_mcp_over_acp")]
             Self::MessageMcpRequest(value) => {
-                super::ClientRequest::MessageMcpRequest(value.into_v2()?)
+                super::ClientRequest::MessageMcpRequest(Box::new(value.into_v2()?))
             }
             Self::ExtMethodRequest(value) => {
-                super::ClientRequest::ExtMethodRequest(value.into_v2()?)
+                super::ClientRequest::ExtMethodRequest(Box::new(value.into_v2()?))
             }
         })
     }
@@ -5393,70 +5401,72 @@ impl IntoV2 for crate::v1::AgentResponse {
                 super::AgentResponse::InitializeResponse(Box::new(value.into_v2()?))
             }
             Self::AuthenticateResponse(value) => {
-                super::AgentResponse::LoginAuthResponse(value.into_v2()?)
+                super::AgentResponse::LoginAuthResponse(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_llm_providers")]
             Self::ListProvidersResponse(value) => {
-                super::AgentResponse::ListProvidersResponse(value.into_v2()?)
+                super::AgentResponse::ListProvidersResponse(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_llm_providers")]
             Self::SetProviderResponse(value) => {
-                super::AgentResponse::SetProviderResponse(value.into_v2()?)
+                super::AgentResponse::SetProviderResponse(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_llm_providers")]
             Self::DisableProviderResponse(value) => {
-                super::AgentResponse::DisableProviderResponse(value.into_v2()?)
+                super::AgentResponse::DisableProviderResponse(Box::new(value.into_v2()?))
             }
             Self::LogoutResponse(value) => {
-                super::AgentResponse::LogoutAuthResponse(value.into_v2()?)
+                super::AgentResponse::LogoutAuthResponse(Box::new(value.into_v2()?))
             }
             Self::NewSessionResponse(value) => {
-                super::AgentResponse::NewSessionResponse(value.into_v2()?)
+                super::AgentResponse::NewSessionResponse(Box::new(value.into_v2()?))
             }
             Self::LoadSessionResponse(value) => {
-                super::AgentResponse::LoadSessionResponse(value.into_v2()?)
+                super::AgentResponse::LoadSessionResponse(Box::new(value.into_v2()?))
             }
             Self::ListSessionsResponse(value) => {
-                super::AgentResponse::ListSessionsResponse(value.into_v2()?)
+                super::AgentResponse::ListSessionsResponse(Box::new(value.into_v2()?))
             }
             Self::DeleteSessionResponse(value) => {
-                super::AgentResponse::DeleteSessionResponse(value.into_v2()?)
+                super::AgentResponse::DeleteSessionResponse(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_session_fork")]
             Self::ForkSessionResponse(value) => {
-                super::AgentResponse::ForkSessionResponse(value.into_v2()?)
+                super::AgentResponse::ForkSessionResponse(Box::new(value.into_v2()?))
             }
             Self::ResumeSessionResponse(value) => {
-                super::AgentResponse::ResumeSessionResponse(value.into_v2()?)
+                super::AgentResponse::ResumeSessionResponse(Box::new(value.into_v2()?))
             }
             Self::CloseSessionResponse(value) => {
-                super::AgentResponse::CloseSessionResponse(value.into_v2()?)
+                super::AgentResponse::CloseSessionResponse(Box::new(value.into_v2()?))
             }
             Self::SetSessionModeResponse(_) => {
                 return Err(removed_v1_enum_variant("AgentResponse", "session/set_mode"));
             }
             Self::SetSessionConfigOptionResponse(value) => {
-                super::AgentResponse::SetSessionConfigOptionResponse(value.into_v2()?)
+                super::AgentResponse::SetSessionConfigOptionResponse(Box::new(value.into_v2()?))
             }
-            Self::PromptResponse(value) => super::AgentResponse::PromptResponse(value.into_v2()?),
+            Self::PromptResponse(value) => {
+                super::AgentResponse::PromptResponse(Box::new(value.into_v2()?))
+            }
             #[cfg(feature = "unstable_nes")]
             Self::StartNesResponse(value) => {
-                super::AgentResponse::StartNesResponse(value.into_v2()?)
+                super::AgentResponse::StartNesResponse(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_nes")]
             Self::SuggestNesResponse(value) => {
-                super::AgentResponse::SuggestNesResponse(value.into_v2()?)
+                super::AgentResponse::SuggestNesResponse(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_nes")]
             Self::CloseNesResponse(value) => {
-                super::AgentResponse::CloseNesResponse(value.into_v2()?)
+                super::AgentResponse::CloseNesResponse(Box::new(value.into_v2()?))
             }
             Self::ExtMethodResponse(value) => {
-                super::AgentResponse::ExtMethodResponse(value.into_v2()?)
+                super::AgentResponse::ExtMethodResponse(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_mcp_over_acp")]
             Self::MessageMcpResponse(value) => {
-                super::AgentResponse::MessageMcpResponse(value.into_v2()?)
+                super::AgentResponse::MessageMcpResponse(Box::new(value.into_v2()?))
             }
         })
     }
@@ -5515,23 +5525,23 @@ impl IntoV2 for crate::v1::ClientNotification {
     fn into_v2(self) -> Result<Self::Output> {
         Ok(match self {
             Self::CancelNotification(value) => {
-                super::ClientNotification::CancelSessionNotification(value.into_v2()?)
+                super::ClientNotification::CancelSessionNotification(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_nes")]
             Self::DidOpenDocumentNotification(value) => {
-                super::ClientNotification::DidOpenDocumentNotification(value.into_v2()?)
+                super::ClientNotification::DidOpenDocumentNotification(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_nes")]
             Self::DidChangeDocumentNotification(value) => {
-                super::ClientNotification::DidChangeDocumentNotification(value.into_v2()?)
+                super::ClientNotification::DidChangeDocumentNotification(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_nes")]
             Self::DidCloseDocumentNotification(value) => {
-                super::ClientNotification::DidCloseDocumentNotification(value.into_v2()?)
+                super::ClientNotification::DidCloseDocumentNotification(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_nes")]
             Self::DidSaveDocumentNotification(value) => {
-                super::ClientNotification::DidSaveDocumentNotification(value.into_v2()?)
+                super::ClientNotification::DidSaveDocumentNotification(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_nes")]
             Self::DidFocusDocumentNotification(value) => {
@@ -5539,18 +5549,18 @@ impl IntoV2 for crate::v1::ClientNotification {
             }
             #[cfg(feature = "unstable_nes")]
             Self::AcceptNesNotification(value) => {
-                super::ClientNotification::AcceptNesNotification(value.into_v2()?)
+                super::ClientNotification::AcceptNesNotification(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_nes")]
             Self::RejectNesNotification(value) => {
-                super::ClientNotification::RejectNesNotification(value.into_v2()?)
+                super::ClientNotification::RejectNesNotification(Box::new(value.into_v2()?))
             }
             #[cfg(feature = "unstable_mcp_over_acp")]
             Self::MessageMcpNotification(value) => {
-                super::ClientNotification::MessageMcpNotification(value.into_v2()?)
+                super::ClientNotification::MessageMcpNotification(Box::new(value.into_v2()?))
             }
             Self::ExtNotification(value) => {
-                super::ClientNotification::ExtNotification(value.into_v2()?)
+                super::ClientNotification::ExtNotification(Box::new(value.into_v2()?))
             }
         })
     }

--- a/agent-client-protocol-schema/src/v2/elicitation.rs
+++ b/agent-client-protocol-schema/src/v2/elicitation.rs
@@ -1897,12 +1897,12 @@ mod tests {
     fn client_response_serialization_accept() {
         use crate::v2::ClientResponse;
 
-        let resp = ClientResponse::CreateElicitationResponse(CreateElicitationResponse::new(
-            ElicitationAction::Accept(ElicitationAcceptAction::new().content(BTreeMap::from([(
-                "name".to_string(),
-                ElicitationContentValue::from("Alice"),
-            )]))),
-        ));
+        let resp =
+            ClientResponse::CreateElicitationResponse(Box::new(CreateElicitationResponse::new(
+                ElicitationAction::Accept(ElicitationAcceptAction::new().content(BTreeMap::from(
+                    [("name".to_string(), ElicitationContentValue::from("Alice"))],
+                ))),
+            )));
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["action"], "accept");
         assert_eq!(json["content"]["name"], "Alice");
@@ -1916,8 +1916,8 @@ mod tests {
     fn client_response_serialization_decline() {
         use crate::v2::ClientResponse;
 
-        let resp = ClientResponse::CreateElicitationResponse(CreateElicitationResponse::new(
-            ElicitationAction::Decline,
+        let resp = ClientResponse::CreateElicitationResponse(Box::new(
+            CreateElicitationResponse::new(ElicitationAction::Decline),
         ));
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["action"], "decline");
@@ -1930,8 +1930,8 @@ mod tests {
     fn client_response_serialization_cancel() {
         use crate::v2::ClientResponse;
 
-        let resp = ClientResponse::CreateElicitationResponse(CreateElicitationResponse::new(
-            ElicitationAction::Cancel,
+        let resp = ClientResponse::CreateElicitationResponse(Box::new(
+            CreateElicitationResponse::new(ElicitationAction::Cancel),
         ));
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["action"], "cancel");


### PR DESCRIPTION
Avoids a breaking change for a future clippy warning.
Given this is mostly just for generation I think this is ok.
