### PR TITLE
docs(libraries): add Caelis Labs ACP Go SDK

### DIFF
--- a/docs/libraries/community.mdx
+++ b/docs/libraries/community.mdx
@@ -36,6 +36,7 @@ description: "Community managed libraries for the Agent Client Protocol"
 - [acp](https://github.com/eino-contrib/acp)
 - [acp-sdk](https://github.com/spachava753/acp-sdk)
 - [acp](https://github.com/Tangerg/acp)
+- [acp-go-sdk](https://github.com/caelis-labs/acp-go-sdk)
 
 ## React
 


### PR DESCRIPTION
Adds [Caelis Labs ACP Go SDK](https://github.com/caelis-labs/acp-go-sdk) to the
Go community libraries list. The existing coder/acp-go-sdk entry is retained;
this project is maintained separately and preserves its upstream attribution.

The stable root package targets ACP v1, with wire types generated from the
pinned official schema-v1.21.0 release. It supports clients and agents,
bounded bidirectional JSON-RPC, lossless batch frames, cancellation, and stdio
NDJSON transport. The repository includes a release-gating, four-direction
interoperability matrix against the official TypeScript and Rust SDKs.
Experimental ACP v2 is isolated in experimental/v2 and is outside the stable
API and cross-SDK conformance claims.

The project is licensed under Apache-2.0; see LICENSE and NOTICE. This PR only
adds the community library link and does not change protocol documentation.

The current stable release is [v1.2.0](https://github.com/caelis-labs/acp-go-sdk/releases/tag/v1.2.0).
Its [release-commit CI](https://github.com/caelis-labs/acp-go-sdk/actions/runs/34078254914)
passed, including official SDK interoperability and native Windows stdio tests.

Validation for this documentation change: Prettier 3.9.6 and git diff --check.
