### PR TITLE
docs: add qq-ai-bot to messaging clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -87,6 +87,7 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 - [Telegram-ACP](https://github.com/SuperKenVery/Telegram-ACP/) (Telegram) — Supports multi-thread chat and message streaming
 - [ACP Router](https://github.com/vcoderun/acprouter) (Telegram) - an ACP client surface for driving ACP agents from Telegram, with rich diffs, approvals and many more.
 - [WeChat ACP](https://github.com/formulahendry/wechat-acp) (WeChat)
+- [qq-ai-bot](https://github.com/happysnaker/qq-ai-bot) (QQ / OneBot 11) — self-hosted bridge for OneBot 11 / NapCat / LLOneBot that connects QQ messaging to ACP-compatible agents with persistent sessions and progress streaming
 - [Sniptail](https://github.com/Justkog/sniptail) (Discord, Slack) - self-hosted chat bridge for running coding agents across your team’s repositories
 - [Lark ACP](https://github.com/4t145/lark-acp) (Lark/飞书)
 - [Zooid](https://github.com/zooid-ai/zooid) (Matrix) - coding agent runtime paired with a Matrix client/ACP bridge for interacting with agents


### PR DESCRIPTION
## Summary
- add `qq-ai-bot` to the Messaging section of ACP clients docs

## Why
`qq-ai-bot` is a public ACP-compatible messaging client surface for QQ / OneBot 11 deployments. It sits alongside the other messaging-oriented ACP clients already listed on this page.

Repo details:
- repo: https://github.com/happysnaker/qq-ai-bot
- homepage: https://happysnaker.github.io/qq-ai-bot/
- latest release: v0.1.3

Positioning in one line:
- self-hosted bridge for OneBot 11 / NapCat / LLOneBot that connects QQ messaging to ACP-compatible agents with persistent sessions and progress streaming

## Scope
- docs-only change in `docs/get-started/clients.mdx`
