### PR TITLE
docs(clients): add BitFun desktop and CLI clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -37,6 +37,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 ## CLI and TUI
 
 - [acpx (CLI)](https://github.com/openclaw/acpx)
+- [BitFun CLI](https://github.com/GCWing/BitFun) — Rust-powered TUI that can expose the BitFun runtime over ACP or launch OpenCode, Claude Code, and Codex as external ACP agents
 - [Hash (shell)](https://github.com/tfcace/hash)
 - [Hydra](https://github.com/smagnuso/hydra-acp)
 - [Nori CLI](https://github.com/tilework-tech/nori-cli)
@@ -50,6 +51,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [AgentRQ](https://github.com/agentrq/agentrq) — Human-in-the-loop realtime task management and collaboration (Web)
 - [AionUi](https://github.com/iOfficeAI/AionUi)
 - [aizen](https://aizen.win)
+- [BitFun](https://github.com/GCWing/BitFun) — cross-platform desktop ACP client with a shared Rust runtime, local and remote workspaces, and stateful Mini Apps
 - [Braide](https://braide.dev) - Parallel sessions, worktrees, personas and interactive agent responses (supports macOS, Windows, Linux)
 - [Casper](https://github.com/joeyshi12/casper) - A web client for kiro-cli that talks to it over the Agent Client Protocol (ACP), giving you a browser-based chat UI with live streaming, session history, and rich per-tool-call rendering.
 - [Codeg](https://github.com/xintaofei/codeg) — collaborative multi-agent coding workbench that unifies ACP agents (Claude Code, Codex, Gemini CLI, OpenCode, and more) with session aggregation; desktop app, self-hosted server, or Docker (macOS, Windows, Linux, Web)


### PR DESCRIPTION
Adds BitFun to the **CLI and TUI** and **Desktop and Web** client sections.

BitFun implements both sides of ACP directly. Its CLI can expose the BitFun runtime as an ACP server, or act as a client for OpenCode, Claude Code, Codex, and other configured agents. The desktop app uses the same client implementation for local and remote workspaces.

Implementation:
- https://github.com/GCWing/BitFun/blob/main/src/apps/cli/src/acp_cli.rs#L201-L219
- https://github.com/GCWing/BitFun/blob/main/src/crates/interfaces/acp/src/client/builtin_clients.rs#L25-L68

Validation: Prettier and `git diff --check` passed. The repository spellcheck wrapper could not run because `typos` is not installed in this environment.

Disclosure: I maintain BitFun. Codex helped inspect the ACP implementation and contribution rules and prepare this two-line documentation change; I reviewed the source claims and final diff.
