### PR TITLE
docs(libraries): add Tangerg/acp to the community Go libraries

### DIFF
--- a/docs/libraries/community.mdx
+++ b/docs/libraries/community.mdx
@@ -31,6 +31,7 @@ description: "Community managed libraries for the Agent Client Protocol"
 - [acp-go](https://github.com/ironpark/acp-go)
 - [acp](https://github.com/eino-contrib/acp)
 - [acp-sdk](https://github.com/spachava753/acp-sdk)
+- [acp](https://github.com/Tangerg/acp)
 
 ## React
 


### PR DESCRIPTION
Adds [acp](https://github.com/Tangerg/acp), a Go implementation of both peers, to the community library list.

- Types are generated from the published `schema-v1.21.0` release assets, and committed, so a schema change is a reviewable source diff
- Serves 23 of the 25 methods; `elicitation/create` and `elicitation/complete` are refused with method-not-found rather than being silently absent
- Apache-2.0