### PR TITLE
docs: add Remote Agent Server to ACP clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -72,6 +72,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Poolside Desktop Assistant](https://poolside.ai/get-started) - An agent agnostic worktree native macOS desktop app.
 - [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) — realtime full-duplex voice client for ACP agents, with wake word and barge-in (macOS desktop, TUI, Web)
 - [RayClaw](https://github.com/rayclaw/rayclaw?tab=readme-ov-file#acp-agent-client-protocol)
+- [Remote Agent Server](https://github.com/ma-pony/remote-agent-server) — self-hosted Web UI and asynchronous HTTP API for running Codex and Claude Code through ACP, with persistent sessions, isolated workspaces, and per-agent MCP and Skills configuration
 - [RLM Code](https://github.com/SuperagenticAI/rlm-code)
 - [Shellular](https://shellular.dev) ([GitHub](https://github.com/shellular-org))
 - [Sidequery _(coming soon)_](https://sidequery.dev)

--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -72,7 +72,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Poolside Desktop Assistant](https://poolside.ai/get-started) - An agent agnostic worktree native macOS desktop app.
 - [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) — realtime full-duplex voice client for ACP agents, with wake word and barge-in (macOS desktop, TUI, Web)
 - [RayClaw](https://github.com/rayclaw/rayclaw?tab=readme-ov-file#acp-agent-client-protocol)
-- [Remote Agent Server](https://github.com/ma-pony/remote-agent-server) — self-hosted Web UI and asynchronous HTTP API for running Codex and Claude Code through ACP, with persistent sessions, isolated workspaces, and per-agent MCP and Skills configuration
+- [Remote Agent Server](https://github.com/ma-pony/remote-agent-server) — self-hosted ACP agent execution gateway for external systems that runs Codex and Claude Code through an asynchronous Task API, with isolated workspaces, persistent sessions, per-agent MCP and Skills, event history, SSE, and signed Webhooks
 - [RLM Code](https://github.com/SuperagenticAI/rlm-code)
 - [Shellular](https://shellular.dev) ([GitHub](https://github.com/shellular-org))
 - [Sidequery _(coming soon)_](https://sidequery.dev)


### PR DESCRIPTION
Adds [Remote Agent Server](https://github.com/ma-pony/remote-agent-server) to the Desktop and Web client list.

Remote Agent Server is a self-hosted ACP agent execution gateway for external systems. It runs Codex and Claude Code behind an asynchronous Task API and provides isolated workspaces, persistent sessions, per-agent MCP and Skills, event history, SSE, and signed Webhooks.

License: MIT

Checks:
- `npx prettier --check docs/get-started/clients.mdx`
- `git diff --check`