### PR TITLE
docs: add Qt Creator to supported clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -19,6 +19,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
   - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
   - through the [Agent Console](https://github.com/donivatamazondotcom/obsidian-agent-console) plugin — a tabbed multi-session workspace: run several ACP agents in parallel with restorable, searchable sessions and quick prompts
 - [Pulsar](https://pulsar-edit.dev) — through the [pulsar-acp-agent](https://github.com/hovancik/pulsar-acp-agent) package
+- [Qt Creator](https://www.qt.io/development/tools/qt-creator-ide) — through the [ACP Client Plugin](https://doc.qt.io/qtcreator/creator-how-to-use-acp-client.html)
 - [Unity ACP Client](https://github.com/3DLabInstruments/UnityACPClient)(Unity plugin)
 - [Unity Agent Client](https://github.com/nuskey8/UnityAgentClient) (Unity editor)
 - Visual Studio Code


### PR DESCRIPTION
## Summary
- Adds Qt Creator to the Editors and IDEs section of the supported clients list.