### PR TITLE
docs: add Martty to CLI and TUI clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -41,6 +41,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [acpx (CLI)](https://github.com/openclaw/acpx)
 - [Hash (shell)](https://github.com/tfcace/hash)
 - [Hydra](https://github.com/smagnuso/hydra-acp)
+- [Martty](https://github.com/openma-ai/Martty) — extensible Rust/ratatui terminal client for DeepSeek Harness and other ACP-compatible agents
 - [Nori CLI](https://github.com/tilework-tech/nori-cli)
 - [pool](https://github.com/poolsideai/pool)
 - [Toad](https://www.batrachian.ai/)


### PR DESCRIPTION
Add Martty to the CLI and TUI client directory.

Martty is a terminal-native ACP client built in Rust/ratatui. It directly depends on the official `agent-client-protocol` Rust crate and can launch or attach to ACP-compatible agents, with DeepSeek Harness as its default integration.

Repository: https://github.com/openma-ai/Martty
