### PR TITLE
docs(clients): add Shellular mobile and web ACP client

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -61,6 +61,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Ngent](https://github.com/beyond5959/ngent)
 - [RayClaw](https://github.com/rayclaw/rayclaw?tab=readme-ov-file#acp-agent-client-protocol)
 - [RLM Code](https://github.com/SuperagenticAI/rlm-code)
+- [Shellular](https://shellular.dev) ([GitHub](https://github.com/shellular-org))
 - [Sidequery _(coming soon)_](https://sidequery.dev)
 - [Tidewave](https://tidewave.ai/)
 - [Web Browser with AI SDK](https://github.com/mcpc-tech/ai-elements-remix-template) (powered by [@mcpc/acp-ai-provider](https://github.com/mcpc-tech/mcpc/tree/main/packages/acp-ai-provider))
@@ -83,6 +84,7 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 - [Ferngeist](https://github.com/arafatamim/Ferngeist) (Android)
 - [Happy](https://happy.engineering/) ([GitHub](https://github.com/slopus/happy)) (iOS, Android, Web)
 - [Mobvibe](https://github.com/Eric-Song-Nop/mobvibe) (iOS, Android, Web)
+- [Shellular](https://shellular.dev) ([GitHub](https://github.com/shellular-org)) (iOS, Android, [Web](https://app.shellular.dev))
 
 ## Messaging
 


### PR DESCRIPTION
[Shellular](https://shellular.dev) provides secure remote access to dev machines from iOS, Android, and the web, with a dedicated UI for ACP coding agents.

#### I did the following before sending this PR.

- [x] `npm run generate`
- [x] `npm run format`