### PR TITLE
docs: add Casper to the list of ACP web clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -45,6 +45,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [AionUi](https://github.com/iOfficeAI/AionUi)
 - [aizen](https://aizen.win)
 - [Braide](https://braide.dev) - Parallel sessions, worktrees, personas and interactive agent responses (supports macOS, Windows, Linux)
+- [Casper](https://github.com/joeyshi12/casper) - A web client for kiro-cli that talks to it over the Agent Client Protocol (ACP), giving you a browser-based chat UI with live streaming, session history, and rich per-tool-call rendering.
 - [Codeg](https://github.com/xintaofei/codeg) — collaborative multi-agent coding workbench that unifies ACP agents (Claude Code, Codex, Gemini CLI, OpenCode, and more) with session aggregation; desktop app, self-hosted server, or Docker (macOS, Windows, Linux, Web)
 - [DeepChat](https://github.com/ThinkInAIXYZ/deepchat)
 - [Devin Desktop](https://devin.ai/desktop)


### PR DESCRIPTION
Casper is a web client for kiro-cli that talks to it over the Agent Client Protocol (ACP), giving you a browser-based chat UI with live streaming, session history, and rich per-tool-call rendering.