### PR TITLE
docs: add CompozyOS to desktop and web clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -53,6 +53,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Braide](https://braide.dev) - Parallel sessions, worktrees, personas and interactive agent responses (supports macOS, Windows, Linux)
 - [Casper](https://github.com/joeyshi12/casper) - A web client for kiro-cli that talks to it over the Agent Client Protocol (ACP), giving you a browser-based chat UI with live streaming, session history, and rich per-tool-call rendering.
 - [Codeg](https://github.com/xintaofei/codeg) — collaborative multi-agent coding workbench that unifies ACP agents (Claude Code, Codex, Gemini CLI, OpenCode, and more) with session aggregation; desktop app, self-hosted server, or Docker (macOS, Windows, Linux, Web)
+- [CompozyOS](https://github.com/compozy/compozy) — open-source agent OS: runs ACP agents as a team on loops and schedules, with shared memory and approvals (Web, CLI)
 - [DeepChat](https://github.com/ThinkInAIXYZ/deepchat)
 - [Devin Desktop](https://devin.ai/desktop)
 - [fabriqa.ai](https://fabriqa.ai)


### PR DESCRIPTION
CompozyOS is an open-source (MIT) operating system for AI agents. It runs the agent CLIs you already use as a team on loops and schedules, with shared project memory, scoped permissions, approvals and an audit trail, all supervised from a web shell. Single Go binary, SQLite-backed, local-first.

- Repo: https://github.com/compozy/compozy
- Site: https://www.compozy.com
- License: MIT

Added under **Desktop and Web**, following the section's existing ordering and format.
