### PR TITLE
docs: add Vibex to clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -75,7 +75,8 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [RLM Code](https://github.com/SuperagenticAI/rlm-code)
 - [Shellular](https://shellular.dev) ([GitHub](https://github.com/shellular-org))
 - [Sidequery _(coming soon)_](https://sidequery.dev)
-- [Tidewave](https://tidewave.ai/)
+- [Tidewave](https://tidewave.ai/) 
+- [Vibex](https://github.com/vibex-ai/vibex) — A native, local-first AI coding workbench for Agent-powered software development. Powered by GPUI and ACP. Your agents. Your workspace. Your control—from prompt to commit, desktop to mobile. Works with Codex, Claude Code, OpenCode, Pi, Grok, DeepSeek Harness, Antigravity, and many more through ACP.
 - [Web Browser with AI SDK](https://github.com/mcpc-tech/ai-elements-remix-template) (powered by [@mcpc/acp-ai-provider](https://github.com/mcpc-tech/mcpc/tree/main/packages/acp-ai-provider))
 - [Kangaroo](https://github.com/dbkangaroo/kangaroo) — database IDE with Agent Client Protocol support
 - [ACP Components](https://github.com/zvzuola/acp-components) - A universal frontend component library for building AI Agent interfaces based on the ACP


### PR DESCRIPTION
Adds Vibex to the Clients page (Desktop and Mobile).

Vibex is a native, local-first AI coding workbench (Rust + GPUI, AGPL-3.0) that
runs coding agents through ACP: every online session is driven over ACP by
managed adapters on an authoritative desktop runtime that also owns workspace files, Git, PTYs, providers, and permissions, and the same sessions can be monitored and steered from native iOS/Android companions over Direct, Tailnet, or an encrypted self-hosted Relay. Any ACP-compatible agent works — built-in presets for Claude Code, Codex, ZCode, and OpenCode, plus a catalog including Gemini CLI, GitHub Copilot, Devin, Cursor, and more.

Related entries on the same page: Jockey, CompozyOS, Codeg.