### PR TITLE
docs: add Gold Band to desktop clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -53,6 +53,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Devin Desktop](https://devin.ai/desktop)
 - [fabriqa.ai](https://fabriqa.ai)
 - [gemini-cli-desktop](https://github.com/Piebald-AI/gemini-cli-desktop)
+- [Gold Band](https://github.com/diodeme/Gold-Band) — open-source, local-first ACP desktop client supporting direct agent conversations, DSL-based workflow orchestration, AI-generated dynamic workflows, and unified context management (Windows, macOS, Linux)
 - [Harnss](https://github.com/OpenSource03/harnss)
 - [Jockey](https://github.com/recailai/jockey) — open-source multi-agent orchestrator (Tauri + Rust + SolidJS) that coordinates Claude Code, Gemini CLI, and Codex CLI via ACP
 - [Lody](https://lody.ai)


### PR DESCRIPTION
## Summary

Add [Gold Band](https://github.com/diodeme/Gold-Band) to the **Desktop and Web** section of the ACP clients page.

Gold Band is an open-source, local-first ACP desktop client. It supports:

- Direct agent conversations
- Declarative DSL-based workflow orchestration
- AI-generated dynamic workflows
- Unified context management
- Windows, macOS, and Linux

Gold Band uses ACP directly to launch and communicate with local coding agents.

## Verification

- Confirmed the entry is placed in alphabetical order
- Ran `git diff --check`