### PR TITLE
docs: add tlbx to Desktop and Web clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -76,6 +76,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Shellular](https://shellular.dev) ([GitHub](https://github.com/shellular-org))
 - [Sidequery _(coming soon)_](https://sidequery.dev)
 - [Tidewave](https://tidewave.ai/)
+- [tlbx](https://github.com/tlbx-ai/tlbx) — self-hosted browser control station for persistent ACP agent and terminal sessions on Windows, macOS, and Linux, supervised from desktop, tablet, or phone browsers
 - [Web Browser with AI SDK](https://github.com/mcpc-tech/ai-elements-remix-template) (powered by [@mcpc/acp-ai-provider](https://github.com/mcpc-tech/mcpc/tree/main/packages/acp-ai-provider))
 - [Kangaroo](https://github.com/dbkangaroo/kangaroo) — database IDE with Agent Client Protocol support
 - [ACP Components](https://github.com/zvzuola/acp-components) - A universal frontend component library for building AI Agent interfaces based on the ACP


### PR DESCRIPTION
Adds [tlbx](https://github.com/tlbx-ai/tlbx) to the **Desktop and Web** clients section.

tlbx is an open-source, self-hosted browser control station for persistent coding-agent and terminal sessions on Windows, macOS, and Linux. Release `v10.8.18-dev` adds a provider-neutral ACP v1 stdio runtime plus local discovery and bookmark relaunch for Grok Build and OpenCode. Codex is supported separately through its native app-server transport.

Evidence:
- [ACP client description in the release README](https://github.com/tlbx-ai/tlbx/tree/v10.8.18-dev#agent-cli-ergonomics)
- [`v10.8.18-dev` release](https://github.com/tlbx-ai/tlbx/releases/tag/v10.8.18-dev)
- [Release workflow](https://github.com/tlbx-ai/tlbx/actions/runs/33015123084)