### PR TITLE
docs(rfd): Clarify session id behavior in forking

### DIFF
--- a/docs/rfds/session-fork.mdx
+++ b/docs/rfds/session-fork.mdx
@@ -63,7 +63,7 @@ Then the client would be able to request a fork of the given session:
 
 The request expects the same options as `session/load`, such as `cwd` and `mcpServers`.
 
-Similarly, the agent would respond with optional data such as config options, the same as `session/load`.
+Similarly, the agent would respond with the `sessionId` of the new session, plus optional data such as config options, the same as `session/new`.
 
 Agents may reply with an error if forking of that specific session or with the given options is not supported,
 for example if the agent does not support forking with a different working directory than the initial session.


### PR DESCRIPTION
Edited the expected response from a 'session/fork' request to include the sessionId of the new fork.

I am suggesting this change because I think the client will need the `sessionId` of the result of forking in order to use the new session that was created via the `session/fork` request.