### PR TITLE
docs: add Claw Orchestrator to the agents list

### DIFF
--- a/docs/get-started/agents.mdx
+++ b/docs/get-started/agents.mdx
@@ -11,6 +11,7 @@ The following agents can be used with an ACP Client:
 - [Blackbox AI](https://docs.blackbox.ai/features/blackbox-cli/introduction)
 - [Bub](https://github.com/bubbuild/bub) (via [bub-acp-server](https://github.com/bubbuild/bub-contrib/tree/main/packages/bub-acp-server))
 - [Claude Agent](https://platform.claude.com/docs/en/agent-sdk/overview) (via [Zed's SDK adapter](https://github.com/zed-industries/claude-agent-acp))
+- [Claw Orchestrator](https://github.com/Enderfga/claw-orchestrator/blob/main/skills/references/acp.md)
 - [Cline](https://cline.bot/)
 - [Codex CLI](https://developers.openai.com/codex/cli) (via [Zed's adapter](https://github.com/zed-industries/codex-acp))
 - [Code Assistant](https://github.com/stippi/code-assistant?tab=readme-ov-file#configuration)


### PR DESCRIPTION
Adds [Claw Orchestrator](https://github.com/Enderfga/claw-orchestrator), which serves ACP over stdio via `clawo acp` (npm: `@enderfga/claw-orchestrator`).

It differs from the other entries in one way worth noting: it is a multi-engine runtime rather than a single agent. So `session/new` returns a `category: "model"` config option whose values are **grouped by engine** — one dropdown spanning Claude Code, Codex and Cursor models, switchable mid-session — and its session modes run multi-agent orchestrations (a council of several engines in isolated git worktrees, reported as one `tool_call` per member).

Built against stable v1 with `@agentclientprotocol/sdk` 1.3.0. Verified against the SDK's own client, and driven from VS Code with the ACP Client extension.

Two limitations, stated up front since client authors care about them: `loadSession` is advertised as `false`, and `session/request_permission` is not implemented (permission resolves into engine CLI flags at session start, so a mid-turn request cannot be honoured — it is offered as a session config option instead). Both are documented in the linked reference.

Listed in `agents.mdx` rather than the ACP Registry, since the registry is limited to agents that support authentication and this one advertises no auth methods.