### PR TITLE
Add Poolside Desktop Assistant to clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -59,6 +59,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Minion Mind](https://minion-mind.nebulame.com/) — through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
 - [Mitto](https://github.com/inercia/mitto)
 - [Ngent](https://github.com/beyond5959/ngent)
+- [Poolside Desktop Assistant](https://poolside.ai/get-started)
 - [RayClaw](https://github.com/rayclaw/rayclaw?tab=readme-ov-file#acp-agent-client-protocol)
 - [RLM Code](https://github.com/SuperagenticAI/rlm-code)
 - [Sidequery _(coming soon)_](https://sidequery.dev)


### PR DESCRIPTION
On July 28, 2026, Poolside released their Desktop Assistant GUI: https://x.com/poolsideai/status/2082149183625085360

_"[Poolside Desktop Assistant is] vendor-agnostic and ACP-powered, so you can bring any compatible agent."_

You can get it at https://poolside.ai/get-started