### PR TITLE
docs: add Panda to clients list (Desktop and Web)

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -75,6 +75,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Minion Mind](https://minion-mind.nebulame.com/) — through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
 - [Mitto](https://github.com/inercia/mitto)
 - [Ngent](https://github.com/beyond5959/ngent)
+- [Panda](https://github.com/lukaisluka/Panda) — conversation-first open-source client with inline permission cards, polished diffs and session history; browser demo included (Web, macOS, Windows)
 - [Poolside Desktop Assistant](https://poolside.ai/get-started) - An agent agnostic worktree native macOS desktop app.
 - [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) — realtime full-duplex voice client for ACP agents, with wake word and barge-in (macOS desktop, TUI, Web)
 - [RayClaw](https://github.com/rayclaw/rayclaw?tab=readme-ov-file#acp-agent-client-protocol)

--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -75,7 +75,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [Minion Mind](https://minion-mind.nebulame.com/) — through the [Agent Client](https://github.com/RAIT-09/obsidian-agent-client) plugin
 - [Mitto](https://github.com/inercia/mitto)
 - [Ngent](https://github.com/beyond5959/ngent)
-- [Panda](https://github.com/lukaisluka/Panda) — conversation-first open-source client with inline permission cards, polished diffs and session history; browser demo included (Web, macOS, Windows)
+- [Panda](https://github.com/lukaisluka/Panda) — a ready-made UI for your ACP agent: you implement the agent side, Panda ships the streaming chat, tool-call cards, inline permission prompts, diffs and session history (Web with scripted demo; macOS/Windows desktop)
 - [Poolside Desktop Assistant](https://poolside.ai/get-started) - An agent agnostic worktree native macOS desktop app.
 - [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) — realtime full-duplex voice client for ACP agents, with wake word and barge-in (macOS desktop, TUI, Web)
 - [RayClaw](https://github.com/rayclaw/rayclaw?tab=readme-ov-file#acp-agent-client-protocol)


### PR DESCRIPTION
Adding **Panda** to the Desktop and Web section (alphabetical, between Ngent and Poolside Desktop Assistant).

- Repo: https://github.com/lukaisluka/Panda (Apache-2.0)
- Live web app: https://lukaisluka.github.io/Panda/ — pure protocol client in the browser (connects to any ACP-over-WebSocket endpoint)
- Scripted in-browser demo, no agent needed: https://lukaisluka.github.io/Panda/#/demo
- Desktop build (macOS/Windows) spawns stdio agents directly

Panda is built for ACP agent developers: you implement the agent side of the protocol, and Panda is the client UI you'd otherwise have to build yourself — streaming messages, tool-call cards, inline permission prompts, polished diffs, and session history, speaking ACP natively. Off-the-shelf agents (Claude Code, Codex, …) work too through their ACP adapters.

The client-side contract Panda holds agents to (required methods, handler semantics, timeouts) is documented for implementers: https://github.com/lukaisluka/Panda/blob/main/docs/acp-agent-requirements.en.md

Happy to adjust the wording or category if it fits elsewhere better.
