### PR TITLE
docs: add Poolside Assistant desktop, VS Code, and Visual Studio clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -23,11 +23,13 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Qt Creator](https://www.qt.io/development/tools/qt-creator-ide) — through the [ACP Client Plugin](https://doc.qt.io/qtcreator/creator-how-to-use-acp-client.html)
 - [Unity ACP Client](https://github.com/3DLabInstruments/UnityACPClient)(Unity plugin)
 - [Unity Agent Client](https://github.com/nuskey8/UnityAgentClient) (Unity editor)
+- Visual Studio — through the [Poolside Assistant](https://marketplace.visualstudio.com/items?itemName=poolside-ai.vs-acp-assistant)
 - Visual Studio Code
   - [ACP Client](https://github.com/formulahendry/vscode-acp) extension
   - [ACP Patchbay](https://github.com/solutionsunity/acp-patchbay) extension
   - [ACP Pro Extension](https://marketplace.visualstudio.com/items?itemName=duclvz.acp-pro)
     - VS Code–compatible IDEs (Cursor, Windsurf, Trae,..): [ACP Pro Extension](https://open-vsx.org/extension/duclvz/acp-pro)
+  - [Poolside Assistant](https://marketplace.visualstudio.com/items?itemName=poolside-ai.acp-assistant)
 - [Zed](https://zed.dev/docs/ai/external-agents)
 
 ## CLI and TUI
@@ -59,6 +61,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Minion Mind](https://minion-mind.nebulame.com/) — through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
 - [Mitto](https://github.com/inercia/mitto)
 - [Ngent](https://github.com/beyond5959/ngent)
+- [Poolside Desktop Assistant](https://poolside.ai/get-started) - An agent agnostic worktree native macOS desktop app.
 - [RayClaw](https://github.com/rayclaw/rayclaw?tab=readme-ov-file#acp-agent-client-protocol)
 - [RLM Code](https://github.com/SuperagenticAI/rlm-code)
 - [Sidequery _(coming soon)_](https://sidequery.dev)


### PR DESCRIPTION
Adds three Poolside Assistant client surfaces to the clients page - macOS desktop app, VS Code extension, Visual Studio extension.