### PR TITLE
docs(schema): Clean up generated documentation and make wording more consistent

### DIFF
--- a/agent-client-protocol-schema/src/v1/agent.rs
+++ b/agent-client-protocol-schema/src/v1/agent.rs
@@ -460,7 +460,8 @@ impl LogoutResponse {
 pub struct AgentAuthCapabilities {
     /// Whether the agent supports the logout method.
     ///
-    /// By supplying `{}` it means that the agent supports the logout method.
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports the logout method.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
@@ -505,7 +506,7 @@ impl AgentAuthCapabilities {
 
 /// Logout capabilities supported by the agent.
 ///
-/// By supplying `{}` it means that the agent supports the logout method.
+/// Supplying `{}` means the agent supports the logout method.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -4041,7 +4042,8 @@ pub struct AgentCapabilities {
     ///
     /// Provider configuration capabilities supported by the agent.
     ///
-    /// By supplying `{}` it means that the agent supports provider configuration methods.
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports provider configuration methods.
     #[cfg(feature = "unstable_llm_providers")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
@@ -4052,6 +4054,9 @@ pub struct AgentCapabilities {
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// NES (Next Edit Suggestions) capabilities supported by the agent.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support
+    /// for NES methods.
     #[cfg(feature = "unstable_nes")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
@@ -4176,7 +4181,7 @@ impl AgentCapabilities {
 ///
 /// Provider configuration capabilities supported by the agent.
 ///
-/// By supplying `{}` it means that the agent supports provider configuration methods.
+/// Supplying `{}` means the agent supports provider configuration methods.
 #[cfg(feature = "unstable_llm_providers")]
 #[serde_as]
 #[skip_serializing_none]
@@ -4231,6 +4236,9 @@ impl ProvidersCapabilities {
 #[non_exhaustive]
 pub struct SessionCapabilities {
     /// Whether the agent supports `session/list`.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports listing sessions.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
@@ -4245,6 +4253,10 @@ pub struct SessionCapabilities {
     pub delete: Option<SessionDeleteCapabilities>,
     /// Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
     ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports `additionalDirectories` on
+    /// supported session lifecycle requests.
+    ///
     /// Agents that also support `session/list` may return
     /// `SessionInfo.additionalDirectories` to report the complete ordered
     /// additional-root list associated with a listed session.
@@ -4257,17 +4269,26 @@ pub struct SessionCapabilities {
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// Whether the agent supports `session/fork`.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports forking sessions.
     #[cfg(feature = "unstable_session_fork")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
     pub fork: Option<SessionForkCapabilities>,
     /// Whether the agent supports `session/resume`.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports resuming sessions.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
     pub resume: Option<SessionResumeCapabilities>,
     /// Whether the agent supports `session/close`.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports closing sessions.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
@@ -4292,6 +4313,9 @@ impl SessionCapabilities {
     }
 
     /// Whether the agent supports `session/list`.
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports listing sessions.
     #[must_use]
     pub fn list(mut self, list: impl IntoOption<SessionListCapabilities>) -> Self {
         self.list = list.into_option();
@@ -4310,6 +4334,10 @@ impl SessionCapabilities {
 
     /// Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
     ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports `additionalDirectories` on
+    /// supported session lifecycle requests.
+    ///
     /// Agents that also support `session/list` may return
     /// `SessionInfo.additionalDirectories` to report the complete ordered
     /// additional-root list associated with a listed session.
@@ -4324,6 +4352,9 @@ impl SessionCapabilities {
 
     #[cfg(feature = "unstable_session_fork")]
     /// Whether the agent supports `session/fork`.
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports forking sessions.
     #[must_use]
     pub fn fork(mut self, fork: impl IntoOption<SessionForkCapabilities>) -> Self {
         self.fork = fork.into_option();
@@ -4331,6 +4362,9 @@ impl SessionCapabilities {
     }
 
     /// Whether the agent supports `session/resume`.
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports resuming sessions.
     #[must_use]
     pub fn resume(mut self, resume: impl IntoOption<SessionResumeCapabilities>) -> Self {
         self.resume = resume.into_option();
@@ -4338,6 +4372,9 @@ impl SessionCapabilities {
     }
 
     /// Whether the agent supports `session/close`.
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports closing sessions.
     #[must_use]
     pub fn close(mut self, close: impl IntoOption<SessionCloseCapabilities>) -> Self {
         self.close = close.into_option();
@@ -4358,7 +4395,7 @@ impl SessionCapabilities {
 
 /// Capabilities for the `session/list` method.
 ///
-/// By supplying `{}` it means that the agent supports listing of sessions.
+/// Supplying `{}` means the agent supports listing sessions.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -4436,8 +4473,8 @@ impl SessionDeleteCapabilities {
 
 /// Capabilities for additional session directories support.
 ///
-/// By supplying `{}` it means that the agent supports the `additionalDirectories`
-/// field on supported session lifecycle requests. Agents that also support
+/// Supplying `{}` means the agent supports the `additionalDirectories` field on
+/// supported session lifecycle requests. Agents that also support
 /// `session/list` may return `SessionInfo.additionalDirectories` to report the
 /// complete ordered additional-root list associated with a listed session.
 #[serde_as]
@@ -4482,7 +4519,7 @@ impl SessionAdditionalDirectoriesCapabilities {
 ///
 /// Capabilities for the `session/fork` method.
 ///
-/// By supplying `{}` it means that the agent supports forking of sessions.
+/// Supplying `{}` means the agent supports forking sessions.
 #[cfg(feature = "unstable_session_fork")]
 #[serde_as]
 #[skip_serializing_none]
@@ -4523,7 +4560,7 @@ impl SessionForkCapabilities {
 
 /// Capabilities for the `session/resume` method.
 ///
-/// By supplying `{}` it means that the agent supports resuming of sessions.
+/// Supplying `{}` means the agent supports resuming sessions.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -4562,7 +4599,7 @@ impl SessionResumeCapabilities {
 
 /// Capabilities for the `session/close` method.
 ///
-/// By supplying `{}` it means that the agent supports closing of sessions.
+/// Supplying `{}` means the agent supports closing sessions.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]

--- a/agent-client-protocol-schema/src/v1/agent.rs
+++ b/agent-client-protocol-schema/src/v1/agent.rs
@@ -1172,7 +1172,7 @@ pub struct LoadSessionRequest {
     #[serde_as(deserialize_as = "DefaultOnError<VecSkipError<_, SkipListener>>")]
     #[schemars(extend("x-deserialize-default-on-error" = true, "x-deserialize-skip-invalid-items" = true))]
     pub mcp_servers: Vec<McpServer>,
-    /// The working directory for this session.
+    /// The working directory for this session. Must be an absolute path.
     pub cwd: PathBuf,
     /// Additional workspace roots to activate for this session. Each path must be absolute.
     ///
@@ -1329,7 +1329,7 @@ impl LoadSessionResponse {
 pub struct ForkSessionRequest {
     /// The ID of the session to fork.
     pub session_id: SessionId,
-    /// The working directory for this session.
+    /// The working directory for this session. Must be an absolute path.
     pub cwd: PathBuf,
     /// Additional workspace roots to activate for this session. Each path must be absolute.
     ///
@@ -1497,7 +1497,7 @@ impl ForkSessionResponse {
 pub struct ResumeSessionRequest {
     /// The ID of the session to resume.
     pub session_id: SessionId,
-    /// The working directory for this session.
+    /// The working directory for this session. Must be an absolute path.
     pub cwd: PathBuf,
     /// Additional workspace roots to activate for this session. Each path must be absolute.
     ///
@@ -3094,7 +3094,7 @@ impl McpServerAcp {
 pub struct McpServerStdio {
     /// Human-readable name identifying this MCP server.
     pub name: String,
-    /// Path to the MCP server executable.
+    /// Absolute path to the MCP server executable.
     pub command: PathBuf,
     /// Command-line arguments to pass to the MCP server.
     #[serde_as(deserialize_as = "DefaultOnError<VecSkipError<_, SkipListener>>")]

--- a/agent-client-protocol-schema/src/v1/client.rs
+++ b/agent-client-protocol-schema/src/v1/client.rs
@@ -1148,7 +1148,7 @@ pub struct CreateTerminalRequest {
     #[schemars(extend("x-deserialize-default-on-error" = true, "x-deserialize-skip-invalid-items" = true))]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub env: Vec<EnvVariable>,
-    /// Working directory for the command (absolute path).
+    /// Working directory for the command. Must be an absolute path.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
@@ -1206,7 +1206,7 @@ impl CreateTerminalRequest {
         self
     }
 
-    /// Working directory for the command (absolute path).
+    /// Working directory for the command. Must be an absolute path.
     #[must_use]
     pub fn cwd(mut self, cwd: impl IntoOption<PathBuf>) -> Self {
         self.cwd = cwd.into_option();

--- a/agent-client-protocol-schema/src/v1/client.rs
+++ b/agent-client-protocol-schema/src/v1/client.rs
@@ -1746,6 +1746,9 @@ pub struct ClientCapabilities {
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// Session-related capabilities supported by the client.
+    ///
+    /// Optional. Omitted or `null` both mean the client does not advertise any
+    /// session-related extensions.
     #[cfg(feature = "unstable_boolean_config")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
@@ -1757,7 +1760,7 @@ pub struct ClientCapabilities {
     ///
     /// Whether the client supports `plan_update` and `plan_removed` session updates.
     ///
-    /// Optional. Omitted means the client does not advertise support.
+    /// Optional. Omitted or `null` both mean the client does not advertise support.
     /// Supplying `{}` means the client can receive both update types.
     #[cfg(feature = "unstable_plan_operations")]
     #[serde_as(deserialize_as = "DefaultOnError")]
@@ -1782,6 +1785,9 @@ pub struct ClientCapabilities {
     ///
     /// Elicitation capabilities supported by the client.
     /// Determines which elicitation modes the agent may use.
+    ///
+    /// Optional. Omitted or `null` both mean the client does not advertise
+    /// elicitation support.
     #[cfg(feature = "unstable_elicitation")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
@@ -1792,6 +1798,9 @@ pub struct ClientCapabilities {
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// NES (Next Edit Suggestions) capabilities supported by the client.
+    ///
+    /// Optional. Omitted or `null` both mean the client does not advertise any
+    /// NES suggestion-kind extensions.
     #[cfg(feature = "unstable_nes")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
@@ -1860,7 +1869,7 @@ impl ClientCapabilities {
     ///
     /// Whether the client supports `plan_update` and `plan_removed` session updates.
     ///
-    /// Omitted means the client does not advertise support.
+    /// Omitted or `null` both mean the client does not advertise support.
     /// Supplying `{}` means the client can receive both update types.
     #[cfg(feature = "unstable_plan_operations")]
     #[must_use]
@@ -1942,7 +1951,7 @@ impl ClientCapabilities {
 pub struct ClientSessionCapabilities {
     /// Config option capabilities supported by the client.
     ///
-    /// Omitted or `null` means the client does not advertise support for any
+    /// Omitted or `null` both mean the client does not advertise support for any
     /// config option extensions.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
@@ -1970,7 +1979,7 @@ impl ClientSessionCapabilities {
 
     /// Config option capabilities supported by the client.
     ///
-    /// Omitted or `null` means the client does not advertise support for any
+    /// Omitted or `null` both mean the client does not advertise support for any
     /// config option extensions.
     #[must_use]
     pub fn config_options(
@@ -2007,7 +2016,7 @@ impl ClientSessionCapabilities {
 pub struct SessionConfigOptionsCapabilities {
     /// Whether the client supports boolean session configuration options.
     ///
-    /// Omitted or `null` means the client does not advertise support.
+    /// Optional. Omitted or `null` both mean the client does not advertise support.
     /// Supplying `{}` means agents may include `type: "boolean"` entries in
     /// `configOptions`, and the client may send `session/set_config_option`
     /// requests with `type: "boolean"` and a boolean `value`.
@@ -2037,7 +2046,7 @@ impl SessionConfigOptionsCapabilities {
 
     /// Whether the client supports boolean session configuration options.
     ///
-    /// Omitted or `null` means the client does not advertise support.
+    /// Omitted or `null` both mean the client does not advertise support.
     /// Supplying `{}` means agents may include `type: "boolean"` entries in
     /// `configOptions`, and the client may send `session/set_config_option`
     /// requests with `type: "boolean"` and a boolean `value`.

--- a/agent-client-protocol-schema/src/v1/elicitation.rs
+++ b/agent-client-protocol-schema/src/v1/elicitation.rs
@@ -1049,11 +1049,17 @@ impl ElicitationSchema {
 #[non_exhaustive]
 pub struct ElicitationCapabilities {
     /// Whether the client supports form-based elicitation.
+    ///
+    /// Optional. Omitted or `null` both mean the client does not advertise support.
+    /// Supplying `{}` means the client supports form-based elicitation.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
     pub form: Option<ElicitationFormCapabilities>,
     /// Whether the client supports URL-based elicitation.
+    ///
+    /// Optional. Omitted or `null` both mean the client does not advertise support.
+    /// Supplying `{}` means the client supports URL-based elicitation.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
@@ -1078,6 +1084,9 @@ impl ElicitationCapabilities {
     }
 
     /// Whether the client supports form-based elicitation.
+    ///
+    /// Omitted or `null` both mean the client does not advertise support.
+    /// Supplying `{}` means the client supports form-based elicitation.
     #[must_use]
     pub fn form(mut self, form: impl IntoOption<ElicitationFormCapabilities>) -> Self {
         self.form = form.into_option();
@@ -1085,6 +1094,9 @@ impl ElicitationCapabilities {
     }
 
     /// Whether the client supports URL-based elicitation.
+    ///
+    /// Omitted or `null` both mean the client does not advertise support.
+    /// Supplying `{}` means the client supports URL-based elicitation.
     #[must_use]
     pub fn url(mut self, url: impl IntoOption<ElicitationUrlCapabilities>) -> Self {
         self.url = url.into_option();
@@ -1108,6 +1120,8 @@ impl ElicitationCapabilities {
 /// This capability is not part of the spec yet, and may be removed or changed at any point.
 ///
 /// Form-based elicitation capabilities.
+///
+/// Supplying `{}` means the client supports form-based elicitation.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -1150,6 +1164,8 @@ impl ElicitationFormCapabilities {
 /// This capability is not part of the spec yet, and may be removed or changed at any point.
 ///
 /// URL-based elicitation capabilities.
+///
+/// Supplying `{}` means the client supports URL-based elicitation.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]

--- a/agent-client-protocol-schema/src/v1/tool_call.rs
+++ b/agent-client-protocol-schema/src/v1/tool_call.rs
@@ -625,7 +625,7 @@ impl Terminal {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Diff {
-    /// The file path being modified.
+    /// The absolute file path being modified.
     pub path: PathBuf,
     /// The original content (None for new files).
     #[serde_as(deserialize_as = "DefaultOnError")]
@@ -689,7 +689,7 @@ impl Diff {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ToolCallLocation {
-    /// The file path being accessed or modified.
+    /// The absolute file path being accessed or modified.
     pub path: PathBuf,
     /// Optional line number within the file.
     #[serde_as(deserialize_as = "DefaultOnError")]

--- a/agent-client-protocol-schema/src/v2/agent.rs
+++ b/agent-client-protocol-schema/src/v2/agent.rs
@@ -1230,7 +1230,7 @@ impl NewSessionResponse {
 pub struct LoadSessionRequest {
     /// The ID of the session to load.
     pub session_id: SessionId,
-    /// The working directory for this session.
+    /// The working directory for this session. Must be an absolute path.
     pub cwd: PathBuf,
     /// Additional workspace roots to activate for this session. Each path must be absolute.
     ///
@@ -1371,7 +1371,7 @@ impl LoadSessionResponse {
 pub struct ForkSessionRequest {
     /// The ID of the session to fork.
     pub session_id: SessionId,
-    /// The working directory for this session.
+    /// The working directory for this session. Must be an absolute path.
     pub cwd: PathBuf,
     /// Additional workspace roots to activate for this session. Each path must be absolute.
     ///
@@ -1519,7 +1519,7 @@ impl ForkSessionResponse {
 pub struct ResumeSessionRequest {
     /// The ID of the session to resume.
     pub session_id: SessionId,
-    /// The working directory for this session.
+    /// The working directory for this session. Must be an absolute path.
     pub cwd: PathBuf,
     /// Additional workspace roots to activate for this session. Each path must be absolute.
     ///
@@ -3130,7 +3130,7 @@ impl McpServerAcp {
 pub struct McpServerStdio {
     /// Human-readable name identifying this MCP server.
     pub name: String,
-    /// Path to the MCP server executable.
+    /// Absolute path to the MCP server executable.
     pub command: PathBuf,
     /// Command-line arguments to pass to the MCP server.
     #[serde_as(deserialize_as = "DefaultOnError<VecSkipError<_, SkipListener>>")]

--- a/agent-client-protocol-schema/src/v2/agent.rs
+++ b/agent-client-protocol-schema/src/v2/agent.rs
@@ -4041,6 +4041,9 @@ pub struct AgentCapabilities {
     #[serde(default)]
     pub session: Option<SessionCapabilities>,
     /// Authentication-related capabilities supported by the agent.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise any
+    /// authentication-related extensions.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
@@ -4051,7 +4054,8 @@ pub struct AgentCapabilities {
     ///
     /// Provider configuration capabilities supported by the agent.
     ///
-    /// By supplying `{}` it means that the agent supports provider configuration methods.
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports provider configuration methods.
     #[cfg(feature = "unstable_llm_providers")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
@@ -4062,6 +4066,9 @@ pub struct AgentCapabilities {
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// NES (Next Edit Suggestions) capabilities supported by the agent.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support
+    /// for NES methods.
     #[cfg(feature = "unstable_nes")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
@@ -4170,7 +4177,7 @@ impl AgentCapabilities {
 ///
 /// Provider configuration capabilities supported by the agent.
 ///
-/// By supplying `{}` it means that the agent supports provider configuration methods.
+/// Supplying `{}` means the agent supports provider configuration methods.
 #[cfg(feature = "unstable_llm_providers")]
 #[serde_as]
 #[skip_serializing_none]
@@ -4251,6 +4258,9 @@ pub struct SessionCapabilities {
     #[serde(default)]
     pub load: Option<SessionLoadCapabilities>,
     /// Whether the agent supports `session/list`.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports listing sessions.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
@@ -4265,6 +4275,10 @@ pub struct SessionCapabilities {
     pub delete: Option<SessionDeleteCapabilities>,
     /// Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
     ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports `additionalDirectories` on
+    /// supported session lifecycle requests.
+    ///
     /// Agents that also support `session/list` may return
     /// `SessionInfo.additionalDirectories` to report the complete ordered
     /// additional-root list associated with a listed session.
@@ -4277,17 +4291,26 @@ pub struct SessionCapabilities {
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// Whether the agent supports `session/fork`.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports forking sessions.
     #[cfg(feature = "unstable_session_fork")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
     pub fork: Option<SessionForkCapabilities>,
     /// Whether the agent supports `session/resume`.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports resuming sessions.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
     pub resume: Option<SessionResumeCapabilities>,
     /// Whether the agent supports `session/close`.
+    ///
+    /// Optional. Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports closing sessions.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
@@ -4343,6 +4366,9 @@ impl SessionCapabilities {
     }
 
     /// Whether the agent supports `session/list`.
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports listing sessions.
     #[must_use]
     pub fn list(mut self, list: impl IntoOption<SessionListCapabilities>) -> Self {
         self.list = list.into_option();
@@ -4361,6 +4387,10 @@ impl SessionCapabilities {
 
     /// Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
     ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports `additionalDirectories` on
+    /// supported session lifecycle requests.
+    ///
     /// Agents that also support `session/list` may return
     /// `SessionInfo.additionalDirectories` to report the complete ordered
     /// additional-root list associated with a listed session.
@@ -4375,6 +4405,9 @@ impl SessionCapabilities {
 
     #[cfg(feature = "unstable_session_fork")]
     /// Whether the agent supports `session/fork`.
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports forking sessions.
     #[must_use]
     pub fn fork(mut self, fork: impl IntoOption<SessionForkCapabilities>) -> Self {
         self.fork = fork.into_option();
@@ -4382,6 +4415,9 @@ impl SessionCapabilities {
     }
 
     /// Whether the agent supports `session/resume`.
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports resuming sessions.
     #[must_use]
     pub fn resume(mut self, resume: impl IntoOption<SessionResumeCapabilities>) -> Self {
         self.resume = resume.into_option();
@@ -4389,6 +4425,9 @@ impl SessionCapabilities {
     }
 
     /// Whether the agent supports `session/close`.
+    ///
+    /// Omitted or `null` both mean the agent does not advertise support.
+    /// Supplying `{}` means the agent supports closing sessions.
     #[must_use]
     pub fn close(mut self, close: impl IntoOption<SessionCloseCapabilities>) -> Self {
         self.close = close.into_option();
@@ -4448,7 +4487,7 @@ impl SessionLoadCapabilities {
 
 /// Capabilities for the `session/list` method.
 ///
-/// By supplying `{}` it means that the agent supports listing of sessions.
+/// Supplying `{}` means the agent supports listing sessions.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -4526,8 +4565,8 @@ impl SessionDeleteCapabilities {
 
 /// Capabilities for additional session directories support.
 ///
-/// By supplying `{}` it means that the agent supports the `additionalDirectories`
-/// field on supported session lifecycle requests. Agents that also support
+/// Supplying `{}` means the agent supports the `additionalDirectories` field on
+/// supported session lifecycle requests. Agents that also support
 /// `session/list` may return `SessionInfo.additionalDirectories` to report the
 /// complete ordered additional-root list associated with a listed session.
 #[serde_as]
@@ -4572,7 +4611,7 @@ impl SessionAdditionalDirectoriesCapabilities {
 ///
 /// Capabilities for the `session/fork` method.
 ///
-/// By supplying `{}` it means that the agent supports forking of sessions.
+/// Supplying `{}` means the agent supports forking sessions.
 #[cfg(feature = "unstable_session_fork")]
 #[serde_as]
 #[skip_serializing_none]
@@ -4613,7 +4652,7 @@ impl SessionForkCapabilities {
 
 /// Capabilities for the `session/resume` method.
 ///
-/// By supplying `{}` it means that the agent supports resuming of sessions.
+/// Supplying `{}` means the agent supports resuming sessions.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -4652,7 +4691,7 @@ impl SessionResumeCapabilities {
 
 /// Capabilities for the `session/close` method.
 ///
-/// By supplying `{}` it means that the agent supports closing of sessions.
+/// Supplying `{}` means the agent supports closing sessions.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]

--- a/agent-client-protocol-schema/src/v2/client.rs
+++ b/agent-client-protocol-schema/src/v2/client.rs
@@ -1542,6 +1542,9 @@ pub struct ClientCapabilities {
     /// Authentication capabilities supported by the client.
     /// Determines which authentication method types the agent may include
     /// in its `InitializeResponse`.
+    ///
+    /// Optional. Omitted or `null` both mean the client does not advertise any
+    /// authentication-method extensions.
     #[cfg(feature = "unstable_auth_methods")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
@@ -1553,6 +1556,9 @@ pub struct ClientCapabilities {
     ///
     /// Elicitation capabilities supported by the client.
     /// Determines which elicitation modes the agent may use.
+    ///
+    /// Optional. Omitted or `null` both mean the client does not advertise
+    /// elicitation support.
     #[cfg(feature = "unstable_elicitation")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
@@ -1563,6 +1569,9 @@ pub struct ClientCapabilities {
     /// This capability is not part of the spec yet, and may be removed or changed at any point.
     ///
     /// NES (Next Edit Suggestions) capabilities supported by the client.
+    ///
+    /// Optional. Omitted or `null` both mean the client does not advertise any
+    /// NES suggestion-kind extensions.
     #[cfg(feature = "unstable_nes")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]

--- a/agent-client-protocol-schema/src/v2/elicitation.rs
+++ b/agent-client-protocol-schema/src/v2/elicitation.rs
@@ -1048,11 +1048,17 @@ impl ElicitationSchema {
 #[non_exhaustive]
 pub struct ElicitationCapabilities {
     /// Whether the client supports form-based elicitation.
+    ///
+    /// Optional. Omitted or `null` both mean the client does not advertise support.
+    /// Supplying `{}` means the client supports form-based elicitation.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
     pub form: Option<ElicitationFormCapabilities>,
     /// Whether the client supports URL-based elicitation.
+    ///
+    /// Optional. Omitted or `null` both mean the client does not advertise support.
+    /// Supplying `{}` means the client supports URL-based elicitation.
     #[serde_as(deserialize_as = "DefaultOnError")]
     #[schemars(extend("x-deserialize-default-on-error" = true))]
     #[serde(default)]
@@ -1077,6 +1083,9 @@ impl ElicitationCapabilities {
     }
 
     /// Whether the client supports form-based elicitation.
+    ///
+    /// Omitted or `null` both mean the client does not advertise support.
+    /// Supplying `{}` means the client supports form-based elicitation.
     #[must_use]
     pub fn form(mut self, form: impl IntoOption<ElicitationFormCapabilities>) -> Self {
         self.form = form.into_option();
@@ -1084,6 +1093,9 @@ impl ElicitationCapabilities {
     }
 
     /// Whether the client supports URL-based elicitation.
+    ///
+    /// Omitted or `null` both mean the client does not advertise support.
+    /// Supplying `{}` means the client supports URL-based elicitation.
     #[must_use]
     pub fn url(mut self, url: impl IntoOption<ElicitationUrlCapabilities>) -> Self {
         self.url = url.into_option();
@@ -1107,6 +1119,8 @@ impl ElicitationCapabilities {
 /// This capability is not part of the spec yet, and may be removed or changed at any point.
 ///
 /// Form-based elicitation capabilities.
+///
+/// Supplying `{}` means the client supports form-based elicitation.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -1149,6 +1163,8 @@ impl ElicitationFormCapabilities {
 /// This capability is not part of the spec yet, and may be removed or changed at any point.
 ///
 /// URL-based elicitation capabilities.
+///
+/// Supplying `{}` means the client supports URL-based elicitation.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]

--- a/agent-client-protocol-schema/src/v2/tool_call.rs
+++ b/agent-client-protocol-schema/src/v2/tool_call.rs
@@ -490,7 +490,7 @@ impl Content {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Diff {
-    /// The file path being modified.
+    /// The absolute file path being modified.
     pub path: PathBuf,
     /// The original content (None for new files).
     #[serde_as(deserialize_as = "DefaultOnError")]
@@ -554,7 +554,7 @@ impl Diff {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ToolCallLocation {
-    /// The file path being accessed or modified.
+    /// The absolute file path being accessed or modified.
     pub path: PathBuf,
     /// Optional line number within the file.
     #[serde_as(deserialize_as = "DefaultOnError")]

--- a/docs/protocol/v1/draft/initialization.mdx
+++ b/docs/protocol/v1/draft/initialization.mdx
@@ -227,8 +227,8 @@ Optionally, they **MAY** support other session methods and notifications by spec
 
 <ResponseField name="delete" type="SessionDeleteCapabilities Object">
   The [`session/delete`](/protocol/v1/draft/session-delete) method is available.
-  Omitted or `null` means the Agent does not advertise support. Supplying `{}`
-  means the Agent supports deleting sessions from `session/list`.
+  Omitted or `null` both mean the Agent does not advertise support. Supplying an
+  empty object means the Agent supports deleting sessions from `session/list`.
 </ResponseField>
 
 <ResponseField
@@ -236,7 +236,7 @@ Optionally, they **MAY** support other session methods and notifications by spec
   type="SessionAdditionalDirectoriesCapabilities Object"
 >
   The Agent supports `additionalDirectories` on supported session lifecycle
-  requests. Omitted or `null` means the Agent does not advertise support.
+  requests. Omitted or `null` both mean the Agent does not advertise support.
   Supplying `{}` means the Agent supports additional workspace roots.
 </ResponseField>
 

--- a/docs/protocol/v1/draft/schema.mdx
+++ b/docs/protocol/v1/draft/schema.mdx
@@ -1065,7 +1065,7 @@ session.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>
-  The working directory for this session.
+  The working directory for this session. Must be an absolute path.
 </ResponseField>
 <ResponseField name="mcpServers" type={<a href="#mcpserver">McpServer[]</a>} >
   List of MCP servers to connect to for this session.
@@ -1210,7 +1210,7 @@ the request `cwd` matches the session's `cwd`.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>
-  The working directory for this session.
+  The working directory for this session. Must be an absolute path.
 </ResponseField>
 <ResponseField name="mcpServers" type={<a href="#mcpserver">McpServer[]</a>} required>
   List of MCP servers to connect to for this session.
@@ -1456,7 +1456,7 @@ the request `cwd` matches the session's `cwd`.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>
-  The working directory for this session.
+  The working directory for this session. Must be an absolute path.
 </ResponseField>
 <ResponseField name="mcpServers" type={<a href="#mcpserver">McpServer[]</a>} >
   List of MCP servers to connect to for this session.
@@ -2284,7 +2284,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
   The command to execute.
 </ResponseField>
 <ResponseField name="cwd" type={"string | null"} >
-  Working directory for the command (absolute path).
+  Working directory for the command. Must be an absolute path.
 </ResponseField>
 <ResponseField name="env" type={<a href="#envvariable">EnvVariable[]</a>} >
   Environment variables for the command.
@@ -3673,7 +3673,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
   The original content (None for new files).
 </ResponseField>
 <ResponseField name="path" type={"string"} required>
-  The file path being modified.
+  The absolute file path being modified.
 </ResponseField>
 
 ## <span class="font-mono">ElicitationAcceptAction</span>
@@ -4883,7 +4883,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
   Command-line arguments to pass to the MCP server.
 </ResponseField>
 <ResponseField name="command" type={"string"} required>
-  Path to the MCP server executable.
+  Absolute path to the MCP server executable.
 </ResponseField>
 <ResponseField name="env" type={<a href="#envvariable">EnvVariable[]</a>} required>
   Environment variables to set when launching the MCP server.
@@ -5015,7 +5015,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
   Command-line arguments to pass to the MCP server.
 </ResponseField>
 <ResponseField name="command" type={"string"} required>
-  Path to the MCP server executable.
+  Absolute path to the MCP server executable.
 </ResponseField>
 <ResponseField name="env" type={<a href="#envvariable">EnvVariable[]</a>} required>
   Environment variables to set when launching the MCP server.
@@ -8268,7 +8268,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
   The original content (None for new files).
 </ResponseField>
 <ResponseField name="path" type={"string"} required>
-  The file path being modified.
+  The absolute file path being modified.
 </ResponseField>
 <ResponseField name="type" type={"string"} required>
   The discriminator value. Must be `"diff"`.
@@ -8338,7 +8338,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
 
 </ResponseField>
 <ResponseField name="path" type={"string"} required>
-  The file path being accessed or modified.
+  The absolute file path being accessed or modified.
 </ResponseField>
 
 ## <span class="font-mono">ToolCallStatus</span>

--- a/docs/protocol/v1/draft/schema.mdx
+++ b/docs/protocol/v1/draft/schema.mdx
@@ -2623,7 +2623,8 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
 <ResponseField name="logout" type={<><span><a href="#logoutcapabilities">LogoutCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports the logout method.
 
-By supplying `\{\}` it means that the agent supports the logout method.
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports the logout method.
 
 </ResponseField>
 
@@ -2673,6 +2674,9 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 NES (Next Edit Suggestions) capabilities supported by the agent.
 
+Optional. Omitted or `null` both mean the agent does not advertise support
+for NES methods.
+
 </ResponseField>
 <ResponseField name="positionEncoding" type={<><span><a href="#positionencodingkind">PositionEncodingKind</a></span><span> | null</span></>} >
   **UNSTABLE**
@@ -2695,7 +2699,8 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 Provider configuration capabilities supported by the agent.
 
-By supplying `\{\}` it means that the agent supports provider configuration methods.
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports provider configuration methods.
 
 </ResponseField>
 <ResponseField name="sessionCapabilities" type={<a href="#sessioncapabilities">SessionCapabilities</a>} >
@@ -3243,6 +3248,9 @@ This capability is not part of the spec yet, and may be removed or changed at an
 Elicitation capabilities supported by the client.
 Determines which elicitation modes the agent may use.
 
+Optional. Omitted or `null` both mean the client does not advertise
+elicitation support.
+
 </ResponseField>
 <ResponseField name="fs" type={<a href="#filesystemcapabilities">FileSystemCapabilities</a>} >
   File system capabilities supported by the client.
@@ -3258,6 +3266,9 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 NES (Next Edit Suggestions) capabilities supported by the client.
 
+Optional. Omitted or `null` both mean the client does not advertise any
+NES suggestion-kind extensions.
+
 </ResponseField>
 <ResponseField name="plan" type={<><span><a href="#plancapabilities">PlanCapabilities</a></span><span> | null</span></>} >
   **UNSTABLE**
@@ -3266,7 +3277,7 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 Whether the client supports `plan_update` and `plan_removed` session updates.
 
-Optional. Omitted means the client does not advertise support.
+Optional. Omitted or `null` both mean the client does not advertise support.
 Supplying `\{\}` means the client can receive both update types.
 
 </ResponseField>
@@ -3284,6 +3295,9 @@ The position encodings supported by the client, in order of preference.
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
 Session-related capabilities supported by the client.
+
+Optional. Omitted or `null` both mean the client does not advertise any
+session-related extensions.
 
 </ResponseField>
 <ResponseField name="terminal" type={"boolean"} >
@@ -3342,7 +3356,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
 <ResponseField name="configOptions" type={<><span><a href="#sessionconfigoptionscapabilities">SessionConfigOptionsCapabilities</a></span><span> | null</span></>} >
   Config option capabilities supported by the client.
 
-Omitted or `null` means the client does not advertise support for any
+Omitted or `null` both mean the client does not advertise support for any
 config option extensions.
 
 </ResponseField>
@@ -3714,9 +3728,17 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
 </ResponseField>
 <ResponseField name="form" type={<><span><a href="#elicitationformcapabilities">ElicitationFormCapabilities</a></span><span> | null</span></>} >
   Whether the client supports form-based elicitation.
+
+Optional. Omitted or `null` both mean the client does not advertise support.
+Supplying `\{\}` means the client supports form-based elicitation.
+
 </ResponseField>
 <ResponseField name="url" type={<><span><a href="#elicitationurlcapabilities">ElicitationUrlCapabilities</a></span><span> | null</span></>} >
   Whether the client supports URL-based elicitation.
+
+Optional. Omitted or `null` both mean the client does not advertise support.
+Supplying `\{\}` means the client supports URL-based elicitation.
+
 </ResponseField>
 
 ## <span class="font-mono">ElicitationContentValue</span>
@@ -3752,6 +3774,8 @@ Allowed wire representations for `ElicitationContentValue`.
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
 Form-based elicitation capabilities.
+
+Supplying `\{\}` means the client supports form-based elicitation.
 
 **Type:** Object
 
@@ -4176,6 +4200,8 @@ Items definition for untitled multi-select enum properties.
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
 URL-based elicitation capabilities.
+
+Supplying `\{\}` means the client supports URL-based elicitation.
 
 **Type:** Object
 
@@ -4690,7 +4716,7 @@ Protocol names that do not begin with `_` are reserved for the ACP spec.
 
 Logout capabilities supported by the agent.
 
-By supplying `\{\}` it means that the agent supports the logout method.
+Supplying `\{\}` means the agent supports the logout method.
 
 **Type:** Object
 
@@ -6730,7 +6756,7 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 Provider configuration capabilities supported by the agent.
 
-By supplying `\{\}` it means that the agent supports provider configuration methods.
+Supplying `\{\}` means the agent supports provider configuration methods.
 
 **Type:** Object
 
@@ -6917,8 +6943,8 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
 
 Capabilities for additional session directories support.
 
-By supplying `\{\}` it means that the agent supports the `additionalDirectories`
-field on supported session lifecycle requests. Agents that also support
+Supplying `\{\}` means the agent supports the `additionalDirectories` field on
+supported session lifecycle requests. Agents that also support
 `session/list` may return `SessionInfo.additionalDirectories` to report the
 complete ordered additional-root list associated with a listed session.
 
@@ -6962,6 +6988,10 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
 <ResponseField name="additionalDirectories" type={<><span><a href="#sessionadditionaldirectoriescapabilities">SessionAdditionalDirectoriesCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
 
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports `additionalDirectories` on
+supported session lifecycle requests.
+
 Agents that also support `session/list` may return
 `SessionInfo.additionalDirectories` to report the complete ordered
 additional-root list associated with a listed session.
@@ -6969,6 +6999,10 @@ additional-root list associated with a listed session.
 </ResponseField>
 <ResponseField name="close" type={<><span><a href="#sessionclosecapabilities">SessionCloseCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/close`.
+
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports closing sessions.
+
 </ResponseField>
 <ResponseField name="delete" type={<><span><a href="#sessiondeletecapabilities">SessionDeleteCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/delete`.
@@ -6984,19 +7018,30 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 Whether the agent supports `session/fork`.
 
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports forking sessions.
+
 </ResponseField>
 <ResponseField name="list" type={<><span><a href="#sessionlistcapabilities">SessionListCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/list`.
+
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports listing sessions.
+
 </ResponseField>
 <ResponseField name="resume" type={<><span><a href="#sessionresumecapabilities">SessionResumeCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/resume`.
+
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports resuming sessions.
+
 </ResponseField>
 
 ## <span class="font-mono">SessionCloseCapabilities</span>
 
 Capabilities for the `session/close` method.
 
-By supplying `\{\}` it means that the agent supports closing of sessions.
+Supplying `\{\}` means the agent supports closing sessions.
 
 **Type:** Object
 
@@ -7172,7 +7217,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
 <ResponseField name="boolean" type={<><span><a href="#booleanconfigoptioncapabilities">BooleanConfigOptionCapabilities</a></span><span> | null</span></>} >
   Whether the client supports boolean session configuration options.
 
-Omitted or `null` means the client does not advertise support.
+Optional. Omitted or `null` both mean the client does not advertise support.
 Supplying `\{\}` means agents may include `type: "boolean"` entries in
 `configOptions`, and the client may send `session/set_config_option`
 requests with `type: "boolean"` and a boolean `value`.
@@ -7301,7 +7346,7 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 Capabilities for the `session/fork` method.
 
-By supplying `\{\}` it means that the agent supports forking of sessions.
+Supplying `\{\}` means the agent supports forking sessions.
 
 **Type:** Object
 
@@ -7394,7 +7439,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
 
 Capabilities for the `session/list` method.
 
-By supplying `\{\}` it means that the agent supports listing of sessions.
+Supplying `\{\}` means the agent supports listing sessions.
 
 **Type:** Object
 
@@ -7470,7 +7515,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/d
 
 Capabilities for the `session/resume` method.
 
-By supplying `\{\}` it means that the agent supports resuming of sessions.
+Supplying `\{\}` means the agent supports resuming sessions.
 
 **Type:** Object
 

--- a/docs/protocol/v1/draft/session-delete.mdx
+++ b/docs/protocol/v1/draft/session-delete.mdx
@@ -82,7 +82,6 @@ On success, the Agent returns an empty result:
 
 ## Semantics
 
-- Agents **MUST NOT** accept `session/delete` calls unless they advertised `sessionCapabilities.delete` during initialization.
 - Deleted sessions no longer appear in future `session/list` results.
 - Deleting an already-deleted session, or a session that never existed, **SHOULD** succeed silently.
 - Agents may implement soft delete or hard delete. ACP only specifies the user-facing session-list behavior.

--- a/docs/protocol/v1/draft/terminals.mdx
+++ b/docs/protocol/v1/draft/terminals.mdx
@@ -72,7 +72,7 @@ Each variable has:
 </ParamField>
 
 <ParamField path="cwd" type="string">
-  Working directory for the command (absolute path)
+  Working directory for the command. Must be an absolute path.
 </ParamField>
 
 <ParamField path="outputByteLimit" type="number">

--- a/docs/protocol/v1/initialization.mdx
+++ b/docs/protocol/v1/initialization.mdx
@@ -207,8 +207,8 @@ Optionally, they **MAY** support other session methods and notifications by spec
 
 <ResponseField name="delete" type="SessionDeleteCapabilities Object">
   The [`session/delete`](/protocol/v1/session-delete) method is available.
-  Omitted or `null` means the Agent does not advertise support. Supplying `{}`
-  means the Agent supports deleting sessions from `session/list`.
+  Omitted or `null` both mean the Agent does not advertise support. Supplying an
+  empty object means the Agent supports deleting sessions from `session/list`.
 </ResponseField>
 
 <ResponseField
@@ -216,7 +216,7 @@ Optionally, they **MAY** support other session methods and notifications by spec
   type="SessionAdditionalDirectoriesCapabilities Object"
 >
   The Agent supports `additionalDirectories` on supported session lifecycle
-  requests. Omitted or `null` means the Agent does not advertise support.
+  requests. Omitted or `null` both mean the Agent does not advertise support.
   Supplying `{}` means the Agent supports additional workspace roots.
 </ResponseField>
 

--- a/docs/protocol/v1/schema.mdx
+++ b/docs/protocol/v1/schema.mdx
@@ -1443,7 +1443,8 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/e
 <ResponseField name="logout" type={<><span><a href="#logoutcapabilities">LogoutCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports the logout method.
 
-By supplying `\{\}` it means that the agent supports the logout method.
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports the logout method.
 
 </ResponseField>
 
@@ -2402,7 +2403,7 @@ for debugging or metrics purposes. (e.g. "1.0.0").
 
 Logout capabilities supported by the agent.
 
-By supplying `\{\}` it means that the agent supports the logout method.
+Supplying `\{\}` means the agent supports the logout method.
 
 **Type:** Object
 
@@ -3009,8 +3010,8 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/e
 
 Capabilities for additional session directories support.
 
-By supplying `\{\}` it means that the agent supports the `additionalDirectories`
-field on supported session lifecycle requests. Agents that also support
+Supplying `\{\}` means the agent supports the `additionalDirectories` field on
+supported session lifecycle requests. Agents that also support
 `session/list` may return `SessionInfo.additionalDirectories` to report the
 complete ordered additional-root list associated with a listed session.
 
@@ -3054,6 +3055,10 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/e
 <ResponseField name="additionalDirectories" type={<><span><a href="#sessionadditionaldirectoriescapabilities">SessionAdditionalDirectoriesCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
 
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports `additionalDirectories` on
+supported session lifecycle requests.
+
 Agents that also support `session/list` may return
 `SessionInfo.additionalDirectories` to report the complete ordered
 additional-root list associated with a listed session.
@@ -3061,6 +3066,10 @@ additional-root list associated with a listed session.
 </ResponseField>
 <ResponseField name="close" type={<><span><a href="#sessionclosecapabilities">SessionCloseCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/close`.
+
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports closing sessions.
+
 </ResponseField>
 <ResponseField name="delete" type={<><span><a href="#sessiondeletecapabilities">SessionDeleteCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/delete`.
@@ -3071,16 +3080,24 @@ Supplying `\{\}` means the agent supports deleting sessions from `session/list`.
 </ResponseField>
 <ResponseField name="list" type={<><span><a href="#sessionlistcapabilities">SessionListCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/list`.
+
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports listing sessions.
+
 </ResponseField>
 <ResponseField name="resume" type={<><span><a href="#sessionresumecapabilities">SessionResumeCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/resume`.
+
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports resuming sessions.
+
 </ResponseField>
 
 ## <span class="font-mono">SessionCloseCapabilities</span>
 
 Capabilities for the `session/close` method.
 
-By supplying `\{\}` it means that the agent supports closing of sessions.
+Supplying `\{\}` means the agent supports closing sessions.
 
 **Type:** Object
 
@@ -3361,7 +3378,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/e
 
 Capabilities for the `session/list` method.
 
-By supplying `\{\}` it means that the agent supports listing of sessions.
+Supplying `\{\}` means the agent supports listing sessions.
 
 **Type:** Object
 
@@ -3437,7 +3454,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/e
 
 Capabilities for the `session/resume` method.
 
-By supplying `\{\}` it means that the agent supports resuming of sessions.
+Supplying `\{\}` means the agent supports resuming sessions.
 
 **Type:** Object
 

--- a/docs/protocol/v1/schema.mdx
+++ b/docs/protocol/v1/schema.mdx
@@ -446,7 +446,7 @@ the request `cwd` matches the session's `cwd`.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>
-  The working directory for this session.
+  The working directory for this session. Must be an absolute path.
 </ResponseField>
 <ResponseField name="mcpServers" type={<a href="#mcpserver">McpServer[]</a>} required>
   List of MCP servers to connect to for this session.
@@ -684,7 +684,7 @@ the request `cwd` matches the session's `cwd`.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>
-  The working directory for this session.
+  The working directory for this session. Must be an absolute path.
 </ResponseField>
 <ResponseField name="mcpServers" type={<a href="#mcpserver">McpServer[]</a>} >
   List of MCP servers to connect to for this session.
@@ -1104,7 +1104,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/e
   The command to execute.
 </ResponseField>
 <ResponseField name="cwd" type={"string | null"} >
-  Working directory for the command (absolute path).
+  Working directory for the command. Must be an absolute path.
 </ResponseField>
 <ResponseField name="env" type={<a href="#envvariable">EnvVariable[]</a>} >
   Environment variables for the command.
@@ -2073,7 +2073,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/e
   The original content (None for new files).
 </ResponseField>
 <ResponseField name="path" type={"string"} required>
-  The file path being modified.
+  The absolute file path being modified.
 </ResponseField>
 
 ## <span class="font-mono">EmbeddedResource</span>
@@ -2538,7 +2538,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/e
   Command-line arguments to pass to the MCP server.
 </ResponseField>
 <ResponseField name="command" type={"string"} required>
-  Path to the MCP server executable.
+  Absolute path to the MCP server executable.
 </ResponseField>
 <ResponseField name="env" type={<a href="#envvariable">EnvVariable[]</a>} required>
   Environment variables to set when launching the MCP server.
@@ -2622,7 +2622,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/e
   Command-line arguments to pass to the MCP server.
 </ResponseField>
 <ResponseField name="command" type={"string"} required>
-  Path to the MCP server executable.
+  Absolute path to the MCP server executable.
 </ResponseField>
 <ResponseField name="env" type={<a href="#envvariable">EnvVariable[]</a>} required>
   Environment variables to set when launching the MCP server.
@@ -4046,7 +4046,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/e
   The original content (None for new files).
 </ResponseField>
 <ResponseField name="path" type={"string"} required>
-  The file path being modified.
+  The absolute file path being modified.
 </ResponseField>
 <ResponseField name="type" type={"string"} required>
   The discriminator value. Must be `"diff"`.
@@ -4116,7 +4116,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v1/e
 
 </ResponseField>
 <ResponseField name="path" type={"string"} required>
-  The file path being accessed or modified.
+  The absolute file path being accessed or modified.
 </ResponseField>
 
 ## <span class="font-mono">ToolCallStatus</span>

--- a/docs/protocol/v1/terminals.mdx
+++ b/docs/protocol/v1/terminals.mdx
@@ -72,7 +72,7 @@ Each variable has:
 </ParamField>
 
 <ParamField path="cwd" type="string">
-  Working directory for the command (absolute path)
+  Working directory for the command. Must be an absolute path.
 </ParamField>
 
 <ParamField path="outputByteLimit" type="number">

--- a/docs/protocol/v2/draft/initialization.mdx
+++ b/docs/protocol/v2/draft/initialization.mdx
@@ -148,20 +148,20 @@ Optionally, Agents **MAY** support prompt extensions, MCP server transports, and
 
 <ResponseField name="mcp" type="McpCapabilities Object">
   Object indicating the MCP server transports that may be included in session
-  lifecycle requests. Omitted or `null` means the Agent does not advertise MCP
-  server transport support for sessions.
+  lifecycle requests. Omitted or `null` both mean the Agent does not advertise
+  MCP server transport support for sessions.
 </ResponseField>
 
 <ResponseField name="load" type="SessionLoadCapabilities Object">
   The [`session/load`](/protocol/v2/draft/session-setup#loading-sessions) method
-  is available. Omitted or `null` means the Agent does not advertise support.
-  Supplying `{}` means the Agent supports loading sessions.
+  is available. Omitted or `null` both mean the Agent does not advertise
+  support. Supplying `{}` means the Agent supports loading sessions.
 </ResponseField>
 
 <ResponseField name="delete" type="SessionDeleteCapabilities Object">
   The [`session/delete`](/protocol/v2/draft/session-delete) method is available.
-  Omitted or `null` means the Agent does not advertise support. Supplying `{}`
-  means the Agent supports deleting sessions from `session/list`.
+  Omitted or `null` both mean the Agent does not advertise support. Supplying an
+  empty object means the Agent supports deleting sessions from `session/list`.
 </ResponseField>
 
 <ResponseField
@@ -169,7 +169,7 @@ Optionally, Agents **MAY** support prompt extensions, MCP server transports, and
   type="SessionAdditionalDirectoriesCapabilities Object"
 >
   The Agent supports `additionalDirectories` on supported session lifecycle
-  requests. Omitted or `null` means the Agent does not advertise support.
+  requests. Omitted or `null` both mean the Agent does not advertise support.
   Supplying `{}` means the Agent supports additional workspace roots.
 </ResponseField>
 

--- a/docs/protocol/v2/draft/schema.mdx
+++ b/docs/protocol/v2/draft/schema.mdx
@@ -1064,7 +1064,7 @@ session.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>
-  The working directory for this session.
+  The working directory for this session. Must be an absolute path.
 </ResponseField>
 <ResponseField name="mcpServers" type={<a href="#mcpserver">McpServer[]</a>} >
   List of MCP servers to connect to for this session.
@@ -1203,7 +1203,7 @@ the request `cwd` matches the session's `cwd`.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>
-  The working directory for this session.
+  The working directory for this session. Must be an absolute path.
 </ResponseField>
 <ResponseField name="mcpServers" type={<a href="#mcpserver">McpServer[]</a>} >
   List of MCP servers to connect to for this session.
@@ -1429,7 +1429,7 @@ the request `cwd` matches the session's `cwd`.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>
-  The working directory for this session.
+  The working directory for this session. Must be an absolute path.
 </ResponseField>
 <ResponseField name="mcpServers" type={<a href="#mcpserver">McpServer[]</a>} >
   List of MCP servers to connect to for this session.
@@ -3213,7 +3213,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
   The original content (None for new files).
 </ResponseField>
 <ResponseField name="path" type={"string"} required>
-  The file path being modified.
+  The absolute file path being modified.
 </ResponseField>
 
 ## <span class="font-mono">ElicitationAcceptAction</span>
@@ -4427,7 +4427,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
   Command-line arguments to pass to the MCP server.
 </ResponseField>
 <ResponseField name="command" type={"string"} required>
-  Path to the MCP server executable.
+  Absolute path to the MCP server executable.
 </ResponseField>
 <ResponseField name="env" type={<a href="#envvariable">EnvVariable[]</a>} required>
   Environment variables to set when launching the MCP server.
@@ -4561,7 +4561,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
   Command-line arguments to pass to the MCP server.
 </ResponseField>
 <ResponseField name="command" type={"string"} required>
-  Path to the MCP server executable.
+  Absolute path to the MCP server executable.
 </ResponseField>
 <ResponseField name="env" type={<a href="#envvariable">EnvVariable[]</a>} required>
   Environment variables to set when launching the MCP server.
@@ -8082,7 +8082,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
   The original content (None for new files).
 </ResponseField>
 <ResponseField name="path" type={"string"} required>
-  The file path being modified.
+  The absolute file path being modified.
 </ResponseField>
 <ResponseField name="type" type={"string"} required>
   The discriminator value. Must be `"diff"`.
@@ -8179,7 +8179,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 
 </ResponseField>
 <ResponseField name="path" type={"string"} required>
-  The file path being accessed or modified.
+  The absolute file path being accessed or modified.
 </ResponseField>
 
 ## <span class="font-mono">ToolCallStatus</span>

--- a/docs/protocol/v2/draft/schema.mdx
+++ b/docs/protocol/v2/draft/schema.mdx
@@ -2146,6 +2146,10 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 </ResponseField>
 <ResponseField name="auth" type={<><span><a href="#agentauthcapabilities">AgentAuthCapabilities</a></span><span> | null</span></>} >
   Authentication-related capabilities supported by the agent.
+
+Optional. Omitted or `null` both mean the agent does not advertise any
+authentication-related extensions.
+
 </ResponseField>
 <ResponseField name="nes" type={<><span><a href="#nescapabilities">NesCapabilities</a></span><span> | null</span></>} >
   **UNSTABLE**
@@ -2153,6 +2157,9 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
 NES (Next Edit Suggestions) capabilities supported by the agent.
+
+Optional. Omitted or `null` both mean the agent does not advertise support
+for NES methods.
 
 </ResponseField>
 <ResponseField name="positionEncoding" type={<><span><a href="#positionencodingkind">PositionEncodingKind</a></span><span> | null</span></>} >
@@ -2170,7 +2177,8 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 Provider configuration capabilities supported by the agent.
 
-By supplying `\{\}` it means that the agent supports provider configuration methods.
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports provider configuration methods.
 
 </ResponseField>
 <ResponseField name="session" type={<><span><a href="#sessioncapabilities">SessionCapabilities</a></span><span> | null</span></>} >
@@ -2830,6 +2838,9 @@ Authentication capabilities supported by the client.
 Determines which authentication method types the agent may include
 in its `InitializeResponse`.
 
+Optional. Omitted or `null` both mean the client does not advertise any
+authentication-method extensions.
+
 </ResponseField>
 <ResponseField name="elicitation" type={<><span><a href="#elicitationcapabilities">ElicitationCapabilities</a></span><span> | null</span></>} >
   **UNSTABLE**
@@ -2839,6 +2850,9 @@ This capability is not part of the spec yet, and may be removed or changed at an
 Elicitation capabilities supported by the client.
 Determines which elicitation modes the agent may use.
 
+Optional. Omitted or `null` both mean the client does not advertise
+elicitation support.
+
 </ResponseField>
 <ResponseField name="nes" type={<><span><a href="#clientnescapabilities">ClientNesCapabilities</a></span><span> | null</span></>} >
   **UNSTABLE**
@@ -2846,6 +2860,9 @@ Determines which elicitation modes the agent may use.
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
 NES (Next Edit Suggestions) capabilities supported by the client.
+
+Optional. Omitted or `null` both mean the client does not advertise any
+NES suggestion-kind extensions.
 
 </ResponseField>
 <ResponseField name="positionEncodings" type={<a href="#positionencodingkind">PositionEncodingKind[]</a>} >
@@ -3254,9 +3271,17 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 </ResponseField>
 <ResponseField name="form" type={<><span><a href="#elicitationformcapabilities">ElicitationFormCapabilities</a></span><span> | null</span></>} >
   Whether the client supports form-based elicitation.
+
+Optional. Omitted or `null` both mean the client does not advertise support.
+Supplying `\{\}` means the client supports form-based elicitation.
+
 </ResponseField>
 <ResponseField name="url" type={<><span><a href="#elicitationurlcapabilities">ElicitationUrlCapabilities</a></span><span> | null</span></>} >
   Whether the client supports URL-based elicitation.
+
+Optional. Omitted or `null` both mean the client does not advertise support.
+Supplying `\{\}` means the client supports URL-based elicitation.
+
 </ResponseField>
 
 ## <span class="font-mono">ElicitationContentValue</span>
@@ -3292,6 +3317,8 @@ Allowed wire representations for `ElicitationContentValue`.
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
 Form-based elicitation capabilities.
+
+Supplying `\{\}` means the client supports form-based elicitation.
 
 **Type:** Object
 
@@ -3716,6 +3743,8 @@ Items definition for untitled multi-select enum properties.
 This capability is not part of the spec yet, and may be removed or changed at any point.
 
 URL-based elicitation capabilities.
+
+Supplying `\{\}` means the client supports URL-based elicitation.
 
 **Type:** Object
 
@@ -6413,7 +6442,7 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 Provider configuration capabilities supported by the agent.
 
-By supplying `\{\}` it means that the agent supports provider configuration methods.
+Supplying `\{\}` means the agent supports provider configuration methods.
 
 **Type:** Object
 
@@ -6643,8 +6672,8 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 
 Capabilities for additional session directories support.
 
-By supplying `\{\}` it means that the agent supports the `additionalDirectories`
-field on supported session lifecycle requests. Agents that also support
+Supplying `\{\}` means the agent supports the `additionalDirectories` field on
+supported session lifecycle requests. Agents that also support
 `session/list` may return `SessionInfo.additionalDirectories` to report the
 complete ordered additional-root list associated with a listed session.
 
@@ -6689,6 +6718,10 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 <ResponseField name="additionalDirectories" type={<><span><a href="#sessionadditionaldirectoriescapabilities">SessionAdditionalDirectoriesCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
 
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports `additionalDirectories` on
+supported session lifecycle requests.
+
 Agents that also support `session/list` may return
 `SessionInfo.additionalDirectories` to report the complete ordered
 additional-root list associated with a listed session.
@@ -6696,6 +6729,10 @@ additional-root list associated with a listed session.
 </ResponseField>
 <ResponseField name="close" type={<><span><a href="#sessionclosecapabilities">SessionCloseCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/close`.
+
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports closing sessions.
+
 </ResponseField>
 <ResponseField name="delete" type={<><span><a href="#sessiondeletecapabilities">SessionDeleteCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/delete`.
@@ -6711,9 +6748,16 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 Whether the agent supports `session/fork`.
 
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports forking sessions.
+
 </ResponseField>
 <ResponseField name="list" type={<><span><a href="#sessionlistcapabilities">SessionListCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/list`.
+
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports listing sessions.
+
 </ResponseField>
 <ResponseField name="load" type={<><span><a href="#sessionloadcapabilities">SessionLoadCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/load`.
@@ -6739,13 +6783,17 @@ required by `session/prompt`.
 </ResponseField>
 <ResponseField name="resume" type={<><span><a href="#sessionresumecapabilities">SessionResumeCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/resume`.
+
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports resuming sessions.
+
 </ResponseField>
 
 ## <span class="font-mono">SessionCloseCapabilities</span>
 
 Capabilities for the `session/close` method.
 
-By supplying `\{\}` it means that the agent supports closing of sessions.
+Supplying `\{\}` means the agent supports closing sessions.
 
 **Type:** Object
 
@@ -7050,7 +7098,7 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 Capabilities for the `session/fork` method.
 
-By supplying `\{\}` it means that the agent supports forking of sessions.
+Supplying `\{\}` means the agent supports forking sessions.
 
 **Type:** Object
 
@@ -7143,7 +7191,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 
 Capabilities for the `session/list` method.
 
-By supplying `\{\}` it means that the agent supports listing of sessions.
+Supplying `\{\}` means the agent supports listing sessions.
 
 **Type:** Object
 
@@ -7181,7 +7229,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/d
 
 Capabilities for the `session/resume` method.
 
-By supplying `\{\}` it means that the agent supports resuming of sessions.
+Supplying `\{\}` means the agent supports resuming sessions.
 
 **Type:** Object
 

--- a/docs/protocol/v2/draft/session-delete.mdx
+++ b/docs/protocol/v2/draft/session-delete.mdx
@@ -82,7 +82,6 @@ On success, the Agent returns an empty result:
 
 ## Semantics
 
-- Agents **MUST NOT** accept `session/delete` calls unless they advertised `session.delete` during initialization.
 - Deleted sessions no longer appear in future `session/list` results.
 - Deleting an already-deleted session, or a session that never existed, **SHOULD** succeed silently.
 - Agents may implement soft delete or hard delete. ACP only specifies the user-facing session-list behavior.

--- a/docs/protocol/v2/initialization.mdx
+++ b/docs/protocol/v2/initialization.mdx
@@ -143,20 +143,20 @@ Optionally, Agents **MAY** support prompt extensions, MCP server transports, and
 
 <ResponseField name="mcp" type="McpCapabilities Object">
   Object indicating the MCP server transports that may be included in session
-  lifecycle requests. Omitted or `null` means the Agent does not advertise MCP
-  server transport support for sessions.
+  lifecycle requests. Omitted or `null` both mean the Agent does not advertise
+  MCP server transport support for sessions.
 </ResponseField>
 
 <ResponseField name="load" type="SessionLoadCapabilities Object">
   The [`session/load`](/protocol/v2/session-setup#loading-sessions) method is
-  available. Omitted or `null` means the Agent does not advertise support.
+  available. Omitted or `null` both mean the Agent does not advertise support.
   Supplying `{}` means the Agent supports loading sessions.
 </ResponseField>
 
 <ResponseField name="delete" type="SessionDeleteCapabilities Object">
   The [`session/delete`](/protocol/v2/session-delete) method is available.
-  Omitted or `null` means the Agent does not advertise support. Supplying `{}`
-  means the Agent supports deleting sessions from `session/list`.
+  Omitted or `null` both mean the Agent does not advertise support. Supplying an
+  empty object means the Agent supports deleting sessions from `session/list`.
 </ResponseField>
 
 <ResponseField
@@ -164,7 +164,7 @@ Optionally, Agents **MAY** support prompt extensions, MCP server transports, and
   type="SessionAdditionalDirectoriesCapabilities Object"
 >
   The Agent supports `additionalDirectories` on supported session lifecycle
-  requests. Omitted or `null` means the Agent does not advertise support.
+  requests. Omitted or `null` both mean the Agent does not advertise support.
   Supplying `{}` means the Agent supports additional workspace roots.
 </ResponseField>
 

--- a/docs/protocol/v2/schema.mdx
+++ b/docs/protocol/v2/schema.mdx
@@ -445,7 +445,7 @@ the request `cwd` matches the session's `cwd`.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>
-  The working directory for this session.
+  The working directory for this session. Must be an absolute path.
 </ResponseField>
 <ResponseField name="mcpServers" type={<a href="#mcpserver">McpServer[]</a>} >
   List of MCP servers to connect to for this session.
@@ -671,7 +671,7 @@ the request `cwd` matches the session's `cwd`.
 
 </ResponseField>
 <ResponseField name="cwd" type={"string"} required>
-  The working directory for this session.
+  The working directory for this session. Must be an absolute path.
 </ResponseField>
 <ResponseField name="mcpServers" type={<a href="#mcpserver">McpServer[]</a>} >
   List of MCP servers to connect to for this session.
@@ -1681,7 +1681,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
   The original content (None for new files).
 </ResponseField>
 <ResponseField name="path" type={"string"} required>
-  The file path being modified.
+  The absolute file path being modified.
 </ResponseField>
 
 ## <span class="font-mono">EmbeddedResource</span>
@@ -2110,7 +2110,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
   Command-line arguments to pass to the MCP server.
 </ResponseField>
 <ResponseField name="command" type={"string"} required>
-  Path to the MCP server executable.
+  Absolute path to the MCP server executable.
 </ResponseField>
 <ResponseField name="env" type={<a href="#envvariable">EnvVariable[]</a>} required>
   Environment variables to set when launching the MCP server.
@@ -2196,7 +2196,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
   Command-line arguments to pass to the MCP server.
 </ResponseField>
 <ResponseField name="command" type={"string"} required>
-  Path to the MCP server executable.
+  Absolute path to the MCP server executable.
 </ResponseField>
 <ResponseField name="env" type={<a href="#envvariable">EnvVariable[]</a>} required>
   Environment variables to set when launching the MCP server.
@@ -3988,7 +3988,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
   The original content (None for new files).
 </ResponseField>
 <ResponseField name="path" type={"string"} required>
-  The file path being modified.
+  The absolute file path being modified.
 </ResponseField>
 <ResponseField name="type" type={"string"} required>
   The discriminator value. Must be `"diff"`.
@@ -4085,7 +4085,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 
 </ResponseField>
 <ResponseField name="path" type={"string"} required>
-  The file path being accessed or modified.
+  The absolute file path being accessed or modified.
 </ResponseField>
 
 ## <span class="font-mono">ToolCallStatus</span>

--- a/docs/protocol/v2/schema.mdx
+++ b/docs/protocol/v2/schema.mdx
@@ -957,6 +957,10 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 </ResponseField>
 <ResponseField name="auth" type={<><span><a href="#agentauthcapabilities">AgentAuthCapabilities</a></span><span> | null</span></>} >
   Authentication-related capabilities supported by the agent.
+
+Optional. Omitted or `null` both mean the agent does not advertise any
+authentication-related extensions.
+
 </ResponseField>
 <ResponseField name="session" type={<><span><a href="#sessioncapabilities">SessionCapabilities</a></span><span> | null</span></>} >
   Session capabilities supported by the agent.
@@ -2819,8 +2823,8 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 
 Capabilities for additional session directories support.
 
-By supplying `\{\}` it means that the agent supports the `additionalDirectories`
-field on supported session lifecycle requests. Agents that also support
+Supplying `\{\}` means the agent supports the `additionalDirectories` field on
+supported session lifecycle requests. Agents that also support
 `session/list` may return `SessionInfo.additionalDirectories` to report the
 complete ordered additional-root list associated with a listed session.
 
@@ -2865,6 +2869,10 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 <ResponseField name="additionalDirectories" type={<><span><a href="#sessionadditionaldirectoriescapabilities">SessionAdditionalDirectoriesCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `additionalDirectories` on supported session lifecycle requests.
 
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports `additionalDirectories` on
+supported session lifecycle requests.
+
 Agents that also support `session/list` may return
 `SessionInfo.additionalDirectories` to report the complete ordered
 additional-root list associated with a listed session.
@@ -2872,6 +2880,10 @@ additional-root list associated with a listed session.
 </ResponseField>
 <ResponseField name="close" type={<><span><a href="#sessionclosecapabilities">SessionCloseCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/close`.
+
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports closing sessions.
+
 </ResponseField>
 <ResponseField name="delete" type={<><span><a href="#sessiondeletecapabilities">SessionDeleteCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/delete`.
@@ -2882,6 +2894,10 @@ Supplying `\{\}` means the agent supports deleting sessions from `session/list`.
 </ResponseField>
 <ResponseField name="list" type={<><span><a href="#sessionlistcapabilities">SessionListCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/list`.
+
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports listing sessions.
+
 </ResponseField>
 <ResponseField name="load" type={<><span><a href="#sessionloadcapabilities">SessionLoadCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/load`.
@@ -2907,13 +2923,17 @@ required by `session/prompt`.
 </ResponseField>
 <ResponseField name="resume" type={<><span><a href="#sessionresumecapabilities">SessionResumeCapabilities</a></span><span> | null</span></>} >
   Whether the agent supports `session/resume`.
+
+Optional. Omitted or `null` both mean the agent does not advertise support.
+Supplying `\{\}` means the agent supports resuming sessions.
+
 </ResponseField>
 
 ## <span class="font-mono">SessionCloseCapabilities</span>
 
 Capabilities for the `session/close` method.
 
-By supplying `\{\}` it means that the agent supports closing of sessions.
+Supplying `\{\}` means the agent supports closing sessions.
 
 **Type:** Object
 
@@ -3253,7 +3273,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 
 Capabilities for the `session/list` method.
 
-By supplying `\{\}` it means that the agent supports listing of sessions.
+Supplying `\{\}` means the agent supports listing sessions.
 
 **Type:** Object
 
@@ -3291,7 +3311,7 @@ See protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/e
 
 Capabilities for the `session/resume` method.
 
-By supplying `\{\}` it means that the agent supports resuming of sessions.
+Supplying `\{\}` means the agent supports resuming sessions.
 
 **Type:** Object
 

--- a/docs/rfds/session-delete.mdx
+++ b/docs/rfds/session-delete.mdx
@@ -71,7 +71,6 @@ On success, returns an empty result:
 
 ### Semantics
 
-- **Capability-gated**: Agents MUST NOT accept `session/delete` calls unless they advertised `sessionCapabilities.delete` at initialization.
 - **Removes from list**: The primary effect is that deleted sessions no longer appear in `session/list` results.
 - **Implementation-defined storage behavior**: Agents may implement soft delete (mark as hidden) or hard delete (remove data). The protocol does not prescribe which.
 - **Implementation-defined load behavior**: Agents may choose what happens when a client calls `session/load` on a deleted session—return the session anyway, return an error, or any other behavior. The protocol does not prescribe which.

--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -1009,7 +1009,7 @@
       "type": "object",
       "properties": {
         "path": {
-          "description": "The file path being modified.",
+          "description": "The absolute file path being modified.",
           "type": "string"
         },
         "oldText": {
@@ -1060,7 +1060,7 @@
       "type": "object",
       "properties": {
         "path": {
-          "description": "The file path being accessed or modified.",
+          "description": "The absolute file path being accessed or modified.",
           "type": "string"
         },
         "line": {
@@ -1176,7 +1176,7 @@
           "x-deserialize-skip-invalid-items": true
         },
         "cwd": {
-          "description": "Working directory for the command (absolute path).",
+          "description": "Working directory for the command. Must be an absolute path.",
           "type": ["string", "null"],
           "x-deserialize-default-on-error": true
         },
@@ -3792,7 +3792,7 @@
           "type": "string"
         },
         "command": {
-          "description": "Path to the MCP server executable.",
+          "description": "Absolute path to the MCP server executable.",
           "type": "string"
         },
         "args": {
@@ -3836,7 +3836,7 @@
           "x-deserialize-skip-invalid-items": true
         },
         "cwd": {
-          "description": "The working directory for this session.",
+          "description": "The working directory for this session. Must be an absolute path.",
           "type": "string"
         },
         "additionalDirectories": {
@@ -3927,7 +3927,7 @@
           ]
         },
         "cwd": {
-          "description": "The working directory for this session.",
+          "description": "The working directory for this session. Must be an absolute path.",
           "type": "string"
         },
         "additionalDirectories": {

--- a/schema/v1/schema.json
+++ b/schema/v1/schema.json
@@ -1713,7 +1713,7 @@
       "type": "object",
       "properties": {
         "list": {
-          "description": "Whether the agent supports `session/list`.",
+          "description": "Whether the agent supports `session/list`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports listing sessions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionListCapabilities"
@@ -1737,7 +1737,7 @@
           "x-deserialize-default-on-error": true
         },
         "additionalDirectories": {
-          "description": "Whether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nAgents that also support `session/list` may return\n`SessionInfo.additionalDirectories` to report the complete ordered\nadditional-root list associated with a listed session.",
+          "description": "Whether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports `additionalDirectories` on\nsupported session lifecycle requests.\n\nAgents that also support `session/list` may return\n`SessionInfo.additionalDirectories` to report the complete ordered\nadditional-root list associated with a listed session.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionAdditionalDirectoriesCapabilities"
@@ -1749,7 +1749,7 @@
           "x-deserialize-default-on-error": true
         },
         "resume": {
-          "description": "Whether the agent supports `session/resume`.",
+          "description": "Whether the agent supports `session/resume`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports resuming sessions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionResumeCapabilities"
@@ -1761,7 +1761,7 @@
           "x-deserialize-default-on-error": true
         },
         "close": {
-          "description": "Whether the agent supports `session/close`.",
+          "description": "Whether the agent supports `session/close`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports closing sessions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionCloseCapabilities"
@@ -1781,7 +1781,7 @@
       }
     },
     "SessionListCapabilities": {
-      "description": "Capabilities for the `session/list` method.\n\nBy supplying `{}` it means that the agent supports listing of sessions.",
+      "description": "Capabilities for the `session/list` method.\n\nSupplying `{}` means the agent supports listing sessions.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -1805,7 +1805,7 @@
       }
     },
     "SessionAdditionalDirectoriesCapabilities": {
-      "description": "Capabilities for additional session directories support.\n\nBy supplying `{}` it means that the agent supports the `additionalDirectories`\nfield on supported session lifecycle requests. Agents that also support\n`session/list` may return `SessionInfo.additionalDirectories` to report the\ncomplete ordered additional-root list associated with a listed session.",
+      "description": "Capabilities for additional session directories support.\n\nSupplying `{}` means the agent supports the `additionalDirectories` field on\nsupported session lifecycle requests. Agents that also support\n`session/list` may return `SessionInfo.additionalDirectories` to report the\ncomplete ordered additional-root list associated with a listed session.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -1817,7 +1817,7 @@
       }
     },
     "SessionResumeCapabilities": {
-      "description": "Capabilities for the `session/resume` method.\n\nBy supplying `{}` it means that the agent supports resuming of sessions.",
+      "description": "Capabilities for the `session/resume` method.\n\nSupplying `{}` means the agent supports resuming sessions.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -1829,7 +1829,7 @@
       }
     },
     "SessionCloseCapabilities": {
-      "description": "Capabilities for the `session/close` method.\n\nBy supplying `{}` it means that the agent supports closing of sessions.",
+      "description": "Capabilities for the `session/close` method.\n\nSupplying `{}` means the agent supports closing sessions.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -1845,7 +1845,7 @@
       "type": "object",
       "properties": {
         "logout": {
-          "description": "Whether the agent supports the logout method.\n\nBy supplying `{}` it means that the agent supports the logout method.",
+          "description": "Whether the agent supports the logout method.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports the logout method.",
           "anyOf": [
             {
               "$ref": "#/$defs/LogoutCapabilities"
@@ -1865,7 +1865,7 @@
       }
     },
     "LogoutCapabilities": {
-      "description": "Logout capabilities supported by the agent.\n\nBy supplying `{}` it means that the agent supports the logout method.",
+      "description": "Logout capabilities supported by the agent.\n\nSupplying `{}` means the agent supports the logout method.",
       "type": "object",
       "properties": {
         "_meta": {

--- a/schema/v1/schema.unstable.json
+++ b/schema/v1/schema.unstable.json
@@ -2537,7 +2537,7 @@
           ]
         },
         "providers": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nProvider configuration capabilities supported by the agent.\n\nBy supplying `{}` it means that the agent supports provider configuration methods.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nProvider configuration capabilities supported by the agent.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports provider configuration methods.",
           "anyOf": [
             {
               "$ref": "#/$defs/ProvidersCapabilities"
@@ -2549,7 +2549,7 @@
           "x-deserialize-default-on-error": true
         },
         "nes": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the agent.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the agent.\n\nOptional. Omitted or `null` both mean the agent does not advertise support\nfor NES methods.",
           "anyOf": [
             {
               "$ref": "#/$defs/NesCapabilities"
@@ -2645,7 +2645,7 @@
       "type": "object",
       "properties": {
         "list": {
-          "description": "Whether the agent supports `session/list`.",
+          "description": "Whether the agent supports `session/list`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports listing sessions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionListCapabilities"
@@ -2669,7 +2669,7 @@
           "x-deserialize-default-on-error": true
         },
         "additionalDirectories": {
-          "description": "Whether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nAgents that also support `session/list` may return\n`SessionInfo.additionalDirectories` to report the complete ordered\nadditional-root list associated with a listed session.",
+          "description": "Whether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports `additionalDirectories` on\nsupported session lifecycle requests.\n\nAgents that also support `session/list` may return\n`SessionInfo.additionalDirectories` to report the complete ordered\nadditional-root list associated with a listed session.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionAdditionalDirectoriesCapabilities"
@@ -2681,7 +2681,7 @@
           "x-deserialize-default-on-error": true
         },
         "fork": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/fork`.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/fork`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports forking sessions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionForkCapabilities"
@@ -2693,7 +2693,7 @@
           "x-deserialize-default-on-error": true
         },
         "resume": {
-          "description": "Whether the agent supports `session/resume`.",
+          "description": "Whether the agent supports `session/resume`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports resuming sessions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionResumeCapabilities"
@@ -2705,7 +2705,7 @@
           "x-deserialize-default-on-error": true
         },
         "close": {
-          "description": "Whether the agent supports `session/close`.",
+          "description": "Whether the agent supports `session/close`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports closing sessions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionCloseCapabilities"
@@ -2725,7 +2725,7 @@
       }
     },
     "SessionListCapabilities": {
-      "description": "Capabilities for the `session/list` method.\n\nBy supplying `{}` it means that the agent supports listing of sessions.",
+      "description": "Capabilities for the `session/list` method.\n\nSupplying `{}` means the agent supports listing sessions.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -2749,7 +2749,7 @@
       }
     },
     "SessionAdditionalDirectoriesCapabilities": {
-      "description": "Capabilities for additional session directories support.\n\nBy supplying `{}` it means that the agent supports the `additionalDirectories`\nfield on supported session lifecycle requests. Agents that also support\n`session/list` may return `SessionInfo.additionalDirectories` to report the\ncomplete ordered additional-root list associated with a listed session.",
+      "description": "Capabilities for additional session directories support.\n\nSupplying `{}` means the agent supports the `additionalDirectories` field on\nsupported session lifecycle requests. Agents that also support\n`session/list` may return `SessionInfo.additionalDirectories` to report the\ncomplete ordered additional-root list associated with a listed session.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -2761,7 +2761,7 @@
       }
     },
     "SessionForkCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for the `session/fork` method.\n\nBy supplying `{}` it means that the agent supports forking of sessions.",
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for the `session/fork` method.\n\nSupplying `{}` means the agent supports forking sessions.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -2773,7 +2773,7 @@
       }
     },
     "SessionResumeCapabilities": {
-      "description": "Capabilities for the `session/resume` method.\n\nBy supplying `{}` it means that the agent supports resuming of sessions.",
+      "description": "Capabilities for the `session/resume` method.\n\nSupplying `{}` means the agent supports resuming sessions.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -2785,7 +2785,7 @@
       }
     },
     "SessionCloseCapabilities": {
-      "description": "Capabilities for the `session/close` method.\n\nBy supplying `{}` it means that the agent supports closing of sessions.",
+      "description": "Capabilities for the `session/close` method.\n\nSupplying `{}` means the agent supports closing sessions.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -2801,7 +2801,7 @@
       "type": "object",
       "properties": {
         "logout": {
-          "description": "Whether the agent supports the logout method.\n\nBy supplying `{}` it means that the agent supports the logout method.",
+          "description": "Whether the agent supports the logout method.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports the logout method.",
           "anyOf": [
             {
               "$ref": "#/$defs/LogoutCapabilities"
@@ -2821,7 +2821,7 @@
       }
     },
     "LogoutCapabilities": {
-      "description": "Logout capabilities supported by the agent.\n\nBy supplying `{}` it means that the agent supports the logout method.",
+      "description": "Logout capabilities supported by the agent.\n\nSupplying `{}` means the agent supports the logout method.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -2833,7 +2833,7 @@
       }
     },
     "ProvidersCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nProvider configuration capabilities supported by the agent.\n\nBy supplying `{}` it means that the agent supports provider configuration methods.",
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nProvider configuration capabilities supported by the agent.\n\nSupplying `{}` means the agent supports provider configuration methods.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -6131,7 +6131,7 @@
           "x-deserialize-default-on-error": true
         },
         "session": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nSession-related capabilities supported by the client.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nSession-related capabilities supported by the client.\n\nOptional. Omitted or `null` both mean the client does not advertise any\nsession-related extensions.",
           "anyOf": [
             {
               "$ref": "#/$defs/ClientSessionCapabilities"
@@ -6143,7 +6143,7 @@
           "x-deserialize-default-on-error": true
         },
         "plan": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the client supports `plan_update` and `plan_removed` session updates.\n\nOptional. Omitted means the client does not advertise support.\nSupplying `{}` means the client can receive both update types.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the client supports `plan_update` and `plan_removed` session updates.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means the client can receive both update types.",
           "anyOf": [
             {
               "$ref": "#/$defs/PlanCapabilities"
@@ -6167,7 +6167,7 @@
           ]
         },
         "elicitation": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nElicitation capabilities supported by the client.\nDetermines which elicitation modes the agent may use.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nElicitation capabilities supported by the client.\nDetermines which elicitation modes the agent may use.\n\nOptional. Omitted or `null` both mean the client does not advertise\nelicitation support.",
           "anyOf": [
             {
               "$ref": "#/$defs/ElicitationCapabilities"
@@ -6179,7 +6179,7 @@
           "x-deserialize-default-on-error": true
         },
         "nes": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the client.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the client.\n\nOptional. Omitted or `null` both mean the client does not advertise any\nNES suggestion-kind extensions.",
           "anyOf": [
             {
               "$ref": "#/$defs/ClientNesCapabilities"
@@ -6236,7 +6236,7 @@
       "type": "object",
       "properties": {
         "configOptions": {
-          "description": "Config option capabilities supported by the client.\n\nOmitted or `null` means the client does not advertise support for any\nconfig option extensions.",
+          "description": "Config option capabilities supported by the client.\n\nOmitted or `null` both mean the client does not advertise support for any\nconfig option extensions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionConfigOptionsCapabilities"
@@ -6260,7 +6260,7 @@
       "type": "object",
       "properties": {
         "boolean": {
-          "description": "Whether the client supports boolean session configuration options.\n\nOmitted or `null` means the client does not advertise support.\nSupplying `{}` means agents may include `type: \"boolean\"` entries in\n`configOptions`, and the client may send `session/set_config_option`\nrequests with `type: \"boolean\"` and a boolean `value`.",
+          "description": "Whether the client supports boolean session configuration options.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means agents may include `type: \"boolean\"` entries in\n`configOptions`, and the client may send `session/set_config_option`\nrequests with `type: \"boolean\"` and a boolean `value`.",
           "anyOf": [
             {
               "$ref": "#/$defs/BooleanConfigOptionCapabilities"
@@ -6326,7 +6326,7 @@
       "type": "object",
       "properties": {
         "form": {
-          "description": "Whether the client supports form-based elicitation.",
+          "description": "Whether the client supports form-based elicitation.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means the client supports form-based elicitation.",
           "anyOf": [
             {
               "$ref": "#/$defs/ElicitationFormCapabilities"
@@ -6338,7 +6338,7 @@
           "x-deserialize-default-on-error": true
         },
         "url": {
-          "description": "Whether the client supports URL-based elicitation.",
+          "description": "Whether the client supports URL-based elicitation.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means the client supports URL-based elicitation.",
           "anyOf": [
             {
               "$ref": "#/$defs/ElicitationUrlCapabilities"
@@ -6358,7 +6358,7 @@
       }
     },
     "ElicitationFormCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nForm-based elicitation capabilities.",
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nForm-based elicitation capabilities.\n\nSupplying `{}` means the client supports form-based elicitation.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -6370,7 +6370,7 @@
       }
     },
     "ElicitationUrlCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nURL-based elicitation capabilities.",
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nURL-based elicitation capabilities.\n\nSupplying `{}` means the client supports URL-based elicitation.",
       "type": "object",
       "properties": {
         "_meta": {

--- a/schema/v1/schema.unstable.json
+++ b/schema/v1/schema.unstable.json
@@ -1045,7 +1045,7 @@
       "type": "object",
       "properties": {
         "path": {
-          "description": "The file path being modified.",
+          "description": "The absolute file path being modified.",
           "type": "string"
         },
         "oldText": {
@@ -1096,7 +1096,7 @@
       "type": "object",
       "properties": {
         "path": {
-          "description": "The file path being accessed or modified.",
+          "description": "The absolute file path being accessed or modified.",
           "type": "string"
         },
         "line": {
@@ -1212,7 +1212,7 @@
           "x-deserialize-skip-invalid-items": true
         },
         "cwd": {
-          "description": "Working directory for the command (absolute path).",
+          "description": "Working directory for the command. Must be an absolute path.",
           "type": ["string", "null"],
           "x-deserialize-default-on-error": true
         },
@@ -6796,7 +6796,7 @@
           "type": "string"
         },
         "command": {
-          "description": "Path to the MCP server executable.",
+          "description": "Absolute path to the MCP server executable.",
           "type": "string"
         },
         "args": {
@@ -6840,7 +6840,7 @@
           "x-deserialize-skip-invalid-items": true
         },
         "cwd": {
-          "description": "The working directory for this session.",
+          "description": "The working directory for this session. Must be an absolute path.",
           "type": "string"
         },
         "additionalDirectories": {
@@ -6931,7 +6931,7 @@
           ]
         },
         "cwd": {
-          "description": "The working directory for this session.",
+          "description": "The working directory for this session. Must be an absolute path.",
           "type": "string"
         },
         "additionalDirectories": {
@@ -6976,7 +6976,7 @@
           ]
         },
         "cwd": {
-          "description": "The working directory for this session.",
+          "description": "The working directory for this session. Must be an absolute path.",
           "type": "string"
         },
         "additionalDirectories": {

--- a/schema/v2/schema.json
+++ b/schema/v2/schema.json
@@ -1694,7 +1694,7 @@
           "x-deserialize-default-on-error": true
         },
         "auth": {
-          "description": "Authentication-related capabilities supported by the agent.",
+          "description": "Authentication-related capabilities supported by the agent.\n\nOptional. Omitted or `null` both mean the agent does not advertise any\nauthentication-related extensions.",
           "anyOf": [
             {
               "$ref": "#/$defs/AgentAuthCapabilities"
@@ -1754,7 +1754,7 @@
           "x-deserialize-default-on-error": true
         },
         "list": {
-          "description": "Whether the agent supports `session/list`.",
+          "description": "Whether the agent supports `session/list`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports listing sessions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionListCapabilities"
@@ -1778,7 +1778,7 @@
           "x-deserialize-default-on-error": true
         },
         "additionalDirectories": {
-          "description": "Whether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nAgents that also support `session/list` may return\n`SessionInfo.additionalDirectories` to report the complete ordered\nadditional-root list associated with a listed session.",
+          "description": "Whether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports `additionalDirectories` on\nsupported session lifecycle requests.\n\nAgents that also support `session/list` may return\n`SessionInfo.additionalDirectories` to report the complete ordered\nadditional-root list associated with a listed session.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionAdditionalDirectoriesCapabilities"
@@ -1790,7 +1790,7 @@
           "x-deserialize-default-on-error": true
         },
         "resume": {
-          "description": "Whether the agent supports `session/resume`.",
+          "description": "Whether the agent supports `session/resume`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports resuming sessions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionResumeCapabilities"
@@ -1802,7 +1802,7 @@
           "x-deserialize-default-on-error": true
         },
         "close": {
-          "description": "Whether the agent supports `session/close`.",
+          "description": "Whether the agent supports `session/close`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports closing sessions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionCloseCapabilities"
@@ -1978,7 +1978,7 @@
       }
     },
     "SessionListCapabilities": {
-      "description": "Capabilities for the `session/list` method.\n\nBy supplying `{}` it means that the agent supports listing of sessions.",
+      "description": "Capabilities for the `session/list` method.\n\nSupplying `{}` means the agent supports listing sessions.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -2002,7 +2002,7 @@
       }
     },
     "SessionAdditionalDirectoriesCapabilities": {
-      "description": "Capabilities for additional session directories support.\n\nBy supplying `{}` it means that the agent supports the `additionalDirectories`\nfield on supported session lifecycle requests. Agents that also support\n`session/list` may return `SessionInfo.additionalDirectories` to report the\ncomplete ordered additional-root list associated with a listed session.",
+      "description": "Capabilities for additional session directories support.\n\nSupplying `{}` means the agent supports the `additionalDirectories` field on\nsupported session lifecycle requests. Agents that also support\n`session/list` may return `SessionInfo.additionalDirectories` to report the\ncomplete ordered additional-root list associated with a listed session.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -2014,7 +2014,7 @@
       }
     },
     "SessionResumeCapabilities": {
-      "description": "Capabilities for the `session/resume` method.\n\nBy supplying `{}` it means that the agent supports resuming of sessions.",
+      "description": "Capabilities for the `session/resume` method.\n\nSupplying `{}` means the agent supports resuming sessions.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -2026,7 +2026,7 @@
       }
     },
     "SessionCloseCapabilities": {
-      "description": "Capabilities for the `session/close` method.\n\nBy supplying `{}` it means that the agent supports closing of sessions.",
+      "description": "Capabilities for the `session/close` method.\n\nSupplying `{}` means the agent supports closing sessions.",
       "type": "object",
       "properties": {
         "_meta": {

--- a/schema/v2/schema.json
+++ b/schema/v2/schema.json
@@ -1319,7 +1319,7 @@
       "type": "object",
       "properties": {
         "path": {
-          "description": "The file path being modified.",
+          "description": "The absolute file path being modified.",
           "type": "string"
         },
         "oldText": {
@@ -1345,7 +1345,7 @@
       "type": "object",
       "properties": {
         "path": {
-          "description": "The file path being accessed or modified.",
+          "description": "The absolute file path being accessed or modified.",
           "type": "string"
         },
         "line": {
@@ -4385,7 +4385,7 @@
           "type": "string"
         },
         "command": {
-          "description": "Path to the MCP server executable.",
+          "description": "Absolute path to the MCP server executable.",
           "type": "string"
         },
         "args": {
@@ -4428,7 +4428,7 @@
           ]
         },
         "cwd": {
-          "description": "The working directory for this session.",
+          "description": "The working directory for this session. Must be an absolute path.",
           "type": "string"
         },
         "additionalDirectories": {
@@ -4520,7 +4520,7 @@
           ]
         },
         "cwd": {
-          "description": "The working directory for this session.",
+          "description": "The working directory for this session. Must be an absolute path.",
           "type": "string"
         },
         "additionalDirectories": {

--- a/schema/v2/schema.unstable.json
+++ b/schema/v2/schema.unstable.json
@@ -2695,7 +2695,7 @@
           "x-deserialize-default-on-error": true
         },
         "auth": {
-          "description": "Authentication-related capabilities supported by the agent.",
+          "description": "Authentication-related capabilities supported by the agent.\n\nOptional. Omitted or `null` both mean the agent does not advertise any\nauthentication-related extensions.",
           "anyOf": [
             {
               "$ref": "#/$defs/AgentAuthCapabilities"
@@ -2707,7 +2707,7 @@
           "x-deserialize-default-on-error": true
         },
         "providers": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nProvider configuration capabilities supported by the agent.\n\nBy supplying `{}` it means that the agent supports provider configuration methods.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nProvider configuration capabilities supported by the agent.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports provider configuration methods.",
           "anyOf": [
             {
               "$ref": "#/$defs/ProvidersCapabilities"
@@ -2719,7 +2719,7 @@
           "x-deserialize-default-on-error": true
         },
         "nes": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the agent.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the agent.\n\nOptional. Omitted or `null` both mean the agent does not advertise support\nfor NES methods.",
           "anyOf": [
             {
               "$ref": "#/$defs/NesCapabilities"
@@ -2791,7 +2791,7 @@
           "x-deserialize-default-on-error": true
         },
         "list": {
-          "description": "Whether the agent supports `session/list`.",
+          "description": "Whether the agent supports `session/list`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports listing sessions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionListCapabilities"
@@ -2815,7 +2815,7 @@
           "x-deserialize-default-on-error": true
         },
         "additionalDirectories": {
-          "description": "Whether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nAgents that also support `session/list` may return\n`SessionInfo.additionalDirectories` to report the complete ordered\nadditional-root list associated with a listed session.",
+          "description": "Whether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports `additionalDirectories` on\nsupported session lifecycle requests.\n\nAgents that also support `session/list` may return\n`SessionInfo.additionalDirectories` to report the complete ordered\nadditional-root list associated with a listed session.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionAdditionalDirectoriesCapabilities"
@@ -2827,7 +2827,7 @@
           "x-deserialize-default-on-error": true
         },
         "fork": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/fork`.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nWhether the agent supports `session/fork`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports forking sessions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionForkCapabilities"
@@ -2839,7 +2839,7 @@
           "x-deserialize-default-on-error": true
         },
         "resume": {
-          "description": "Whether the agent supports `session/resume`.",
+          "description": "Whether the agent supports `session/resume`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports resuming sessions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionResumeCapabilities"
@@ -2851,7 +2851,7 @@
           "x-deserialize-default-on-error": true
         },
         "close": {
-          "description": "Whether the agent supports `session/close`.",
+          "description": "Whether the agent supports `session/close`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports closing sessions.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionCloseCapabilities"
@@ -3051,7 +3051,7 @@
       }
     },
     "SessionListCapabilities": {
-      "description": "Capabilities for the `session/list` method.\n\nBy supplying `{}` it means that the agent supports listing of sessions.",
+      "description": "Capabilities for the `session/list` method.\n\nSupplying `{}` means the agent supports listing sessions.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -3075,7 +3075,7 @@
       }
     },
     "SessionAdditionalDirectoriesCapabilities": {
-      "description": "Capabilities for additional session directories support.\n\nBy supplying `{}` it means that the agent supports the `additionalDirectories`\nfield on supported session lifecycle requests. Agents that also support\n`session/list` may return `SessionInfo.additionalDirectories` to report the\ncomplete ordered additional-root list associated with a listed session.",
+      "description": "Capabilities for additional session directories support.\n\nSupplying `{}` means the agent supports the `additionalDirectories` field on\nsupported session lifecycle requests. Agents that also support\n`session/list` may return `SessionInfo.additionalDirectories` to report the\ncomplete ordered additional-root list associated with a listed session.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -3087,7 +3087,7 @@
       }
     },
     "SessionForkCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for the `session/fork` method.\n\nBy supplying `{}` it means that the agent supports forking of sessions.",
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nCapabilities for the `session/fork` method.\n\nSupplying `{}` means the agent supports forking sessions.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -3099,7 +3099,7 @@
       }
     },
     "SessionResumeCapabilities": {
-      "description": "Capabilities for the `session/resume` method.\n\nBy supplying `{}` it means that the agent supports resuming of sessions.",
+      "description": "Capabilities for the `session/resume` method.\n\nSupplying `{}` means the agent supports resuming sessions.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -3111,7 +3111,7 @@
       }
     },
     "SessionCloseCapabilities": {
-      "description": "Capabilities for the `session/close` method.\n\nBy supplying `{}` it means that the agent supports closing of sessions.",
+      "description": "Capabilities for the `session/close` method.\n\nSupplying `{}` means the agent supports closing sessions.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -3135,7 +3135,7 @@
       }
     },
     "ProvidersCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nProvider configuration capabilities supported by the agent.\n\nBy supplying `{}` it means that the agent supports provider configuration methods.",
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nProvider configuration capabilities supported by the agent.\n\nSupplying `{}` means the agent supports provider configuration methods.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -6872,7 +6872,7 @@
       "type": "object",
       "properties": {
         "auth": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAuthentication capabilities supported by the client.\nDetermines which authentication method types the agent may include\nin its `InitializeResponse`.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nAuthentication capabilities supported by the client.\nDetermines which authentication method types the agent may include\nin its `InitializeResponse`.\n\nOptional. Omitted or `null` both mean the client does not advertise any\nauthentication-method extensions.",
           "anyOf": [
             {
               "$ref": "#/$defs/AuthCapabilities"
@@ -6884,7 +6884,7 @@
           "x-deserialize-default-on-error": true
         },
         "elicitation": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nElicitation capabilities supported by the client.\nDetermines which elicitation modes the agent may use.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nElicitation capabilities supported by the client.\nDetermines which elicitation modes the agent may use.\n\nOptional. Omitted or `null` both mean the client does not advertise\nelicitation support.",
           "anyOf": [
             {
               "$ref": "#/$defs/ElicitationCapabilities"
@@ -6896,7 +6896,7 @@
           "x-deserialize-default-on-error": true
         },
         "nes": {
-          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the client.",
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nNES (Next Edit Suggestions) capabilities supported by the client.\n\nOptional. Omitted or `null` both mean the client does not advertise any\nNES suggestion-kind extensions.",
           "anyOf": [
             {
               "$ref": "#/$defs/ClientNesCapabilities"
@@ -6965,7 +6965,7 @@
       "type": "object",
       "properties": {
         "form": {
-          "description": "Whether the client supports form-based elicitation.",
+          "description": "Whether the client supports form-based elicitation.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means the client supports form-based elicitation.",
           "anyOf": [
             {
               "$ref": "#/$defs/ElicitationFormCapabilities"
@@ -6977,7 +6977,7 @@
           "x-deserialize-default-on-error": true
         },
         "url": {
-          "description": "Whether the client supports URL-based elicitation.",
+          "description": "Whether the client supports URL-based elicitation.\n\nOptional. Omitted or `null` both mean the client does not advertise support.\nSupplying `{}` means the client supports URL-based elicitation.",
           "anyOf": [
             {
               "$ref": "#/$defs/ElicitationUrlCapabilities"
@@ -6997,7 +6997,7 @@
       }
     },
     "ElicitationFormCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nForm-based elicitation capabilities.",
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nForm-based elicitation capabilities.\n\nSupplying `{}` means the client supports form-based elicitation.",
       "type": "object",
       "properties": {
         "_meta": {
@@ -7009,7 +7009,7 @@
       }
     },
     "ElicitationUrlCapabilities": {
-      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nURL-based elicitation capabilities.",
+      "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.\n\nURL-based elicitation capabilities.\n\nSupplying `{}` means the client supports URL-based elicitation.",
       "type": "object",
       "properties": {
         "_meta": {

--- a/schema/v2/schema.unstable.json
+++ b/schema/v2/schema.unstable.json
@@ -1463,7 +1463,7 @@
       "type": "object",
       "properties": {
         "path": {
-          "description": "The file path being modified.",
+          "description": "The absolute file path being modified.",
           "type": "string"
         },
         "oldText": {
@@ -1489,7 +1489,7 @@
       "type": "object",
       "properties": {
         "path": {
-          "description": "The file path being accessed or modified.",
+          "description": "The absolute file path being accessed or modified.",
           "type": "string"
         },
         "line": {
@@ -7446,7 +7446,7 @@
           "type": "string"
         },
         "command": {
-          "description": "Path to the MCP server executable.",
+          "description": "Absolute path to the MCP server executable.",
           "type": "string"
         },
         "args": {
@@ -7489,7 +7489,7 @@
           ]
         },
         "cwd": {
-          "description": "The working directory for this session.",
+          "description": "The working directory for this session. Must be an absolute path.",
           "type": "string"
         },
         "additionalDirectories": {
@@ -7581,7 +7581,7 @@
           ]
         },
         "cwd": {
-          "description": "The working directory for this session.",
+          "description": "The working directory for this session. Must be an absolute path.",
           "type": "string"
         },
         "additionalDirectories": {
@@ -7626,7 +7626,7 @@
           ]
         },
         "cwd": {
-          "description": "The working directory for this session.",
+          "description": "The working directory for this session. Must be an absolute path.",
           "type": "string"
         },
         "additionalDirectories": {


### PR DESCRIPTION
- **docs(schema): Clarify absolute path requirements**
- **docs(schema): clarify nullable capabilities semantics**
- **Clean up inconsistent drafts**
