### PR TITLE
docs(clients): add Capsule to Desktop and Web

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -57,6 +57,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 - [AionUi](https://github.com/iOfficeAI/AionUi)
 - [aizen](https://aizen.win)
 - [Braide](https://braide.dev) - Parallel sessions, worktrees, personas and interactive agent responses (supports macOS, Windows, Linux)
+- [Capsule](https://github.com/realbakari/Capsule-App) — local-first macOS desktop workspace for ACP coding agents and harnesses (Claude Code, Codex, Grok), with projects, conversations, diffs, and approvals
 - [Casper](https://github.com/joeyshi12/casper) - A web client for kiro-cli that talks to it over the Agent Client Protocol (ACP), giving you a browser-based chat UI with live streaming, session history, and rich per-tool-call rendering.
 - [Clover](https://github.com/zhangcongmr/clover)
 - [Codeg](https://github.com/xintaofei/codeg) — collaborative multi-agent coding workbench that unifies ACP agents (Claude Code, Codex, Gemini CLI, OpenCode, and more) with session aggregation; desktop app, self-hosted server, or Docker (macOS, Windows, Linux, Web)


### PR DESCRIPTION
Adds **Capsule** to the Desktop and Web section (alphabetical, between Braide and Casper).

- Repo: https://github.com/realbakari/Capsule-App
- Local-first macOS desktop workspace for ACP coding agents and harnesses (Claude Code, Codex, Grok)
- Projects, conversations, diffs, and approvals on-device

Capsule talks ACP directly: it can spawn an ACP-capable CLI itself, or connect through an OpenClaw Gateway adapter.