### PR TITLE
docs: add qwen-audio-agent voice client to clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -62,6 +62,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Mitto](https://github.com/inercia/mitto)
 - [Ngent](https://github.com/beyond5959/ngent)
 - [Poolside Desktop Assistant](https://poolside.ai/get-started) - An agent agnostic worktree native macOS desktop app.
+- [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) — realtime full-duplex voice client for ACP agents, with wake word and barge-in (macOS desktop, TUI, Web)
 - [RayClaw](https://github.com/rayclaw/rayclaw?tab=readme-ov-file#acp-agent-client-protocol)
 - [RLM Code](https://github.com/SuperagenticAI/rlm-code)
 - [Sidequery _(coming soon)_](https://sidequery.dev)


### PR DESCRIPTION
Adds qwen-audio-agent to the **Desktop and Web** clients section.

qwen-audio-agent implements ACP directly as a client: it is a realtime full-duplex voice runtime that spawns ACP agents (Claude Code via claude-code-acp, OpenCode, Codex, Kimi CLI, and more) and lets users converse with them by voice — including local wake word, barge-in, and async task results flowing back into the conversation. Ships a macOS desktop app, terminal TUI, and web UI.

Disclosure: I am a maintainer of this project.