### PR TITLE
docs: add Alchemy to the client list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -52,6 +52,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [AgentRQ](https://github.com/agentrq/agentrq) — Human-in-the-loop realtime task management and collaboration (Web)
 - [AionUi](https://github.com/iOfficeAI/AionUi)
 - [aizen](https://aizen.win)
+- [Alchemy](https://github.com/thrashr888/alchemy) — local-first research notebook for macOS: run your own coding agent inside a notebook, with that notebook's sources reachable over the app's built-in MCP server
 - [Braide](https://braide.dev) - Parallel sessions, worktrees, personas and interactive agent responses (supports macOS, Windows, Linux)
 - [Casper](https://github.com/joeyshi12/casper) - A web client for kiro-cli that talks to it over the Agent Client Protocol (ACP), giving you a browser-based chat UI with live streaming, session history, and rich per-tool-call rendering.
 - [Codeg](https://github.com/xintaofei/codeg) — collaborative multi-agent coding workbench that unifies ACP agents (Claude Code, Codex, Gemini CLI, OpenCode, and more) with session aggregation; desktop app, self-hosted server, or Docker (macOS, Windows, Linux, Web)

--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -52,7 +52,6 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [AgentRQ](https://github.com/agentrq/agentrq) — Human-in-the-loop realtime task management and collaboration (Web)
 - [AionUi](https://github.com/iOfficeAI/AionUi)
 - [aizen](https://aizen.win)
-- [Alchemy](https://github.com/thrashr888/alchemy) — local-first research notebook for macOS: run your own coding agent inside a notebook, with that notebook's sources reachable over the app's built-in MCP server
 - [Braide](https://braide.dev) - Parallel sessions, worktrees, personas and interactive agent responses (supports macOS, Windows, Linux)
 - [Casper](https://github.com/joeyshi12/casper) - A web client for kiro-cli that talks to it over the Agent Client Protocol (ACP), giving you a browser-based chat UI with live streaming, session history, and rich per-tool-call rendering.
 - [Codeg](https://github.com/xintaofei/codeg) — collaborative multi-agent coding workbench that unifies ACP agents (Claude Code, Codex, Gemini CLI, OpenCode, and more) with session aggregation; desktop app, self-hosted server, or Docker (macOS, Windows, Linux, Web)
@@ -86,6 +85,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 ## Notebook and data tools
 
 - [agent-client-kernel](https://github.com/wiki3-ai/agent-client-kernel) (Jupyter notebooks)
+- [Alchemy](https://github.com/thrashr888/alchemy) — local-first research notebook for macOS: run your own coding agent inside a notebook, with that notebook's sources reachable over the app's built-in MCP server
 - DuckDB — through the [sidequery/duckdb-acp](https://github.com/sidequery/duckdb-acp) extension
 - [marimo notebook](https://github.com/marimo-team/marimo)
 


### PR DESCRIPTION
Adds [Alchemy](https://github.com/thrashr888/alchemy) under **Notebook and data tools**.

Alchemy is a local-first research notebook for macOS. A notebook holds sources (documents, web pages, pasted text) and notes; the Agent view runs the user's own installed coding agent over ACP inside that notebook, and passes the app's built-in MCP server in `session/new` so the agent can search the notebook's sources while it works.

- ACP client since v0.44.0, built on the `agent-client-protocol` Rust SDK (v2).
- Ships support for opencode, Claude Code (via `@agentclientprotocol/claude-agent-acp`) and Codex (via `@agentclientprotocol/codex-acp`), with permission prompts, cancellation, and one session per notebook.
- The agent's own CLI login is the credential; Alchemy stores no provider keys for it.

Filed under *Notebook and data tools* since that is where a reader looking for notebook clients will look, though it is a research notebook rather than a computational one like the other entries there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)