### PR TITLE
docs(clients): add acp-connector to messaging section

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -113,6 +113,7 @@ These mobile-first tools bring ACP and related coding-agent workflows to phones 
 ## Messaging
 
 - [ACP Discord](https://github.com/broven/acp-discord) (Discord)
+- [acp-connector](https://github.com/galiprandi/acp-connector) (Telegram, Discord) — thin, agent-agnostic bridge with cron jobs, routines, HTTP API, session management, and webhook callbacks
 - [duckdb-claude-slack](https://github.com/sidequery/duckdb-claude-slack) (Slack)
 - [Juan](https://github.com/DiscreteTom/juan) (Slack)
 - [OpenACP](https://github.com/Open-ACP/OpenACP) (Telegram, Discord, Slack) — self-hosted bridge for ACP agents; streams tool calls and responses in real time


### PR DESCRIPTION
## Summary

Add [acp-connector](https://github.com/galiprandi/acp-connector) to the Messaging section of the clients list.

acp-connector is a thin, agent-agnostic bridge that connects Telegram and Discord to any ACP-compatible coding agent. Features include:

- Cron jobs and reusable routines for scheduled/repeated prompts
- HTTP API (`POST /prompt`) with webhook callbacks for CI/CD integration
- Session management commands (`/new`, `/sessions`, `/session`)
- Media handling (images, files)
- Inline permission approvals
- Agent-agnostic — works with Devin, Claude Code, Codex, OpenCode, Gemini CLI, and any ACP agent

Available on npm: https://www.npmjs.com/package/acp-connector

#### Test plan

- [x] Entry added in alphabetical order within the Messaging section
- [x] Link points to the correct GitHub repo
- [x] Description matches the format of other entries