### PR TITLE
docs: Link to AgentClientProtocol/codex-acp instead of zed-industries/codex-acp

### DIFF
--- a/docs/get-started/agents.mdx
+++ b/docs/get-started/agents.mdx
@@ -13,7 +13,7 @@ The following agents can be used with an ACP Client:
 - [Claude Agent](https://platform.claude.com/docs/en/agent-sdk/overview) (via [Zed's SDK adapter](https://github.com/zed-industries/claude-agent-acp))
 - [Claw Orchestrator](https://github.com/Enderfga/claw-orchestrator/blob/main/skills/references/acp.md)
 - [Cline](https://cline.bot/)
-- [Codex CLI](https://developers.openai.com/codex/cli) (via [Zed's adapter](https://github.com/zed-industries/codex-acp))
+- [Codex CLI](https://developers.openai.com/codex/cli) (via [ACP's adapter](https://github.com/agentclientprotocol/codex-acp))
 - [Code Assistant](https://github.com/stippi/code-assistant?tab=readme-ov-file#configuration)
 - [Construct](https://github.com/construct-worlds/construct#acp-agent-client-protocol-server)
 - [crow-cli](https://crow-ai.dev)


### PR DESCRIPTION
https://github.com/zed-industries/codex-acp has been archived and development continues at https://github.com/agentclientprotocol/codex-acp