### PR TITLE
docs(clients): add Agent Console as a second Obsidian ACP client

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -15,7 +15,9 @@ The following projects implement ACP directly, connect ACP agents to other envir
   - through the [carlos-algms/agentic.nvim](https://github.com/carlos-algms/agentic.nvim) plugin
   - through the [yetone/avante.nvim](https://github.com/yetone/avante.nvim) plugin
   - through the [hermes.nvim](https://github.com/Ruddickmg/hermes.nvim) plugin
-- [Obsidian](https://obsidian.md) — through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
+- [Obsidian](https://obsidian.md)
+  - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
+  - through the [Agent Console](https://github.com/donivatamazondotcom/obsidian-agent-console) plugin — a tabbed multi-session workspace: run several ACP agents in parallel with restorable, searchable sessions and quick prompts
 - [Pulsar](https://pulsar-edit.dev) — through the [pulsar-acp-agent](https://github.com/hovancik/pulsar-acp-agent) package
 - [Unity ACP Client](https://github.com/3DLabInstruments/UnityACPClient)(Unity plugin)
 - [Unity Agent Client](https://github.com/nuskey8/UnityAgentClient) (Unity editor)


### PR DESCRIPTION
Adds **Agent Console** alongside the existing Agent Client entry under Editors and IDEs → Obsidian.

Agent Console is a published, Apache-2.0 Obsidian Community Plugin that connects to any ACP-compatible agent (Claude Code, Codex, Gemini CLI, Kiro CLI, custom). It's a maintained fork of RAIT-09/obsidian-agent-client. As of v2.0.0 it has diverged substantially from the upstream — a tabbed multi-session workspace for running several agents in parallel with at-a-glance status, plus restart- and reopen-restorable sessions, full-text session search, quick prompts, configurable per-agent working directories, and an Obsidian-context system prompt. v2.0.0 runs on ACP SDK 1.0 (`@agentclientprotocol/sdk` 1.0, via the `acp.client()` builder).

- Store listing: https://community.obsidian.md/plugins/agent-console
- Repo: https://github.com/donivatamazondotcom/obsidian-agent-console
- Docs: https://donivatamazondotcom.github.io/obsidian-agent-console/

Uses the same parent/sub-bullet format already used for neovim's multiple plugins, and preserves alphabetical ordering. The original Agent Client entry is unchanged.
