### PR TITLE
docs: add VibeAround to clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -76,6 +76,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Shellular](https://shellular.dev) ([GitHub](https://github.com/shellular-org))
 - [Sidequery _(coming soon)_](https://sidequery.dev)
 - [Tidewave](https://tidewave.ai/)
+- [VibeAround](https://github.com/jazzenchen/VibeAround) — all-in-one hub for ACP coding agents (Claude Code, Codex CLI, Gemini CLI, Pi, OpenCode): launch with any model provider, continue the same session across desktop, CLI/TUI, web, mobile browser, and messaging apps, with local and time-scoped remote preview (macOS, Windows, Linux)
 - [Web Browser with AI SDK](https://github.com/mcpc-tech/ai-elements-remix-template) (powered by [@mcpc/acp-ai-provider](https://github.com/mcpc-tech/mcpc/tree/main/packages/acp-ai-provider))
 - [Kangaroo](https://github.com/dbkangaroo/kangaroo) — database IDE with Agent Client Protocol support
 - [ACP Components](https://github.com/zvzuola/acp-components) - A universal frontend component library for building AI Agent interfaces based on the ACP
@@ -114,6 +115,7 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 - [Lark ACP](https://github.com/4t145/lark-acp) (Lark/飞书)
 - [Zooid](https://github.com/zooid-ai/zooid) (Matrix) - coding agent runtime paired with a Matrix client/ACP bridge for interacting with agents
 - [Pomerium AgentOps](https://github.com/pomerium/agentops) (Slack)
+- [VibeAround](https://github.com/jazzenchen/VibeAround) (Telegram, Feishu/Lark, Discord, Slack, WeChat, WhatsApp, DingTalk, WeCom, QQ) — continue desktop/CLI agent sessions from messaging apps through channel plugins
 
 ## Frameworks
 


### PR DESCRIPTION
Adds [VibeAround](https://github.com/jazzenchen/VibeAround) to the Clients page, in the Desktop and Web section and the Messaging section.

VibeAround is an open-source hub that runs coding agents (Claude Code, Codex CLI, Gemini CLI, Pi, OpenCode) through ACP. It launches an agent with any model provider, then keeps the same ACP session reachable from the desktop app, CLI/TUI, web, mobile browser, and messaging apps via channel plugins (Telegram, Feishu/Lark, Discord, Slack, WeChat, WhatsApp, DingTalk, WeCom, QQ), with local and time-scoped remote preview of dev servers and rendered files. Runs on macOS, Windows, and Linux.

Listed twice following the Shellular precedent, since the messaging channels are a distinct client surface. Related entries on the same page: Codeg, Jockey, Harnss, OpenACP.