### PR TITLE
Making the ACP more stable

### DIFF
--- a/docs/protocol/v1/extensibility.mdx
+++ b/docs/protocol/v1/extensibility.mdx
@@ -132,3 +132,25 @@ Implementations **SHOULD** use the `_meta` field in capability objects to advert
 ```
 
 This allows implementations to negotiate custom features during initialization without breaking compatibility with standard Clients and Agents.
+
+The same pattern covers capability keys that a newer protocol version drafts. A key the negotiated version does not define, such as a `sessionCapabilities` entry that only exists in a v2 draft, is not a v1 capability. Tolerant clients ignore unknown keys, but clients that validate strictly reject the whole `initialize` response when they hit such a key, and the connection dies before the first turn runs. Advertise version-drafted keys under `_meta` while negotiating with an older protocol version, and promote them into the registered capability object once the version that defines them lands:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "protocolVersion": 1,
+    "agentCapabilities": {
+      "sessionCapabilities": {
+        "list": {},
+        "resume": {},
+        "close": {},
+        "_meta": {
+          "fork": {}
+        }
+      }
+    }
+  }
+}
+```

--- a/docs/protocol/v1/initialization.mdx
+++ b/docs/protocol/v1/initialization.mdx
@@ -109,7 +109,7 @@ Capabilities are high-level and are not attached to a specific base protocol con
 
 Capabilities may specify the availability of protocol methods, notifications, or a subset of their parameters. They may also signal behaviors of the Agent or Client implementation.
 
-Implementations can also [advertise custom capabilities](/protocol/v1/extensibility#advertising-custom-capabilities) using the `_meta` field to indicate support for protocol extensions.
+Implementations can also [advertise custom capabilities](/protocol/v1/extensibility#advertising-custom-capabilities) using the `_meta` field to indicate support for protocol extensions. A capability key that the negotiated protocol version does not define is an extension; it belongs under `_meta` until a protocol version registers it as a first-class capability.
 
 ### Client Capabilities
 


### PR DESCRIPTION
Agents occasionally advertise capability keys that the negotiated protocol version does not define. Under a v1 negotiation, a `sessionCapabilities` object can carry keys that only exist in the v2 draft, such as `fork`. Tolerant clients ignore unknown keys, but strict clients reject the whole `initialize` response over them, and the connection dies before the first turn runs.

While a key is not registered by the negotiated version, the protocol already reserves the right place for it: `_meta`, the extension field every client knows to tolerate. This change documents that rule in the extensibility and initialization guides, with an example showing a v2-drafted session capability advertised through `_meta` during a v1 negotiation.
