### PR TITLE
docs(clients): add AgentConnect to Desktop and Web

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -49,6 +49,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 
 - [ACP UI](https://github.com/formulahendry/acp-ui) (Windows, macOS, Linux, iOS, Android, Web)
 - [Agent Studio](https://github.com/sxhxliang/agent-studio)
+- [AgentConnect](https://github.com/agentconnect-md/agentconnect) — open-source multi-agent platform that brings ACP agents into team workflows across Slack, Telegram, Discord, Lark, GitHub, and GitLab, managed from a web console
 - [AgentRQ](https://github.com/agentrq/agentrq) — Human-in-the-loop realtime task management and collaboration (Web)
 - [AionUi](https://github.com/iOfficeAI/AionUi)
 - [aizen](https://aizen.win)


### PR DESCRIPTION
## Summary

Add [AgentConnect](https://github.com/agentconnect-md/agentconnect) to the Desktop and Web clients list.

AgentConnect is an open-source multi-agent platform whose daemon acts as an ACP client using [`@agentclientprotocol/sdk`](https://github.com/agentconnect-md/agentconnect/blob/main/packages/daemon/package.json#L44). It brings ACP-compatible agents into shared team workflows across Slack, Telegram, Discord, Lark, GitHub, and GitLab, managed from a web console.

- Repository: https://github.com/agentconnect-md/agentconnect
- Website: https://agentconnect.md
- Scope: one documentation-only entry in `docs/get-started/clients.mdx`

## Validation

- `npx prettier --check docs/get-started/clients.mdx`
- `git diff --check upstream/main...HEAD`

Created by Codex . GPT-5
