### PR TITLE
docs: add construct to integrations and agents list

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Consumers should not infer wire compatibility from the crate or schema release v
 - [Schema](./schema/v1/schema.json)
 - [Agents](https://agentclientprotocol.com/overview/agents)
 - [Clients](https://agentclientprotocol.com/overview/clients)
-- **construct**: [`construct`](https://github.com/construct-worlds/construct) — ACP stdio agent server (`construct acp`) for construct daemon sessions; see [Agents](https://agentclientprotocol.com/get-started/agents)
 - Official Libraries
   - **Kotlin**: [`acp-kotlin`](https://github.com/agentclientprotocol/kotlin-sdk) - Supports JVM, other targets are in progress, see [samples](https://github.com/agentclientprotocol/kotlin-sdk/tree/master/samples/kotlin-acp-client-sample/src/main/kotlin/com/agentclientprotocol/samples)
   - **Java**: [`java-sdk`](https://github.com/agentclientprotocol/java-sdk) - See [examples](https://github.com/agentclientprotocol/java-sdk/tree/main/examples)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Consumers should not infer wire compatibility from the crate or schema release v
 - [Schema](./schema/v1/schema.json)
 - [Agents](https://agentclientprotocol.com/overview/agents)
 - [Clients](https://agentclientprotocol.com/overview/clients)
+- **construct**: [`construct`](https://github.com/construct-worlds/construct) — ACP stdio agent server (`construct acp`) for construct daemon sessions; see [Agents](https://agentclientprotocol.com/get-started/agents)
 - Official Libraries
   - **Kotlin**: [`acp-kotlin`](https://github.com/agentclientprotocol/kotlin-sdk) - Supports JVM, other targets are in progress, see [samples](https://github.com/agentclientprotocol/kotlin-sdk/tree/master/samples/kotlin-acp-client-sample/src/main/kotlin/com/agentclientprotocol/samples)
   - **Java**: [`java-sdk`](https://github.com/agentclientprotocol/java-sdk) - See [examples](https://github.com/agentclientprotocol/java-sdk/tree/main/examples)

--- a/docs/get-started/agents.mdx
+++ b/docs/get-started/agents.mdx
@@ -14,6 +14,7 @@ The following agents can be used with an ACP Client:
 - [Cline](https://cline.bot/)
 - [Codex CLI](https://developers.openai.com/codex/cli) (via [Zed's adapter](https://github.com/zed-industries/codex-acp))
 - [Code Assistant](https://github.com/stippi/code-assistant?tab=readme-ov-file#configuration)
+- [construct](https://github.com/construct-worlds/construct) — ACP stdio agent server (`construct acp`) for construct daemon sessions
 - [crow-cli](https://crow-ai.dev)
 - [Cursor](https://cursor.com/docs/cli/acp)
 - [Docker's cagent](https://github.com/docker/cagent)

--- a/docs/get-started/agents.mdx
+++ b/docs/get-started/agents.mdx
@@ -14,7 +14,7 @@ The following agents can be used with an ACP Client:
 - [Cline](https://cline.bot/)
 - [Codex CLI](https://developers.openai.com/codex/cli) (via [Zed's adapter](https://github.com/zed-industries/codex-acp))
 - [Code Assistant](https://github.com/stippi/code-assistant?tab=readme-ov-file#configuration)
-- [construct](https://github.com/construct-worlds/construct) — ACP stdio agent server (`construct acp`) for construct daemon sessions
+- [Construct](https://github.com/construct-worlds/construct#acp-agent-client-protocol-server)
 - [crow-cli](https://crow-ai.dev)
 - [Cursor](https://cursor.com/docs/cli/acp)
 - [Docker's cagent](https://github.com/docker/cagent)


### PR DESCRIPTION
## Summary

- Adds [construct](https://github.com/construct-worlds/construct) to the [Agents](https://agentclientprotocol.com/get-started/agents) page

construct implements an ACP stdio agent server via `construct acp` that maps ACP session lifecycle calls onto construct daemon sessions.

## Test plan

- [x] Verified README and `docs/get-started/agents.mdx` list construct in the expected section
- [ ] Maintainer review of wording and placement