### PR TITLE
docs: add Open Knowledge to clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -20,6 +20,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
   - through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
   - through the [Agent Console](https://github.com/donivatamazondotcom/obsidian-agent-console) plugin — a tabbed multi-session workspace: run several ACP agents in parallel with restorable, searchable sessions and quick prompts
   - through the [Obsidian Harness](https://github.com/vlln/obsidian-harness) plugin — Obsidian as a cockpit for ACP agents (Claude Code, Codex, Gemini CLI, Pi); every agent session is a first-class `.session` vault file with Codex-style Session and Turn navigators
+- [Open Knowledge](https://openknowledge.ai) — local-first Markdown knowledge base with built-in ACP agent threads and one-click agent install from the ACP Registry
 - [Pulsar](https://pulsar-edit.dev) — through the [pulsar-acp-agent](https://github.com/hovancik/pulsar-acp-agent) package
 - [Qt Creator](https://www.qt.io/development/tools/qt-creator-ide) — through the [ACP Client Plugin](https://doc.qt.io/qtcreator/creator-how-to-use-acp-client.html)
 - [Unity ACP Client](https://github.com/3DLabInstruments/UnityACPClient)(Unity plugin)


### PR DESCRIPTION
Adds Open Knowledge to the Editors and IDEs section (alphabetically, between Obsidian and Pulsar).

## What is Open Knowledge?

[Open Knowledge](https://github.com/inkeep/open-knowledge) is an open-source, local-first Markdown knowledge base and editor (an "AI-native markdown IDE") with **3.4k+ stars and 220+ forks on GitHub**. It ships as a desktop app for macOS, Windows, and Linux, and as a CLI ([`@inkeep/open-knowledge`](https://www.npmjs.com/package/@inkeep/open-knowledge) on npm).

## ACP support is native and first-party

- Agent threads run in a side panel next to your documents, built directly on `@agentclientprotocol/sdk` (protocol v1: fs read/write, terminals, permissions, session config options, slash commands, session resume).
- Agents install in one click from the ACP Registry — the app consumes `cdn.agentclientprotocol.com/registry/v1/latest/registry.json` live, including auth-method handling and managed runtimes for `npx`/`uvx` distributions. Registry additions show up for Open Knowledge users with no app update.
- ACP functionality of OpenKnowledge is built into the product itself and maintained by the core team.

Website: https://openknowledge.ai
