### PR TITLE
docs: clarify the session/update variant set is not exhaustive

### DIFF
--- a/docs/protocol/v1/draft/extensibility.mdx
+++ b/docs/protocol/v1/draft/extensibility.mdx
@@ -132,3 +132,7 @@ Implementations **SHOULD** use the `_meta` field in capability objects to advert
 ```
 
 This allows implementations to negotiate custom features during initialization without breaking compatibility with standard Clients and Agents.
+
+## Unrecognized Session Update Variants
+
+Every `session/update` notification carries a `sessionUpdate` field that identifies the variant. Future protocol versions may define new variants. Clients are encouraged to ignore variants they do not recognize rather than treating them as errors. The [`SessionUpdate`](/protocol/v1/draft/schema#sessionupdate) schema reference lists the variants defined in this version.

--- a/docs/protocol/v1/draft/prompt-turn.mdx
+++ b/docs/protocol/v1/draft/prompt-turn.mdx
@@ -105,6 +105,13 @@ Upon receiving the prompt request, the Agent processes the user's message and se
 
 The Agent reports the model's output to the Client via `session/update` notifications. This may include the Agent's plan for accomplishing the task:
 
+<Note>
+  This page walks through the `session/update` variants most common in a prompt
+  turn. It is not the full set. See the
+  [`SessionUpdate`](/protocol/v1/draft/schema#sessionupdate) schema reference
+  for every variant defined in this version.
+</Note>
+
 ```json expandable
 {
   "jsonrpc": "2.0",

--- a/docs/protocol/v1/extensibility.mdx
+++ b/docs/protocol/v1/extensibility.mdx
@@ -132,3 +132,7 @@ Implementations **SHOULD** use the `_meta` field in capability objects to advert
 ```
 
 This allows implementations to negotiate custom features during initialization without breaking compatibility with standard Clients and Agents.
+
+## Unrecognized Session Update Variants
+
+Every `session/update` notification carries a `sessionUpdate` field that identifies the variant. Future protocol versions may define new variants. Clients are encouraged to ignore variants they do not recognize rather than treating them as errors. The [`SessionUpdate`](/protocol/v1/schema#sessionupdate) schema reference lists the variants defined in this version.

--- a/docs/protocol/v1/prompt-turn.mdx
+++ b/docs/protocol/v1/prompt-turn.mdx
@@ -105,6 +105,13 @@ Upon receiving the prompt request, the Agent processes the user's message and se
 
 The Agent reports the model's output to the Client via `session/update` notifications. This may include the Agent's plan for accomplishing the task:
 
+<Note>
+  This page walks through the `session/update` variants most common in a prompt
+  turn. It is not the full set. See the
+  [`SessionUpdate`](/protocol/v1/schema#sessionupdate) schema reference for
+  every variant defined in this version.
+</Note>
+
 ```json expandable
 {
   "jsonrpc": "2.0",


### PR DESCRIPTION
Fixes #1694.

The prompt-turn page walks a turn through five `session/update` variants, while `schema/v1/schema.json` defines eleven. Nothing marks the walkthrough as partial, so it reads as the full set.

Adds a Note pointing at the `SessionUpdate` schema reference, plus a short section in `extensibility.mdx` on unrecognized variants, which that page didn't cover. The `draft/` copies get the same change, matching 8750b93.

Two calls worth flagging: I kept the extensibility wording advisory rather than **SHOULD**, since `SessionUpdate` is a closed `oneOf` with no catch-all. And v2 has the same gap (9 shown against 17) which I left alone, happy to add it here or in a follow-up.

The StopReason question in the issue is a separate protocol matter, untouched here.
