### PR TITLE
Add ACP Sidebar (Chrome side-panel client) to clients list

### DIFF
--- a/docs/get-started/clients.mdx
+++ b/docs/get-started/clients.mdx
@@ -9,6 +9,7 @@ The following projects implement ACP directly, connect ACP agents to other envir
 
 - [Anycode](https://github.com/anycode-ade/anycode) — web-based IDE with Rust backend and React frontend
 - [Chrome ACP](https://github.com/Areo-Joe/chrome-acp) (Chrome extension / PWA)
+- [ACP Sidebar](https://github.com/aganhui/acp-sidepanel) (Chrome extension) — side-panel chat with your local Claude Code, with one-click quoting of selections and full pages
 - Emacs via [agent-shell.el](https://github.com/xenodium/agent-shell)
 - [Exo for VSCode](https://marketplace.visualstudio.com/items?itemName=AntonSubbotin.exo) — A typography-first VS Code client featuring parallel sessions isolated in Git worktrees, native Diff Editor approvals, and a distraction-free, highly polished UI.
 - [JetBrains](https://www.jetbrains.com/help/ai-assistant/acp.html)


### PR DESCRIPTION
## Summary

Adds [ACP Sidebar](https://github.com/aganhui/acp-sidepanel) to the **Editors and IDEs** section, next to Chrome ACP.

ACP Sidebar is a Chrome side-panel extension for chatting with a locally-running Claude Code (via `claude-agent-acp`) over ACP. Its differentiating feature is **in-browser quoting**: highlight text on any page (or attach the full page / another tab) and ask the agent about it, with quote references rendered compactly in the chat history.

## Checklist

- [x] Project is open source and publicly available
- [x] Implements ACP as a client (connects to `claude-agent-acp` over a WebSocket bridge)
- [x] Entry placed alphabetically next to Chrome ACP in the Editors and IDEs section