### PR TITLE
Add additional option for Go SDK to community libraries documentation

### DIFF
--- a/docs/libraries/community.mdx
+++ b/docs/libraries/community.mdx
@@ -25,6 +25,7 @@ description: "Community managed libraries for the Agent Client Protocol"
 - [acp-go-sdk](https://github.com/coder/acp-go-sdk)
 - [acp-go](https://github.com/ironpark/acp-go)
 - [acp](https://github.com/eino-contrib/acp)
+- [acp-sdk](https://github.com/spachava753/acp-sdk)
 
 ## React
 


### PR DESCRIPTION
Hello! I've created and been using [this](https://github.com/spachava753/acp-sdk) Go SDK for a while, and wanted to add it as another option for the Go ecosystem. It has full coverage of the methods and types offered in the spec, including unstable features, and is a modified fork of the official MCP SDK to support ACP.