### PR TITLE
docs: Add Kronos to clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -62,6 +62,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Harnss](https://github.com/OpenSource03/harnss)
 - [Jockey](https://github.com/recailai/jockey) — open-source multi-agent orchestrator (Tauri + Rust + SolidJS) that coordinates Claude Code, Gemini CLI, and Codex CLI via ACP
 - [Kepler](https://www.gitkraken.com/kepler) — GitKraken’s agentic development environment (ADE) giving you full clarity and control to run parallel agents at scale
+- [Kronos](https://github.com/Reqeique/Kronos) — self-hosted scheduler and orchestration dashboard that runs ACP agent tasks on schedules via a bridge CLI, with Slack channel delivery and a real-time dashboard
 - [Lody](https://lody.ai)
 - [Minion Mind](https://minion-mind.nebulame.com/) — through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
 - [Mitto](https://github.com/inercia/mitto)


### PR DESCRIPTION
Adds [Kronos](https://github.com/Reqeique/Kronos) to the Clients page (Desktop and Web section).

Kronos is a self-hosted scheduler and orchestration dashboard that runs agent tasks through ACP: tasks are scheduled from a web dashboard, delivered to workers via a streamable-HTTP queue, and executed by driving any ACP-compatible agent through the ACP SDK, with lifecycle events streamed back to the dashboard in real time (optional Slack channel delivery).

Related entries on the same page: Jockey, CompozyOS, Codeg.