### PR TITLE
docs(clients): add Obsidian Harness plugin

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -19,6 +19,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Obsidian](https://obsidian.md)
   - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
   - through the [Agent Console](https://github.com/donivatamazondotcom/obsidian-agent-console) plugin — a tabbed multi-session workspace: run several ACP agents in parallel with restorable, searchable sessions and quick prompts
+  - through the [Obsidian Harness](https://github.com/vlln/obsidian-harness) plugin — Obsidian as a cockpit for ACP agents (Claude Code, Codex, Gemini CLI, Pi); every agent session is a first-class `.session` vault file with Codex-style Session and Turn navigators
 - [Pulsar](https://pulsar-edit.dev) — through the [pulsar-acp-agent](https://github.com/hovancik/pulsar-acp-agent) package
 - [Qt Creator](https://www.qt.io/development/tools/qt-creator-ide) — through the [ACP Client Plugin](https://doc.qt.io/qtcreator/creator-how-to-use-acp-client.html)
 - [Unity ACP Client](https://github.com/3DLabInstruments/UnityACPClient)(Unity plugin)


### PR DESCRIPTION
Adds [Obsidian Harness](https://github.com/vlln/obsidian-harness) under the Obsidian entry in the clients list.

Obsidian Harness is an Obsidian plugin that turns the vault into a cockpit for ACP agents (Claude Code, Codex, Gemini CLI, Pi). Every agent session is a first-class `.session` vault file — openable, linkable, searchable, and resumable — with Codex-style Session and Turn navigators. Public release: https://github.com/vlln/obsidian-harness/releases/tag/v0.6.0 ; docs: https://vlln.github.io/obsidian-harness/ .