### PR TITLE
docs: add Runmote to mobile clients

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -96,7 +96,7 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 - [Ferngeist](https://github.com/arafatamim/Ferngeist) (Android)
 - [Happy](https://happy.engineering/) ([GitHub](https://github.com/slopus/happy)) (iOS, Android, Web)
 - [Mobvibe](https://github.com/Eric-Song-Nop/mobvibe) (iOS, Android, Web)
-- [Runmote](https://runmote.dev) ([GitHub](https://github.com/Raza-learner/Runmote)) (iOS, Android, Linux, macOS, Windows) — Run any ACP agent on your PC from your phone via QR code or 8-digit pairing; no SSH/VPN
+- [Runmote](https://runmote.dev) ([GitHub](https://github.com/Raza-learner/Runmote)) (Android, Linux, macOS, Windows) — Run any ACP agent on your PC from your phone via QR code or 8-digit pairing; no SSH/VPN
 - [Shellular](https://shellular.dev) ([GitHub](https://github.com/shellular-org)) (iOS, Android, [Web](https://app.shellular.dev))
 - [VACP](https://play.google.com/store/apps/details?id=com.intellexie.vacp) (Android) — voice control for AI coding agents (OpenCode, KiloCode, and any ACP-compatible agent over TCP)
 

--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -96,6 +96,7 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 - [Ferngeist](https://github.com/arafatamim/Ferngeist) (Android)
 - [Happy](https://happy.engineering/) ([GitHub](https://github.com/slopus/happy)) (iOS, Android, Web)
 - [Mobvibe](https://github.com/Eric-Song-Nop/mobvibe) (iOS, Android, Web)
+- [Runmote](https://runmote.dev) ([GitHub](https://github.com/Raza-learner/Runmote)) (iOS, Android, Linux, macOS, Windows) — Run any ACP agent on your PC from your phone via QR code or 8-digit pairing; no SSH/VPN
 - [Shellular](https://shellular.dev) ([GitHub](https://github.com/shellular-org)) (iOS, Android, [Web](https://app.shellular.dev))
 - [VACP](https://play.google.com/store/apps/details?id=com.intellexie.vacp) (Android) — voice control for AI coding agents (OpenCode, KiloCode, and any ACP-compatible agent over TCP)
 


### PR DESCRIPTION
Adds Runmote — mobile ACP client + desktop daemon.

- Implements ACP over WSS/stdio, auto-detects opencode/claude/codex/cursor
- Connects via QR code or 8-digit pairing, no SSH/VPN, streaming tool calls/diffs with session resume
- Links: https://runmote.dev | https://github.com/Raza-learner/Runmote
- Category: Mobile clients (alphabetical between Mobvibe and Shellular)

No schema changes, only docs.