### PR TITLE
docs: add Ghosty Teams to ACP clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -60,6 +60,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Devin Desktop](https://devin.ai/desktop)
 - [fabriqa.ai](https://fabriqa.ai)
 - [gemini-cli-desktop](https://github.com/Piebald-AI/gemini-cli-desktop)
+- [Ghosty Teams](https://ghosty.studio) — multi-tenant team workspace where ACP agents work alongside chat, collaborative documents, artifacts, forms, and live calls (Web)
 - [Gold Band](https://github.com/diodeme/Gold-Band) — open-source, local-first ACP desktop client supporting direct agent conversations, DSL-based workflow orchestration, AI-generated dynamic workflows, and unified context management (Windows, macOS, Linux)
 - [Harnss](https://github.com/OpenSource03/harnss)
 - [Jockey](https://github.com/recailai/jockey) — open-source multi-agent orchestrator (Tauri + Rust + SolidJS) that coordinates Claude Code, Gemini CLI, and Codex CLI via ACP


### PR DESCRIPTION
Adds Ghosty Teams to the Desktop and Web section of the clients list.

Ghosty Teams is a multi-tenant team workspace that acts as an ACP client, running ACP agents alongside chat, collaborative documents, artifacts, forms, and live calls.

Agents are added by pasting a WebSocket endpoint, given a `@handle`, and then addressed from any channel or DM in the workspace:

<img src="https://raw.githubusercontent.com/blissito/agent-client-protocol/pr-assets/ghosty-teams-acp.png" alt="Adding an ACP agent to a Ghosty Teams workspace by WebSocket URL and @handle" width="620">
