### PR TITLE
docs: clarify permission context for raw input

### DIFF
--- a/docs/protocol/v1/tool-calls.mdx
+++ b/docs/protocol/v1/tool-calls.mdx
@@ -163,7 +163,7 @@ The Client responds with the user's decision:
 }
 ```
 
-Clients **MAY** automatically allow or reject permission requests according to the user settings.
+Clients **MAY** automatically allow or reject permission requests according to the user settings. When making a permission decision, Clients **SHOULD** treat the supplied `toolCall` details as the context being approved, not just the tool identity. If a permission policy or UI depends on `rawInput` and that field is absent or unavailable, the Client should avoid presenting the request as if argument details were known; it should either show that the arguments are unavailable or apply a stricter policy such as requiring explicit user confirmation.
 
 If the current prompt turn gets [cancelled](/protocol/v1/prompt-turn#cancellation), the Client **MUST** respond with the `"cancelled"` outcome:
 


### PR DESCRIPTION
## Summary
- Clarifies that `session/request_permission` approvals are bound to the supplied `toolCall` context, not only the tool identity.
- Advises clients to avoid presenting argument-dependent permission prompts as fully known when `rawInput` is absent/unavailable, and to show that gap or use stricter policy.

Closes #1979

## Test Plan
- `npx prettier --check docs/protocol/v1/tool-calls.mdx`
- `npm run spellcheck`
- `git diff --check`

Note: attempted an additional Claude Code review pass, but local Claude Code is not authenticated (`Not logged in · Please run /login`).
