### PR TITLE
docs: add acp-cpp (C++) to community libraries

### DIFF
--- a/docs/libraries/community.mdx
+++ b/docs/libraries/community.mdx
@@ -7,6 +7,10 @@ description: "Community managed libraries for the Agent Client Protocol"
 
 - [acp-cj](https://atomgit.com/ystyle/acp-cj)
 
+## C++
+
+- [acp-cpp](https://github.com/dunkbing/acp-cpp)
+
 ## Crystal
 
 - [acp.cr](https://github.com/hahwul/acp.cr)


### PR DESCRIPTION
## Summary
- add [acp-cpp](https://github.com/dunkbing/acp-cpp), a C++20 client library, to the community libraries page

The library follows the shape of the official SDKs (`acp::Client` for agent→client calls, `acp::Connection` for `initialize`/`session/new`/`session/load`/`session/prompt`/`session/cancel`/`authenticate`, stdio transport). It was extracted from [DearSQL](https://dearsql.dev), where it drives the AI sidebar against Claude Code, Gemini CLI and Codex. MIT licensed.

## Testing
- npx prettier --check docs/libraries/community.mdx