### PR TITLE
docs: list Copilot for Obsidian client

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -19,6 +19,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Obsidian](https://obsidian.md)
   - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
   - through the [Agent Console](https://github.com/donivatamazondotcom/obsidian-agent-console) plugin — a tabbed multi-session workspace: run several ACP agents in parallel with restorable, searchable sessions and quick prompts
+  - through the [Copilot for Obsidian](https://github.com/logancyang/obsidian-copilot) plugin — runs OpenCode and Codex through ACP with vault context, projects, and shared skills
   - through the [Obsidian Harness](https://github.com/vlln/obsidian-harness) plugin — Obsidian as a cockpit for ACP agents (Claude Code, Codex, Gemini CLI, Pi); every agent session is a first-class `.session` vault file with Codex-style Session and Turn navigators
 - [Pulsar](https://pulsar-edit.dev) — through the [pulsar-acp-agent](https://github.com/hovancik/pulsar-acp-agent) package
 - [Qt Creator](https://www.qt.io/development/tools/qt-creator-ide) — through the [ACP Client Plugin](https://doc.qt.io/qtcreator/creator-how-to-use-acp-client.html)


### PR DESCRIPTION
## Summary

Add Copilot for Obsidian to the official ACP client list under Obsidian. Copilot runs OpenCode and Codex through ACP and provides vault context, projects, and shared skills.

## Validation

- `npx --yes prettier@3.9.6 --check docs/get-started/clients.mdx`
