### PR TITLE
docs(clients): Add Multicoder extension

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -29,6 +29,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
   - [ACP Patchbay](https://github.com/solutionsunity/acp-patchbay) extension
   - [ACP Pro Extension](https://marketplace.visualstudio.com/items?itemName=duclvz.acp-pro)
     - VS Code–compatible IDEs (Cursor, Windsurf, Trae,..): [ACP Pro Extension](https://open-vsx.org/extension/duclvz/acp-pro)
+  - [Multicoder](https://marketplace.visualstudio.com/items?itemName=multicoder.multicoder) extension
   - [Poolside Assistant](https://marketplace.visualstudio.com/items?itemName=poolside-ai.acp-assistant)
 - [Zed](https://zed.dev/docs/ai/external-agents)
 


### PR DESCRIPTION
Add [Multicoder extension](https://marketplace.visualstudio.com/items?itemName=multicoder.multicoder) to the clients list (VS Code section)

Multicoder VS Code extension allows switching between multiple agents, provides more visibility and better VS Code integration:

- 1-click install for 35+ agents from the [ACP registry](https://agentclientprotocol.com/get-started/registry)
- all your agent sessions in one place - CLI history included
- per-agent session params: model, thinking level, permission mode
- full session introspection: outline, reasoning blocks, tool calls, subagent runs
- changed files with aggregated and per-change diffs
- per-file change history - which session last touched it
- works in remote workspaces (SSH, WSL, containers)

Questions and ideas: [GitHub Discussions](https://github.com/multicoder-ai/vscode-release/discussions)

Bugs: [GitHub Issues](https://github.com/multicoder-ai/vscode-release/issues)
