### PR TITLE
Add Raxol to the agents list, and an Elixir community library

### DIFF
--- a/docs/get-started/agents.mdx
+++ b/docs/get-started/agents.mdx
@@ -38,6 +38,7 @@ The following agents can be used with an ACP Client:
 - [Poolside](https://github.com/poolsideai/pool)
 - [Qoder CLI](https://docs.qoder.com/cli/acp)
 - [Qwen Code](https://github.com/QwenLM/qwen-code)
+- [Raxol](https://github.com/DROOdotFOO/raxol/blob/master/docs/features/CODING_AGENT.md) (`raxol acp`)
 - [siGit Code](https://github.com/getsigit/sigit)
 - [Stakpak](https://github.com/stakpak/agent?tab=readme-ov-file#agent-client-protocol-acp)
 - [stdio Bus](https://github.com/stdiobus/stdiobus)

--- a/docs/libraries/community.mdx
+++ b/docs/libraries/community.mdx
@@ -17,6 +17,10 @@ description: "Community managed libraries for the Agent Client Protocol"
 - [Acp.Net](https://github.com/MertBasar0/acp-net)
 - [Agentic.ACPLibrary](https://github.com/AgenticDesktop/ACPLibrary)
 
+## Elixir
+
+- [raxol_agent_client_protocol](https://github.com/DROOdotFOO/raxol/tree/master/packages/raxol_agent_client_protocol)
+
 ## Emacs
 
 - [acp.el](https://github.com/xenodium/acp.el)


### PR DESCRIPTION
Two small additions, both for [Raxol](https://github.com/DROOdotFOO/raxol).

**Agents list.** `raxol acp` serves a coding agent over ACP from a self-contained binary, so there is no Erlang or Elixir install required on the host. Inserted alphabetically.

**Community libraries — Elixir.** There is no Elixir section on the page today. [`raxol_agent_client_protocol`](https://github.com/DROOdotFOO/raxol/tree/master/packages/raxol_agent_client_protocol) is an Elixir/OTP implementation of ACP v1 covering **both roles** — agent and client — including the agent→client direction (`session/request_permission`, `fs/*`, `terminal/*`). It runs one supervised process per connection with per-session processes under a `DynamicSupervisor`, and generates its callback surface and dispatcher from a single method table so the two cannot drift apart. Transports are stdio and an in-process pair for tests.

It is honest about its stage: `0.1.0-rc.0`, pre-alpha, not yet on Hex, and the README says so up front. Happy to hold this half until it is published if you would rather the list only carry released packages.

Provenance is deliberately layered, since it matters for a protocol project: the schema layer is ported MIT→MIT from `f1729/agent_client_protocol`, the conformance corpus MIT→MIT from `openclaw/acpx`, and the OTP runtime is clean-room. The official ACP JSON Schema is vendored as a SHA256-pinned dev/test oracle with a drift-check task, and excluded from any published package so its terms never propagate downstream. Details in [`NOTICE.md`](https://github.com/DROOdotFOO/raxol/blob/master/packages/raxol_agent_client_protocol/NOTICE.md).

Separately, the registry entry is in flight as agentclientprotocol/registry#492.
